### PR TITLE
refreshing the list of tasks on day change

### DIFF
--- a/astrid/src/main/java/com/todoroo/astrid/adapter/TaskAdapter.java
+++ b/astrid/src/main/java/com/todoroo/astrid/adapter/TaskAdapter.java
@@ -541,6 +541,7 @@ public class TaskAdapter extends CursorAdapter implements Filterable {
     @Override
     public void notifyDataSetChanged() {
         super.notifyDataSetChanged();
+        dateCache.clear();
         fontSize = preferences.getIntegerFromString(R.string.p_fontSize, 18);
     }
 


### PR DESCRIPTION
It is a simple fix to address issue #100 at least in most cases (when user returns to the application after midnight).
It is done by:
- checking in `onResume()` if the date has changed and if yes sending a refresh broadcast
- clearing `dateCache` in `notifyDataSetChanged()`, because the date could have changed.

In general I'm not sure if `dateCache` is really necessary, because `TaskAdapter#formatDate()` is a pretty fast operation.
