### PR TITLE
Add CATEGORY_REMINDER to notifications (Marshmallow+)

### DIFF
--- a/src/main/java/org/tasks/Notifier.java
+++ b/src/main/java/org/tasks/Notifier.java
@@ -157,6 +157,7 @@ public class Notifier {
 
         Notification notification = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_check_white_24dp)
+                .setCategory(NotificationCompat.CATEGORY_REMINDER)
                 .setTicker(title)
                 .setWhen(currentTimeMillis())
                 .setContentTitle(title)
@@ -237,6 +238,7 @@ public class Notifier {
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_check_white_24dp)
+                .setCategory(NotificationCompat.CATEGORY_REMINDER)
                 .setTicker(taskTitle)
                 .setWhen(currentTimeMillis())
                 .setContentTitle(taskTitle)


### PR DESCRIPTION
API 23 and above (Marshmallow+) have a CATEGORY_REMINDER, that allows notifications classified as such to notify normally when the device is in the priority do-not-disturb mode. This change allows "Ring once" reminders to properly notify the user when the device is in priority mode.

I've added the classification for all notifications except missed call notifications. My reasoning for this is that:
- Priority mode has special rules for phone call notifications anyways. It would defeat the purpose of the do-not-disturb mode if calls the user doesn't care about cause Tasks to make notifications that get the user's attention
- A missed call notification is informational, not a reminder

Tested on Nougat and Lollipop emulators