### PR TITLE
Get CI working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - tools # https://github.com/travis-ci/travis-ci/issues/5049
     - android-23
     - platform-tools-23.1
-    - build-tools-23.0.2
+    - build-tools-23.0.3
     - extra-android-m2repository
     - extra-google-m2repository
   licenses:
@@ -28,4 +28,3 @@ script:
 after_success:
   - mv build/reports/coverage/googleplay/debug/report.xml build/reports/coverage/googleplay/debug/coverage.xml
   - bash <(curl -s https://codecov.io/bash)
-

--- a/src/main/java/com/todoroo/andlib/data/DatabaseDao.java
+++ b/src/main/java/com/todoroo/andlib/data/DatabaseDao.java
@@ -219,7 +219,7 @@ public class DatabaseDao<TYPE extends AbstractModel> {
             if (result.get()) {
                 onModelUpdated(item);
                 item.markSaved();
-                Timber.d("%s %s", op, item);
+                Timber.d("%s %s", op, item.toString());
             }
         }
         return result.get();


### PR DESCRIPTION
Before this change:
* We used to have the wrong build requirements in .travis.yml
* The Android linter crashed during CI

The Android linter crash is this problem:
https://github.com/JakeWharton/timber/issues/109

We work around it in this change by explicitly calling `.toString()` on a
parameter to a logging call.

As for the build requirements, this change simply corrects them.