### PR TITLE
Add a quick add input on top of the task list

### DIFF
--- a/app/src/main/res/layout/fragment_task_list.xml
+++ b/app/src/main/res/layout/fragment_task_list.xml
@@ -21,6 +21,25 @@
     <include layout="@layout/toolbar"/>
 
     <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+      <EditText
+          android:id="@+id/quickAdd"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="24dp"
+          android:layout_marginTop="8dp"
+          android:layout_marginRight="24dp"
+          android:layout_marginBottom="8dp"
+          android:ems="10"
+          android:hint="@string/quick_add_hint"
+          android:inputType="text"
+          android:singleLine="true" />
+    </LinearLayout>
+
+    <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:elevation="@dimen/elevation_task_list"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,4 +566,5 @@ File %1$s contained %2$s.\n\n
   <string name="desaturate_colors">Desaturate colors</string>
   <string name="desaturate_colors_summary_on">Colors will be desaturated in dark themes</string>
   <string name="desaturate_colors_summary_off">Colors will not be desaturated in dark themes</string>
+  <string name="quick_add_hint">Quick add task</string>
 </resources>


### PR DESCRIPTION
Unfortunately Wunderlist is shutting down. I'd like to use this opportunity to switch to something selfhosted. Tasks looks great but the one feature I'm missing the most is an text input on top of the task list which allows you to quickly add new tasks, e.g. food to your groceries shopping list for which you only need a title.

This PR is to open the discussion if such a feature would be added and if so, how it should be implemented. (Disclaimer: I'm not and Android developer and have a hard time navigating the code, please let me know if something is not optimally or idiomatically implemented)

One question I have:
* Should this be configurable? I.e. should the user be able to switch the input on and off in the configuration?

What is not working yet:
* Tasks are not automatically added to the tag/list if you're in a tag/list view.

Please let me know what you think and what would be required to get this merged.