### PR TITLE
correct the german translation for opacity

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -374,7 +374,7 @@
 	<string name="back_button_saves_task">Zurück-Button speichert die Aufgabe</string>
 	<string name="default_list">Standard-Liste</string>
 	<string name="default_sync">Standardsynchronisation</string>
-	<string name="opacity">Durchsichtigkeit</string>
+	<string name="opacity">Deckkraft</string>
 	<string name="color">Farbe</string>
 	<string name="accent">Akzent</string>
 	<string name="launcher_icon">Startersymbol</string>


### PR DESCRIPTION
opacity was misunderstood as transparency before