### PR TITLE
choose between save and discard on back key in editmode

### DIFF
--- a/src/main/java/com/todoroo/astrid/actfm/FilterSettingsActivity.java
+++ b/src/main/java/com/todoroo/astrid/actfm/FilterSettingsActivity.java
@@ -154,7 +154,12 @@ public class FilterSettingsActivity extends ThemedInjectingAppCompatActivity {
                             finish();
                         }
                     })
-                    .setNegativeButton(android.R.string.cancel, null)
+                    .setNegativeButton(R.string.save, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            save();
+                        }
+                    })
                     .show();
         }
     }

--- a/src/main/java/com/todoroo/astrid/actfm/FilterSettingsActivity.java
+++ b/src/main/java/com/todoroo/astrid/actfm/FilterSettingsActivity.java
@@ -10,6 +10,8 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
@@ -61,8 +63,8 @@ public class FilterSettingsActivity extends ThemedInjectingAppCompatActivity {
         ActionBar supportActionBar = getSupportActionBar();
         if (supportActionBar != null) {
             supportActionBar.setDisplayHomeAsUpEnabled(true);
-            Drawable drawable = DrawableCompat.wrap(getResources().getDrawable(R.drawable.ic_close_24dp));
-            DrawableCompat.setTint(drawable, getResources().getColor(android.R.color.white));
+            Drawable drawable = DrawableCompat.wrap(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_close_24dp, null));
+            DrawableCompat.setTint(drawable, ContextCompat.getColor(getBaseContext(), android.R.color.white));
             supportActionBar.setHomeAsUpIndicator(drawable);
             supportActionBar.setTitle(filter.listingTitle);
         }
@@ -103,7 +105,7 @@ public class FilterSettingsActivity extends ThemedInjectingAppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.tag_settings_activity, menu);
-        MenuColorizer.colorMenu(this, menu, getResources().getColor(android.R.color.white));
+        MenuColorizer.colorMenu(this, menu, ContextCompat.getColor(getBaseContext(), android.R.color.white));
         return super.onCreateOptionsMenu(menu);
     }
 

--- a/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.java
+++ b/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.format.DateUtils;
@@ -122,9 +123,9 @@ public final class TaskEditFragment extends InjectingFragment implements Toolbar
         }
 
         final boolean backButtonSavesTask = preferences.backButtonSavesTask();
-        Drawable drawable = DrawableCompat.wrap(getResources().getDrawable(
+        Drawable drawable = DrawableCompat.wrap(ContextCompat.getDrawable(getActivity(),
                 backButtonSavesTask ? R.drawable.ic_close_24dp : R.drawable.ic_save_24dp));
-        DrawableCompat.setTint(drawable, getResources().getColor(android.R.color.white));
+        DrawableCompat.setTint(drawable, ContextCompat.getColor(context, android.R.color.white));
         toolbar.setNavigationIcon(drawable);
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
@@ -139,7 +140,7 @@ public final class TaskEditFragment extends InjectingFragment implements Toolbar
         toolbar.inflateMenu(R.menu.task_edit_fragment);
         Menu menu = toolbar.getMenu();
         for (int i = 0 ; i < menu.size() ; i++) {
-            MenuColorizer.colorMenuItem(menu.getItem(i), getResources().getColor(android.R.color.white));
+            MenuColorizer.colorMenuItem(menu.getItem(i), ContextCompat.getColor(context, android.R.color.white));
         }
         toolbar.setOnMenuItemClickListener(this);
 
@@ -260,7 +261,12 @@ public final class TaskEditFragment extends InjectingFragment implements Toolbar
     public void discardButtonClick() {
         if (hasChanges(taskEditControlSetFragmentManager.getFragmentsInPersistOrder())) {
             dialogBuilder.newMessageDialog(R.string.discard_confirmation)
-                    .setPositiveButton(R.string.keep_editing, null)
+                    .setPositiveButton(R.string.save, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            save();
+                        }
+                    })
                     .setNegativeButton(R.string.discard, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {

--- a/src/main/java/com/todoroo/astrid/core/CustomFilterActivity.java
+++ b/src/main/java/com/todoroo/astrid/core/CustomFilterActivity.java
@@ -12,6 +12,8 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
@@ -156,8 +158,8 @@ public class CustomFilterActivity extends ThemedInjectingAppCompatActivity {
         ActionBar supportActionBar = getSupportActionBar();
         if (supportActionBar != null) {
             supportActionBar.setDisplayHomeAsUpEnabled(true);
-            Drawable drawable = DrawableCompat.wrap(getResources().getDrawable(R.drawable.ic_close_24dp));
-            DrawableCompat.setTint(drawable, getResources().getColor(android.R.color.white));
+            Drawable drawable = DrawableCompat.wrap(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_close_24dp, null));
+            DrawableCompat.setTint(drawable, ContextCompat.getColor(getBaseContext(), android.R.color.white));
             supportActionBar.setHomeAsUpIndicator(drawable);
             supportActionBar.setTitle(R.string.FLA_new_filter);
         }
@@ -354,7 +356,7 @@ public class CustomFilterActivity extends ThemedInjectingAppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.tag_settings_activity, menu);
-        MenuColorizer.colorMenu(this, menu, getResources().getColor(android.R.color.white));
+        MenuColorizer.colorMenu(this, menu, ContextCompat.getColor(getBaseContext(), android.R.color.white));
         menu.findItem(R.id.delete).setVisible(false);
         return super.onCreateOptionsMenu(menu);
     }

--- a/src/main/java/com/todoroo/astrid/core/CustomFilterActivity.java
+++ b/src/main/java/com/todoroo/astrid/core/CustomFilterActivity.java
@@ -388,7 +388,12 @@ public class CustomFilterActivity extends ThemedInjectingAppCompatActivity {
                             finish();
                         }
                     })
-                    .setNegativeButton(android.R.string.cancel, null)
+                    .setNegativeButton(R.string.save, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            saveAndView();
+                        }
+                    })
                     .show();
         }
     }


### PR DESCRIPTION
when option to "save changes after back key" is disabled, user was asked to "discard" or "keep editing". At the same time back key could be used to "keep editing".

By allowing the user to choose between "save" and "discard" user can use less interactions while at te same time "keep editing" fundtion still works when using back key.

also updated some depriciated function calls
