### PR TITLE
Make Eisenhower box strings clearer

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -622,10 +622,10 @@ File %1$s contained %2$s.\n\n
   <string name="filter_medium_priority">Medium priority</string>
   <string name="filter_low_priority">Low priority</string>
   <string name="filter_no_priority">No priority</string>
-  <string name="filter_eisenhower_box_1">Eisenhower box 1</string>
-  <string name="filter_eisenhower_box_2">Eisenhower box 2</string>
-  <string name="filter_eisenhower_box_3">Eisenhower box 3</string>
-  <string name="filter_eisenhower_box_4">Eisenhower box 4</string>
+  <string name="filter_eisenhower_box_1">Important and urgent</string>
+  <string name="filter_eisenhower_box_2">Important and not urgent</string>
+  <string name="filter_eisenhower_box_3">Not important and urgent</string>
+  <string name="filter_eisenhower_box_4">Not important and not urgent</string>
   <string name="enjoying_tasks">Enjoying Tasks?</string>
   <string name="tell_me_how_im_doing">Please tell me how I\'m doing</string>
   <string name="support_development_subscribe">Unlock additional features and support open source software</string>


### PR DESCRIPTION
I assume that the order is the same as in https://en.wikipedia.org/wiki/Time_management#The_Eisenhower_Method.

Fixes #990.