### PR TITLE
Closes #1000 Makes five time reminders play sound 5x instead of 2x

### DIFF
--- a/app/src/main/java/org/tasks/notifications/NotificationManager.kt
+++ b/app/src/main/java/org/tasks/notifications/NotificationManager.kt
@@ -202,6 +202,9 @@ class NotificationManager @Inject constructor(
             cancel(evicted)
         }
         for (i in 0 until ringTimes) {
+            if (i > 0) {
+                notificationManager.pause(2000)
+            }
             notificationManager.notify(notificationId.toInt(), notification)
         }
     }

--- a/app/src/main/java/org/tasks/notifications/Throttle.kt
+++ b/app/src/main/java/org/tasks/notifications/Throttle.kt
@@ -34,4 +34,8 @@ internal class Throttle constructor(
             oldest = (oldest + 1) % throttle.size
         }
     }
+
+    fun pause(millis: Long) = executor.execute {
+        Thread.sleep(millis)
+    }
 }

--- a/app/src/main/java/org/tasks/notifications/ThrottledNotificationManager.kt
+++ b/app/src/main/java/org/tasks/notifications/ThrottledNotificationManager.kt
@@ -26,6 +26,8 @@ class ThrottledNotificationManager @Inject constructor(
         }
     }
 
+    fun pause(millis: Long) = throttle.pause(millis)
+
     companion object {
         private const val NOTIFICATIONS_PER_SECOND = 4
     }


### PR DESCRIPTION
Fixes a bug which caused notification sounds to overlap in five times mode; instead of five times the sound was played just twice.
Closes #1000 