### PR TITLE
Actually fetch tasks in batches of 30.

### DIFF
--- a/app/src/main/java/org/tasks/caldav/CalDAVSyncAdapter.java
+++ b/app/src/main/java/org/tasks/caldav/CalDAVSyncAdapter.java
@@ -168,7 +168,7 @@ public class CalDAVSyncAdapter extends InjectingAbstractThreadedSyncAdapter {
                         }
                     }
                 } else {
-                    ArrayList<HttpUrl> urls = newArrayList(transform(changed, DavResource::getLocation));
+                    ArrayList<HttpUrl> urls = newArrayList(transform(items, DavResource::getLocation));
                     davCalendar.multiget(urls);
 
                     Timber.d("MULTI %s", urls);


### PR DESCRIPTION
This fixes syncing a collection with > 2000 tasks for me.