### PR TITLE
backups: Warn about backup deletion at uninstall

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -291,6 +291,7 @@
     <string name="quiet_hours">Ruhezeit</string>
     <string name="attachment_directory">Ordner für Anhänge</string>
     <string name="backup_directory">Sicherungsordner</string>
+    <string name="backup_directory_warning">WICHTIG: Damit die Sicherung eine Deinstallation der App überlebt, müssen Sie entweder den Sicherungsordner von der Standardeinstellung (privater Ordner der App) auf einen anderen Ordner setzen, oder die erstellte Sicherungsdatei nach außerhalb des Ordners kopieren.</string>
     <string name="google_drive_backup">Nach Google Drive kopieren</string>
     <string name="miscellaneous">Verschiedenes</string>
     <string name="synchronization">Synchronisierung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,7 @@ File %1$s contained %2$s.\n\n
   <string name="quiet_hours">Quiet hours</string>
   <string name="attachment_directory">Attachment folder</string>
   <string name="backup_directory">Backup folder</string>
+  <string name="backup_directory_warning">IMPORTANT: If you want your backup to survive an uninstall of the app, you must either change the Backup folder away from the default (the app\'s private directory), or copy the created backup file outside of the folder manually.</string>
   <string name="google_drive_backup">Copy to Google Drive</string>
   <string name="miscellaneous">Miscellaneous</string>
   <string name="synchronization">Synchronization</string>

--- a/app/src/main/res/xml/preferences_backups.xml
+++ b/app/src/main/res/xml/preferences_backups.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
   <Preference
     android:key="@string/p_backup_dir"
@@ -15,6 +16,7 @@
 
   <Preference
     android:key="@string/backup_BAc_export"
-    android:title="@string/backup_BAc_export" />
+    android:title="@string/backup_BAc_export"
+    android:summary="@string/backup_directory_warning" />
 
 </PreferenceScreen>


### PR DESCRIPTION
https://tasks.org/docs/backups.html#backup-location says

> Backup files are stored in Tasks' private directory. **Android will delete this directory if Tasks is uninstalled!**

but this warning should really be shown in the app when you do the backup, not in some docs website!

Because of this, I lost all tasks of the last 9 months, when I switched from the Play Store to the F-Droid version. :(