### PR TITLE
Adding support for comment export/import

### DIFF
--- a/src/main/java/com/todoroo/astrid/backup/BackupConstants.java
+++ b/src/main/java/com/todoroo/astrid/backup/BackupConstants.java
@@ -31,6 +31,9 @@ class BackupConstants {
     /** Tag containing a task */
     public static final String TASK_TAG = "task";
 
+    /** Tag containing a comment item */
+    public static final String COMMENT_TAG = "comment";
+
     /** Tag containing a metadata item */
     public static final String METADATA_TAG = "metadata";
 

--- a/src/main/java/com/todoroo/astrid/backup/TasksXmlImporter.java
+++ b/src/main/java/com/todoroo/astrid/backup/TasksXmlImporter.java
@@ -316,6 +316,8 @@ public class TasksXmlImporter {
     private static final String FORMAT3 = "3"; //$NON-NLS-1$
     private class Format3TaskImporter extends Format2TaskImporter {
 
+        final UserActivity userActivity = new UserActivity();
+
         public Format3TaskImporter(XmlPullParser xpp) throws XmlPullParserException, IOException {
             this.xpp = xpp;
             while (xpp.next() != XmlPullParser.END_DOCUMENT) {

--- a/src/main/java/com/todoroo/astrid/backup/TasksXmlImporter.java
+++ b/src/main/java/com/todoroo/astrid/backup/TasksXmlImporter.java
@@ -23,9 +23,11 @@ import com.todoroo.astrid.api.AstridApiConstants;
 import com.todoroo.astrid.dao.MetadataDao;
 import com.todoroo.astrid.dao.TagDataDao;
 import com.todoroo.astrid.dao.TaskDao;
+import com.todoroo.astrid.dao.UserActivityDao;
 import com.todoroo.astrid.data.Metadata;
 import com.todoroo.astrid.data.TagData;
 import com.todoroo.astrid.data.Task;
+import com.todoroo.astrid.data.UserActivity;
 import com.todoroo.astrid.tags.TaskToTagMetadata;
 
 import org.tasks.R;
@@ -46,6 +48,7 @@ public class TasksXmlImporter {
 
     private final TagDataDao tagDataDao;
     private final MetadataDao metadataDao;
+    private final UserActivityDao userActivityDao;
     private final DialogBuilder dialogBuilder;
     private final TaskDao taskDao;
 
@@ -63,10 +66,11 @@ public class TasksXmlImporter {
     }
 
     @Inject
-    public TasksXmlImporter(TagDataDao tagDataDao, MetadataDao metadataDao,
+    public TasksXmlImporter(TagDataDao tagDataDao, MetadataDao metadataDao, UserActivityDao userActivityDao,
                             DialogBuilder dialogBuilder, TaskDao taskDao) {
         this.tagDataDao = tagDataDao;
         this.metadataDao = metadataDao;
+        this.userActivityDao = userActivityDao;
         this.dialogBuilder = dialogBuilder;
         this.taskDao = taskDao;
     }
@@ -328,6 +332,9 @@ public class TasksXmlImporter {
                         case BackupConstants.METADATA_TAG:
                             parseMetadata(3);
                             break;
+                        case BackupConstants.COMMENT_TAG:
+                            parseComment();
+                            break;
                         case BackupConstants.TAGDATA_TAG:
                             parseTagdata();
                             break;
@@ -337,6 +344,30 @@ public class TasksXmlImporter {
                     Timber.e(e, e.getMessage());
                 }
             }
+        }
+
+        /**
+         * Imports a comment from the XML we're reading.
+         * taken from EditNoteActivity.addComment()
+         */
+        private void parseComment() {
+            if (!currentTask.isSaved()) {
+                return;
+            }
+            userActivity.clear();
+
+            // We only want to import these fields.
+            // These are the fields that are sent in EditNoteActivity.addComment() when a user creates a comment.
+            final Property<?>[] NEW_PROPERTIES = new Property<?>[4];
+            NEW_PROPERTIES[0] = UserActivity.MESSAGE;
+            NEW_PROPERTIES[1] = UserActivity.ACTION;
+            NEW_PROPERTIES[2] = UserActivity.TARGET_ID;
+            NEW_PROPERTIES[3] = UserActivity.CREATED_AT;
+            deserializeModel(userActivity, NEW_PROPERTIES);
+
+            userActivity.setId(UserActivity.NO_ID);
+
+            userActivityDao.createNew(userActivity);
         }
 
         private void parseTagdata() {


### PR DESCRIPTION
This patch exports comments along with the backup to XML function.
Additionally, comments can be import with the import from XML function.
See issue #373 