### PR TITLE
Increase HTTP timeout to 30s.

### DIFF
--- a/app/src/main/java/org/tasks/caldav/CalDAVSyncAdapter.java
+++ b/app/src/main/java/org/tasks/caldav/CalDAVSyncAdapter.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -109,6 +110,7 @@ public class CalDAVSyncAdapter extends InjectingAbstractThreadedSyncAdapter {
                 .cookieJar(new MemoryCookieStore())
                 .followRedirects(false)
                 .followSslRedirects(false)
+                .readTimeout(30, TimeUnit.SECONDS)
                 .build();
         URI uri = URI.create(caldavAccount.getUrl());
         HttpUrl httpUrl = HttpUrl.get(uri);


### PR DESCRIPTION
This is required for slow calendars. 

The default read timeout for OkHttp is 10s. In my case, my CalDAV server responds in a little over 11s. For a background task, it seems fine if this is a little slow.