### PR TITLE
Changed quiet hours and default reminder time settings to use TimePicker instead of list arrays

### DIFF
--- a/api/src/main/java/com/todoroo/andlib/utility/TodorooPreferenceActivity.java
+++ b/api/src/main/java/com/todoroo/andlib/utility/TodorooPreferenceActivity.java
@@ -14,15 +14,18 @@ package com.todoroo.andlib.utility;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
+import android.preference.DialogPreference;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
+import android.preference.PreferenceManager;
 import android.preference.RingtonePreference;
 
 import com.todoroo.andlib.service.ContextManager;
+import com.todoroo.astrid.ui.TimePreference;
 
 /**
  * Displays a preference screen for users to edit their preferences. Override
@@ -74,7 +77,10 @@ abstract public class TodorooPreferenceActivity extends PreferenceActivity {
             } else if(preference instanceof EditTextPreference) {
                 value = ((EditTextPreference) preference).getText();
             } else if(preference instanceof RingtonePreference) {
-                value = getPreferenceManager().getSharedPreferences().getString(preference.getKey(), null);
+                value = PreferenceManager.getDefaultSharedPreferences(preference.getContext())
+                        .getString(preference.getKey(), null);
+            } else if(preference instanceof TimePreference) {
+                value = ((TimePreference) preference).getLastHour();
             }
 
             updatePreferences(preference, value);

--- a/api/src/main/java/com/todoroo/astrid/ui/TimePreference.java
+++ b/api/src/main/java/com/todoroo/astrid/ui/TimePreference.java
@@ -1,0 +1,90 @@
+package com.todoroo.astrid.ui;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.preference.DialogPreference;
+import android.text.format.DateFormat;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TimePicker;
+
+/**
+ * Preference dialog that displays a TimePicker and persists the selected value.
+ *
+ * The xml to use it is of the form:
+ < com.todoroo.astrid.ui.TimePreference
+     android:key="@string/my_key_value"
+     android:defaultValue="-1"
+     android:positiveButtonText="Save"
+     android:negativeButtonText="Reset"
+     android:title="@string/my_pref_title_value" />
+ */
+public class TimePreference extends DialogPreference {
+
+    /** The last hour digit picked by the user in String format */
+    private String lastHour = "0";
+    private TimePicker picker = null;
+
+    public TimePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        setPositiveButtonText(android.R.string.ok);
+        setNegativeButtonText(android.R.string.cancel);
+
+    }
+
+    @Override
+    public View onCreateDialogView() {
+        picker = new TimePicker(getContext());
+
+        picker.setCurrentHour(Integer.parseInt(getLastHour()));
+        picker.setCurrentMinute(0);
+        picker.setIs24HourView(DateFormat.is24HourFormat(getContext()));
+
+        return picker;
+    }
+
+    @Override
+    public void onBindDialogView(View v) {
+        super.onBindDialogView(v);
+
+        picker.setCurrentHour(Integer.parseInt(getLastHour()));
+        picker.setCurrentMinute(0);
+        picker.setIs24HourView(DateFormat.is24HourFormat(getContext()));
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+        /** When the dialog is closed update the lastHour variable and store the value in preferences */
+        if (positiveResult) {
+            lastHour = String.valueOf(picker.getCurrentHour());
+
+            if (callChangeListener(lastHour)) {
+                persistString(lastHour);
+            }
+        }
+    }
+
+    @Override
+    public Object onGetDefaultValue(TypedArray array, int index) {
+        return (array.getString(index));
+    }
+
+    /** When called for the first time initialize the value of the last hour to either the saved one
+     * or to the default one. If a default one is not provided use "0" */
+    @Override
+    public void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        String defString = (defaultValue == null) ? "0" : defaultValue.toString();
+
+        if (restoreValue) {
+            lastHour = getPersistedString(defString);
+        } else {
+            lastHour = defString;
+        }
+    }
+
+    public String getLastHour() {
+        return lastHour;
+    }
+}

--- a/astrid/src/main/java/com/todoroo/astrid/reminders/Notifications.java
+++ b/astrid/src/main/java/com/todoroo/astrid/reminders/Notifications.java
@@ -469,9 +469,11 @@ public class Notifications extends BroadcastReceiver {
      * @return whether we're in quiet hours
      */
     public static boolean isQuietHours() {
+        boolean quietHoursEnabled = Preferences.getBoolean(R.string.p_rmd_enable_quiet, false);
         int quietHoursStart = Preferences.getIntegerFromString(R.string.p_rmd_quietStart, -1);
         int quietHoursEnd = Preferences.getIntegerFromString(R.string.p_rmd_quietEnd, -1);
-        if(quietHoursStart != -1 && quietHoursEnd != -1) {
+
+        if(quietHoursEnabled) {
             int hour = newDate().getHours();
             if(quietHoursStart <= quietHoursEnd) {
                 if(hour >= quietHoursStart && hour < quietHoursEnd) {

--- a/astrid/src/main/java/com/todoroo/astrid/reminders/ReminderPreferences.java
+++ b/astrid/src/main/java/com/todoroo/astrid/reminders/ReminderPreferences.java
@@ -31,33 +31,33 @@ public class ReminderPreferences extends TodorooPreferenceActivity {
     public void updatePreferences(Preference preference, Object value) {
         Resources r = getResources();
 
-        if(r.getString(R.string.p_rmd_quietStart).equals(preference.getKey())) {
-            int index = AndroidUtilities.indexOf(r.getStringArray(R.array.EPr_quiet_hours_start_values), value);
-            Preference endPreference = findPreference(getString(R.string.p_rmd_quietEnd));
+        if(r.getString(R.string.p_rmd_enable_quiet).equals(preference.getKey())) {
+            if( !(Boolean) value) {
+                preference.setSummary(r.getString(R.string.rmd_EPr_quiet_hours_desc_none));
+            } else {
+                preference.setSummary("");
+            }
+        } else if(r.getString(R.string.p_rmd_quietStart).equals(preference.getKey())) {
+            int index = Integer.parseInt((String) value);
+
             if(index <= 0) {
                 preference.setSummary(r.getString(R.string.rmd_EPr_quiet_hours_desc_none));
-                endPreference.setEnabled(false);
             } else {
-                String setting = r.getStringArray(R.array.EPr_quiet_hours_start)[index];
+                String setting = String.valueOf(index);
                 preference.setSummary(r.getString(R.string.rmd_EPr_quiet_hours_start_desc, setting));
-                endPreference.setEnabled(true);
             }
         } else if(r.getString(R.string.p_rmd_quietEnd).equals(preference.getKey())) {
-            int index = AndroidUtilities.indexOf(r.getStringArray(R.array.EPr_quiet_hours_end_values), value);
+            int index = Integer.parseInt((String) value);
             int quietHoursStart = Preferences.getIntegerFromString(R.string.p_rmd_quietStart, -1);
             if(index == -1 || quietHoursStart == -1) {
                 preference.setSummary(r.getString(R.string.rmd_EPr_quiet_hours_desc_none));
             } else {
-                String setting = r.getStringArray(R.array.EPr_quiet_hours_end)[index];
+                String setting = String.valueOf(index);
                 preference.setSummary(r.getString(R.string.rmd_EPr_quiet_hours_end_desc, setting));
             }
         } else if(r.getString(R.string.p_rmd_time).equals(preference.getKey())) {
-            int index = AndroidUtilities.indexOf(r.getStringArray(R.array.EPr_rmd_time_values), value);
-            if (index != -1 && index < r.getStringArray(R.array.EPr_rmd_time).length) {
-                // FIXME this does not fix the underlying cause of the ArrayIndexOutofBoundsException
-                String setting = r.getStringArray(R.array.EPr_rmd_time)[index];
-                preference.setSummary(r.getString(R.string.rmd_EPr_rmd_time_desc, setting));
-            }
+            String setting = (String) value;
+            preference.setSummary(r.getString(R.string.rmd_EPr_rmd_time_desc, setting));
         } else if(r.getString(R.string.p_rmd_ringtone).equals(preference.getKey())) {
             if(value == null || "content://settings/system/notification_sound".equals(value)) //$NON-NLS-1$
             {
@@ -93,7 +93,7 @@ public class ReminderPreferences extends TodorooPreferenceActivity {
                 preference.setSummary(r.getString(R.string.rmd_EPr_snooze_dialog_desc_false));
             }
         } else if (r.getString(R.string.p_rmd_enabled).equals(preference.getKey())) {
-            if((Boolean)value) {
+            if( (Boolean)value ) {
                 preference.setSummary(R.string.rmd_EPr_enabled_desc_true);
             } else {
                 preference.setSummary(R.string.rmd_EPr_enabled_desc_false);

--- a/astrid/src/main/java/com/todoroo/astrid/reminders/ReminderService.java
+++ b/astrid/src/main/java/com/todoroo/astrid/reminders/ReminderService.java
@@ -112,6 +112,7 @@ public final class ReminderService  {
         Editor editor = prefs.edit();
         Resources r = context.getResources();
 
+        Preferences.setIfUnset(prefs, editor, r, R.string.p_rmd_enable_quiet, false);
         Preferences.setIfUnset(prefs, editor, r, R.string.p_rmd_quietStart, 22);
         Preferences.setIfUnset(prefs, editor, r, R.string.p_rmd_quietEnd, 10);
         Preferences.setIfUnset(prefs, editor, r, R.string.p_rmd_default_random_hours, 0);
@@ -320,7 +321,7 @@ public final class ReminderService  {
                 date.setSeconds(0);
                 dueDateAlarm = date.getTime();
                 if (dueDate > getNowValue() && dueDateAlarm < getNowValue()) {
-                    // this only happens for tasks due today, cause dueDateAlarm wouldnt be in the past otherwise
+                    // this only happens for tasks due today, cause dueDateAlarm wouldn't be in the past otherwise
                     // if the default reminder is in the past, then reschedule it
                     // on this day before start of quiet hours or after quiet hours
                     // randomly placed in this interval
@@ -336,13 +337,14 @@ public final class ReminderService  {
                     quietHoursEndDate.setMinutes(0);
                     quietHoursEndDate.setSeconds(0);
 
+                    boolean quietHoursEnabled = Preferences.getBoolean(R.string.p_rmd_enable_quiet, false);
+
                     long millisToQuiet;
                     long millisToEndOfDay = dueDate - getNowValue();
 
-                    //
                     int periodDivFactor = 4;
 
-                    if(quietHoursStart != -1 && quietHoursEnd != -1) {
+                    if(quietHoursEnabled) {
                         int hour = newDate().getHours();
                         if(quietHoursStart <= quietHoursEnd) {
                             if(hour >= quietHoursStart && hour < quietHoursEnd) {

--- a/astrid/src/main/java/com/todoroo/astrid/utility/AstridDefaultPreferenceSpec.java
+++ b/astrid/src/main/java/com/todoroo/astrid/utility/AstridDefaultPreferenceSpec.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
 
 import com.todoroo.andlib.service.ContextManager;
+import com.todoroo.andlib.utility.AndroidUtilities;
 import com.todoroo.andlib.utility.Preferences;
 import com.todoroo.astrid.activity.BeastModePreferences;
 import com.todoroo.astrid.core.SortHelper;
@@ -88,6 +89,46 @@ public class AstridDefaultPreferenceSpec extends AstridPreferenceSpec {
         setPreference(prefs, editor, r, R.string.p_hide_plus_button, true);
 
         extras.setExtras(context);
+
+        /** START Migration to new Quiet Hours settings */
+        boolean hasMigrated = Preferences.getBoolean(R.string.p_rmd_hasMigrated, false);
+
+        if(!hasMigrated) {
+            // for each preference load old stored value
+            int quietHoursStart = Preferences.getIntegerFromString(R.string.p_rmd_quietStart_old, -1);
+            int quietHoursEnd = Preferences.getIntegerFromString(R.string.p_rmd_quietEnd_old, -1);
+            int defReminderTime = Preferences.getIntegerFromString(R.string.p_rmd_time_old, -1);
+            System.out.println("!!!!!!!!Values before:" + quietHoursStart + "," + quietHoursEnd + "," + defReminderTime);
+            // if a previous quietHoursStart preference exists and it's not disabled (so it's not 0 or -1)
+            if (quietHoursStart > 0) {
+                quietHoursStart = (quietHoursStart - 5) >= 0 ? quietHoursStart - 5 : 19 + quietHoursStart;
+                // if a previous quietHoursEnd preference exists adapt it
+                if (quietHoursEnd >= 0) {
+                    quietHoursEnd = (quietHoursEnd + 9) % 23;
+                }
+                Preferences.setBoolean(R.string.p_rmd_enable_quiet, true);
+            } else {
+                // set new quietHoursEnabled setting to false
+                Preferences.setBoolean( R.string.p_rmd_enable_quiet, false);
+            }
+            // if a previous defReminderTime preference exists
+            if (defReminderTime >= 0 && defReminderTime < r.getStringArray(R.array.EPr_rmd_time).length) {
+                // convert to hours from index. 9 is the initial 9AM in the reminder array
+                // so you have to return 9 hours to get to 0 (and modulo the result to reverse negative results)
+                defReminderTime = (defReminderTime + 9) % 23;
+            } else if (defReminderTime == -1) {
+                defReminderTime = 0;
+            }
+
+            // save changed preferences in the new preference keys
+            Preferences.setStringFromInteger(R.string.p_rmd_quietStart, quietHoursStart);
+            Preferences.setStringFromInteger(R.string.p_rmd_quietEnd, quietHoursEnd);
+            Preferences.setStringFromInteger(R.string.p_rmd_time, defReminderTime);
+
+            // set migration to completed
+            Preferences.setBoolean(R.string.p_rmd_hasMigrated, true);
+        }
+        /** END Migration to new Quiet Hours settings */
 
         editor.commit();
     }

--- a/astrid/src/main/res/values/keys.xml
+++ b/astrid/src/main/res/values/keys.xml
@@ -11,16 +11,31 @@
 
   <!-- whether reminders should appear at all -->
   <string name="p_rmd_enabled">notif_enabled</string>
-  
-  <!-- hour to start quiet hours (inclusive) -->
-  <string name="p_rmd_quietStart">notif_qstart</string>
+
+  <!-- boolean : whether to enable quiet hours or not -->
+  <string name="p_rmd_enable_quiet">enable_qhours</string>
+
+    <!-- hour to start quiet hours (inclusive) -->
+  <string name="p_rmd_quietStart">notif_qstart_new</string>
   
   <!-- hour to end quiet hours (non-inclusive) -->
-  <string name="p_rmd_quietEnd">notif_qend</string>
-  
+  <string name="p_rmd_quietEnd">notif_qend_new</string>
+
+  <!-- Whether or not the user has migrated (automatically) to the new reminder prefs -->
+  <string name="p_rmd_hasMigrated">has_migrated_rmd</string>
+
   <!-- reminder time when task doesn't have a due time (hour of day) -->
-  <string name="p_rmd_time">reminder_time</string>
-  
+  <string name="p_rmd_time">reminder_time_new</string>
+
+  <!-- OLD Quiet hours settings -->
+    <!-- reminder time when task doesn't have a due time (hour of day) -->
+    <string name="p_rmd_time_old">reminder_time</string>
+    <!-- hour to start quiet hours (inclusive) -->
+    <string name="p_rmd_quietStart_old">notif_qstart</string>
+    <!-- hour to end quiet hours (non-inclusive) -->
+    <string name="p_rmd_quietEnd_old">notif_qend</string>
+  <!-- END OF OLD Quiet hours settings -->
+
   <!-- whether "clear all notifications" clears astrid notifications -->
   <string name="p_rmd_persistent">notif_annoy</string>
   

--- a/astrid/src/main/res/values/strings-reminders.xml
+++ b/astrid/src/main/res/values/strings-reminders.xml
@@ -82,8 +82,10 @@
   <!-- Reminder Preference Reminders Enabled Description (true) -->
   <string name="rmd_EPr_enabled_desc_true">Reminders are enabled (this is normal)</string>
   <!-- Reminder Preference Reminders Enabled Description (false) -->
-  <string name="rmd_EPr_enabled_desc_false">Reminders will never appear on your phone</string>  
-    
+  <string name="rmd_EPr_enabled_desc_false">Reminders will never appear on your phone</string>
+
+  <!-- Reminder Preference: Quiet Hours Start Title -->
+  <string name="rmd_EPr_enable_quiet_title">Enable quiet hours</string>
   <!-- Reminder Preference: Quiet Hours Start Title -->
   <string name="rmd_EPr_quiet_hours_start_title">Quiet hours start</string>
   <!-- Reminder Preference: Quiet Hours Start Description (%s => time set) -->
@@ -144,7 +146,7 @@
   <string name="rmd_EPr_defaultRemind_desc_disabled">New tasks will have no random reminders</string>
   <!-- Reminder Preference: Default Reminders Setting (%s => setting) -->
   <string name="rmd_EPr_defaultRemind_desc">New tasks will remind randomly: %s</string>
-  
+
   <!-- slide 39a: Defaults Title -->
   
   <string-array name="EPr_reminder_random">
@@ -162,7 +164,7 @@
     <item>monthly</item>
     <item>bi-monthly</item>
   </string-array>
-        
+
   <string-array name="EPr_quiet_hours_start">
     <!-- Reminder Preference: quiet_hours_start: options for preference menu. Translate but don't change the times!. -->
     <item>disabled</item>
@@ -191,7 +193,7 @@
     <item>6 PM</item>
     <item>7 PM</item>
   </string-array>
-  
+
   <string-array name="EPr_quiet_hours_end">
     <!-- Reminder Preference: quiet_hours_end: options for preference menu. Translate but don't change the times! -->
     <item>9 AM</item>
@@ -219,7 +221,7 @@
     <item>7 AM</item>
     <item>8 AM</item>
   </string-array>
-  
+
   <string-array name="EPr_rmd_time">
     <!-- Reminder Preference: rmd_time: options for preference menu. Translate but don't change the times! -->
     <item>9 AM</item>

--- a/astrid/src/main/res/xml/preferences_reminders.xml
+++ b/astrid/src/main/res/xml/preferences_reminders.xml
@@ -8,45 +8,48 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/rmd_EPr_alerts_header">
 
-    <com.todoroo.astrid.ui.MultilineListPreference
+    <CheckBoxPreference
+        android:key="@string/p_rmd_enable_quiet"
+        android:title="@string/rmd_EPr_enable_quiet_title"
+        android:defaultValue="false"/>
+    <com.todoroo.astrid.ui.TimePreference
         android:key="@string/p_rmd_quietStart"
-        android:entries="@array/EPr_quiet_hours_start"
-        android:entryValues="@array/EPr_quiet_hours_start_values"
+        android:defaultValue="-1"
+        android:dependency="@string/p_rmd_enable_quiet"
         android:title="@string/rmd_EPr_quiet_hours_start_title"/>
-    <com.todoroo.astrid.ui.MultilineListPreference
+    <com.todoroo.astrid.ui.TimePreference
         android:key="@string/p_rmd_quietEnd"
-        android:entries="@array/EPr_quiet_hours_end"
-        android:entryValues="@array/EPr_quiet_hours_end_values"
+        android:defaultValue="-1"
+        android:dependency="@string/p_rmd_quietStart"
         android:title="@string/rmd_EPr_quiet_hours_end_title"/>
-    <com.todoroo.astrid.ui.MultilineListPreference
-        android:key="@string/p_rmd_time"
-        android:entries="@array/EPr_rmd_time"
-        android:entryValues="@array/EPr_rmd_time_values"
-        android:title="@string/rmd_EPr_rmd_time_title"/>
-    <com.todoroo.astrid.ui.MultilineCheckboxPreference
-        android:key="@string/p_rmd_persistent"
-        android:title="@string/rmd_EPr_persistent_title"/>
-    <com.todoroo.astrid.ui.MultilineCheckboxPreference
-        android:key="@string/p_rmd_maxvolume"
-        android:title="@string/rmd_EPr_multiple_maxvolume_title"
-        android:defaultValue="false"  />
-    <com.todoroo.astrid.ui.MultilineCheckboxPreference
-        android:key="@string/p_rmd_vibrate"
-        android:title="@string/rmd_EPr_vibrate_title"
-        android:defaultValue="true"  />
-    <com.todoroo.astrid.ui.MultilineCheckboxPreference
-       android:key="@string/p_rmd_snooze_dialog"
-       android:title="@string/rmd_EPr_snooze_dialog_title"
-       android:defaultValue="false"  />
-    <RingtonePreference
-        android:key="@string/p_rmd_ringtone"
-        android:title="@string/rmd_EPr_ringtone_title"
-        android:ringtoneType="notification"
-		android:showDefault="true"
-		android:showSilent="true" />
-	<com.todoroo.astrid.ui.MultilineCheckboxPreference
-        android:key="@string/p_rmd_enabled"
-        android:title="@string/rmd_EPr_enabled_title"
-        android:defaultValue="true"/>
-       
+<com.todoroo.astrid.ui.TimePreference
+    android:key="@string/p_rmd_time"
+    android:defaultValue="7"
+    android:title="@string/rmd_EPr_rmd_time_title"/>
+<com.todoroo.astrid.ui.MultilineCheckboxPreference
+    android:key="@string/p_rmd_persistent"
+    android:title="@string/rmd_EPr_persistent_title"/>
+<com.todoroo.astrid.ui.MultilineCheckboxPreference
+    android:key="@string/p_rmd_maxvolume"
+    android:title="@string/rmd_EPr_multiple_maxvolume_title"
+    android:defaultValue="false"  />
+<com.todoroo.astrid.ui.MultilineCheckboxPreference
+    android:key="@string/p_rmd_vibrate"
+    android:title="@string/rmd_EPr_vibrate_title"
+    android:defaultValue="true"  />
+<com.todoroo.astrid.ui.MultilineCheckboxPreference
+   android:key="@string/p_rmd_snooze_dialog"
+   android:title="@string/rmd_EPr_snooze_dialog_title"
+   android:defaultValue="false"  />
+<RingtonePreference
+    android:key="@string/p_rmd_ringtone"
+    android:title="@string/rmd_EPr_ringtone_title"
+    android:ringtoneType="notification"
+    android:showDefault="true"
+    android:showSilent="true" />
+<com.todoroo.astrid.ui.MultilineCheckboxPreference
+    android:key="@string/p_rmd_enabled"
+    android:title="@string/rmd_EPr_enabled_title"
+    android:defaultValue="true"/>
+
 </PreferenceScreen>

--- a/astrid/src/test/java/com/todoroo/andlib/utility/DateUtilitiesTest.java
+++ b/astrid/src/test/java/com/todoroo/andlib/utility/DateUtilitiesTest.java
@@ -37,7 +37,7 @@ import static org.tasks.date.DateTimeUtils.newDate;
 @RunWith(RobolectricTestRunner.class)
 public class DateUtilitiesTest {
 
-    private Locale defaultLocale;
+    private static Locale defaultLocale;
 
     @Before
     public void before() {


### PR DESCRIPTION
So, 
I changed the three reminder settings to use a TimePicker instead of the MultilinePreference like they did before. Now you only need the arrays containing the AM/PM hours for legacy reasons. I tested the new settings on two emulators (2.3.3 and 4.4) and on a tablet with 4.2 and they seem to work as expected and it takes into account the smartphones time mode (if it's 24h or AM/PM).  
I also added the piece of code to migrate from the old settings to the new ones. I did some minor tests to see if it works well and it seems ok but I'd say you have to test the migration part as well just to make sure.

Hope it's ok. :)
