### PR TITLE
Fixed incorrect opacity of widgets (when set below 100)

### DIFF
--- a/src/main/java/org/tasks/widget/BaseWidgetConfigActivity.java
+++ b/src/main/java/org/tasks/widget/BaseWidgetConfigActivity.java
@@ -19,7 +19,7 @@ public abstract class BaseWidgetConfigActivity extends InjectingAppCompatActivit
 
     private static final String FRAG_TAG_WIDGET_CONFIG = "frag_tag_widget_config";
 
-    public static final int DEFAULT_OPACITY = 100;
+    public static final int DEFAULT_OPACITY = 255;
 
     public static final String PREF_WIDGET_ID = "widget-id-";
     public static final String PREF_SHOW_DUE_DATE = "widget-show-due-date-";

--- a/src/main/java/org/tasks/widget/TasksWidget.java
+++ b/src/main/java/org/tasks/widget/TasksWidget.java
@@ -106,10 +106,8 @@ public class TasksWidget extends InjectingAppWidgetProvider {
                 getSolidBackground(theme.getContentBackground()));
         remoteViews.setImageViewBitmap(R.id.widget_header_background,
                 getSolidBackground(theme.getPrimaryColor()));
-        if (opacity < 100) {
-            remoteViews.setInt(R.id.widget_background, "setAlpha", opacity);
-            remoteViews.setInt(R.id.widget_header_background, "setAlpha", opacity);
-        }
+        remoteViews.setInt(R.id.widget_background, "setAlpha", opacity);
+        remoteViews.setInt(R.id.widget_header_background, "setAlpha", opacity);
         if (!theme.isDark()) {
             remoteViews.setInt(R.id.widget_header_separator, "setVisibility", View.GONE);
         }

--- a/src/main/java/org/tasks/widget/WidgetConfigDialog.java
+++ b/src/main/java/org/tasks/widget/WidgetConfigDialog.java
@@ -156,7 +156,7 @@ public class WidgetConfigDialog extends InjectingDialogFragment implements SeekB
     }
 
     private void updateOpacity() {
-        opacityValue.setText(Integer.toString(opacitySeekbar.getProgress()));
+        opacityValue.setText(Integer.toString(opacitySeekbar.getProgress()*100/255)+"%");
     }
 
     private void updateTheme() {

--- a/src/main/res/layout/widget_config_activity.xml
+++ b/src/main/res/layout/widget_config_activity.xml
@@ -88,7 +88,9 @@
             android:id="@+id/opacity_seekbar"
             style="@style/WidgetConfigRow"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:max="255"
+            android:indeterminate="false" />
 
         <CheckBox
             android:id="@+id/hideDueDate"


### PR DESCRIPTION
Opacity was not set in range 0-255 but 0-100. Therefore high opacitys could not be set