### PR TITLE
Sync hide-until metadata with Google Tasks

### DIFF
--- a/src/androidTestGoogleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilitiesTest.java
+++ b/src/androidTestGoogleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilitiesTest.java
@@ -86,6 +86,7 @@ public class GtasksApiUtilitiesTest extends AndroidTestCase {
         // Verify that a new links list was set on our mock
         ArgumentCaptor<List> argument = ArgumentCaptor.forClass(List.class);
         Mockito.verify(task).setLinks(argument.capture());
+        Mockito.verifyNoMoreInteractions(task);
         List<Task.Links> links = argument.getValue();
 
         validateHideUntilEntry(time, links);
@@ -99,6 +100,8 @@ public class GtasksApiUtilitiesTest extends AndroidTestCase {
         Mockito.when(task.getLinks()).thenReturn(links);
 
         GtasksApiUtilities.addHideUntilTime(task, null);
+        Mockito.verify(task).getLinks();
+        Mockito.verifyNoMoreInteractions(task);
 
         validateHideUntilEntry(time, links);
     }
@@ -120,5 +123,28 @@ public class GtasksApiUtilitiesTest extends AndroidTestCase {
         Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ", Locale.ENGLISH).parse(datestring);
 
         assertEquals(time, date.getTime());
+    }
+
+    public void testParseLinksNullList() {
+        com.todoroo.astrid.data.Task task = Mockito.mock(com.todoroo.astrid.data.Task.class);
+        GtasksApiUtilities.parseLinks(null, task);
+        Mockito.verifyNoMoreInteractions(task);
+    }
+
+    public void testMarshalHideUntilRoundtrip() {
+        final Long TIME = 123456789L;
+
+        // Marshal hide-until metadata
+        Task gtask = new Task();
+        gtask.setLinks(new LinkedList<Task.Links>());
+        GtasksApiUtilities.addHideUntilTime(gtask, TIME);
+
+        // Unmarshal hide-until metadata
+        com.todoroo.astrid.data.Task astridTask = new com.todoroo.astrid.data.Task();
+        assertFalse(astridTask.hasHideUntilDate());
+        GtasksApiUtilities.parseLinks(gtask.getLinks(), astridTask);
+
+        assertTrue(astridTask.hasHideUntilDate());
+        assertEquals(TIME, astridTask.getHideUntil());
     }
 }

--- a/src/androidTestGoogleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilitiesTest.java
+++ b/src/androidTestGoogleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilitiesTest.java
@@ -120,6 +120,21 @@ public class GtasksApiUtilitiesTest extends AndroidTestCase {
         assertFalse(task.hasHideUntilDate());
     }
 
+    public void testParseLinksGarbage() {
+        Task.Links taskLink = new Task.Links();
+        taskLink.setType(GtasksApiUtilities.LINK_TYPE);
+        taskLink.setLink(GtasksApiUtilities.ASTRID_URL);
+        taskLink.setDescription(GtasksApiUtilities.HIDE_UNTIL + ": garbase");
+
+        List<Task.Links> links = new LinkedList<>();
+        links.add(taskLink);
+
+        com.todoroo.astrid.data.Task task = new com.todoroo.astrid.data.Task();
+        GtasksApiUtilities.parseLinks(links, task);
+
+        assertFalse(task.hasHideUntilDate());
+    }
+
     public void testMarshalHideUntilRoundtrip() {
         final Long TIME = 1234567890L;
 

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
@@ -8,8 +8,12 @@ package com.todoroo.astrid.gtasks.api;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.tasks.model.Task;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import timber.log.Timber;
@@ -71,7 +75,21 @@ public class GtasksApiUtilities {
      * @param hideUntilUnixtime Hide until this timestamp
      */
     public static void addHideUntilTime(Task gtask, Long hideUntilUnixtime) {
-        // This method has tests, awaits implementation
+        List<Task.Links> links = gtask.getLinks();
+        if (links == null) {
+            links = new LinkedList<>();
+            gtask.setLinks(links);
+        }
+
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH);
+        String dateString = df.format(new Date(hideUntilUnixtime * 1000));
+
+        Task.Links taskLink = new Task.Links();
+        taskLink.setType(LINK_TYPE);
+        taskLink.setLink(ASTRID_URL);
+        taskLink.setDescription(HIDE_UNTIL + ": " + dateString);
+
+        links.add(taskLink);
     }
 
     /**

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
@@ -128,7 +128,7 @@ public class GtasksApiUtilities {
         try {
             date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH).parse(dateString);
         } catch (ParseException e) {
-            Timber.w("Failed to parse synced date", e);
+            Timber.w(e, "Failed to parse synced date");
             return;
         }
         long javatime = date.getTime();

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
@@ -9,6 +9,7 @@ import com.google.api.client.util.DateTime;
 import com.google.api.services.tasks.model.Task;
 
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
 
 import timber.log.Timber;
@@ -70,6 +71,13 @@ public class GtasksApiUtilities {
      * @param hideUntilUnixtime Hide until this timestamp
      */
     public static void addHideUntilTime(Task gtask, Long hideUntilUnixtime) {
+        // This method has tests, awaits implementation
+    }
+
+    /**
+     * Parse the links section of a GTasks object and update our local task with what we find there.
+     */
+    public static void parseLinks(List<Task.Links> links, com.todoroo.astrid.data.Task task) {
         // This method awaits tests, then implementation
     }
 }

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/api/GtasksApiUtilities.java
@@ -6,6 +6,7 @@
 package com.todoroo.astrid.gtasks.api;
 
 import com.google.api.client.util.DateTime;
+import com.google.api.services.tasks.model.Task;
 
 import java.util.Date;
 import java.util.TimeZone;
@@ -13,6 +14,9 @@ import java.util.TimeZone;
 import timber.log.Timber;
 
 public class GtasksApiUtilities {
+    public static String LINK_TYPE = "astrid";
+    public static String HIDE_UNTIL = "Hide until";
+    public static String ASTRID_URL = "https://github.com/tasks/tasks";
 
     public static DateTime unixTimeToGtasksCompletionTime(long time) {
         if (time < 0) {
@@ -60,5 +64,12 @@ public class GtasksApiUtilities {
             Timber.e(e, e.getMessage());
             return 0;
         }
+    }
+
+    /**
+     * @param hideUntilUnixtime Hide until this timestamp
+     */
+    public static void addHideUntilTime(Task gtask, Long hideUntilUnixtime) {
+        // This method awaits tests, then implementation
     }
 }

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/sync/GtasksSyncService.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/sync/GtasksSyncService.java
@@ -285,6 +285,9 @@ public class GtasksSyncService {
         if (values.containsKey(Task.DUE_DATE.name) && task.hasDueDate()) {
             remoteModel.setDue(GtasksApiUtilities.unixTimeToGtasksDueDate(task.getDueDate()));
         }
+        if (values.containsKey(Task.HIDE_UNTIL.name) && task.hasHideUntilDate()) {
+            GtasksApiUtilities.addHideUntilTime(remoteModel, task.getHideUntil());
+        }
         if (values.containsKey(Task.COMPLETION_DATE.name)) {
             if (task.isCompleted()) {
                 remoteModel.setCompleted(GtasksApiUtilities.unixTimeToGtasksCompletionTime(task.getCompletionDate()));

--- a/src/googleplay/java/com/todoroo/astrid/gtasks/sync/GtasksTaskContainer.java
+++ b/src/googleplay/java/com/todoroo/astrid/gtasks/sync/GtasksTaskContainer.java
@@ -43,6 +43,7 @@ public class GtasksTaskContainer {
         long createdDate = Task.createDueDate(Task.URGENCY_SPECIFIC_DAY, dueDate);
         task.setDueDate(createdDate);
         task.setNotes(remoteTask.getNotes());
+        GtasksApiUtilities.parseLinks(remoteTask.getLinks(), task);
 
         gtaskMetadata.setValue(GtasksMetadata.ID, remoteTask.getId());
         gtaskMetadata.setValue(GtasksMetadata.LIST_ID, listId);


### PR DESCRIPTION
The data is stored in a "Links" with:
* type = "astrid"
* url = "https://github.com/tasks/tasks"
* description = "Hide until: <ISO-8601 timestamp>"
