### PR TITLE
Change "Manage lists" to "Manage drawer"

### DIFF
--- a/app/src/main/java/org/tasks/activities/NavigationDrawerCustomization.kt
+++ b/app/src/main/java/org/tasks/activities/NavigationDrawerCustomization.kt
@@ -60,7 +60,7 @@ class NavigationDrawerCustomization : ThemedInjectingAppCompatActivity(), Toolba
         toolbar = binding.toolbar.toolbar
 
         with(toolbar) {
-            title = getString(R.string.manage_lists)
+            title = getString(R.string.manage_drawer)
             navigationIcon = getDrawable(R.drawable.ic_outline_arrow_back_24px)
             setNavigationOnClickListener { finish() }
             setOnMenuItemClickListener(this@NavigationDrawerCustomization)

--- a/app/src/main/java/org/tasks/filters/FilterProvider.kt
+++ b/app/src/main/java/org/tasks/filters/FilterProvider.kt
@@ -184,7 +184,7 @@ class FilterProvider @Inject constructor(
                             NavigationDrawerFragment.REQUEST_PURCHASE)
                 }
                 .plus(NavigationDrawerAction(
-                        context.getString(R.string.manage_lists),
+                        context.getString(R.string.manage_drawer),
                         R.drawable.ic_outline_edit_24px,
                         Intent(context, NavigationDrawerCustomization::class.java),
                         0))

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -189,7 +189,6 @@
     <string name="EPr_show_task_edit_comments">إظهار التعليقات في شاشة تحرير المهمة</string>
     <string name="back_button_saves_task">الضغط على زر الرجوع يحفظ المهمة</string>
     <string name="lists">القوائم</string>
-    <string name="manage_lists">إدارة القوائم</string>
     <string name="places">الأماكن</string>
     <string name="notification_disable_battery_optimizations_description">قد يؤدي تحسين البطارية إلى تأخير الإشعارات</string>
     <string name="EPr_reset_preferences_warning">ستتم إعادة تعيين التفضيلات إلى القيم الافتراضية</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -462,7 +462,6 @@
     <string name="today_lowercase">днес</string>
     <string name="yesterday_lowercase">вчера</string>
     <string name="default_location">Място по подразбиране</string>
-    <string name="manage_lists">Управление на списъци</string>
     <string name="enter_tag_name">Въведете име на етикета</string>
     <string name="create_new_tag">Добавяне на „%s“</string>
     <string name="add_filter">Добавяне на филтър</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -8,7 +8,6 @@
     <string name="SSD_sort_my_order">আমার তালিকা</string>
     <string name="action_open">খুলো</string>
     <string name="action_call">কল</string>
-    <string name="manage_lists">তালিকা পরিচালনা করো</string>
     <string name="TAd_actionEditTask">সম্পাদনা</string>
     <string name="TLA_menu_settings">সেটিংস</string>
     <string name="TLA_menu_search">সার্চ</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -548,7 +548,6 @@
     <string name="CFC_list_name">V seznamu…</string>
     <string name="astrid_sort_order_summary">Zapněte ruční řazení Astrid pro \"Moje úkoly\", \"Dnes\" a štítky. Tento režim řazení bude v budoucnu nahrazen režimem \"Vlastní řazení\"</string>
     <string name="astrid_sort_order">Ruční řazení Astrid</string>
-    <string name="manage_lists">Spravovat seznamy</string>
     <string name="CRA_default_list_name">Akční položky: %s</string>
     <string name="open_last_viewed_list">Otevřít poslední prohlížený seznam</string>
     <string name="on_launch">Při spuštění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -96,7 +96,6 @@
     <string name="EPr_show_task_edit_comments">Vis kommentarer i opgaveredigering</string>
     <string name="EPr_fullTask_title">Vis hele opgavetitlen</string>
     <string name="astrid_sort_order">Astrids manuelle sortering</string>
-    <string name="manage_lists">Administrer lister</string>
     <string name="permission_read_tasks">Fuld adgang til Tasks-databasen</string>
     <string name="reset_sort_order">Nulstil rækkefølge</string>
     <string name="lists">Lister</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -587,7 +587,6 @@
     <string name="date_shortcut_tomorrow_night">morgen Nacht</string>
     <string name="date_shortcut_tomorrow_evening">morgen Abend</string>
     <string name="reset_sort_order">Sortierung zurücksetzen</string>
-    <string name="manage_lists">Listen verwalten</string>
     <string name="permission_read_tasks">Vollzugriff auf die Tasks-Datenbank</string>
     <string name="tell_me_how_im_doing">Erzählen Sie mir bitte, wie gut ich das mache</string>
     <string name="davx5_selection_description">Aufgaben mit der DAVx⁵-App synchronisieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -587,7 +587,6 @@
     <string name="date_shortcut_tomorrow_night">Mañana por la noche</string>
     <string name="date_shortcut_tomorrow_evening">Mañana por la tarde</string>
     <string name="reset_sort_order">Restablecer orden de clasificación</string>
-    <string name="manage_lists">Administrar listas</string>
     <string name="permission_read_tasks">Acceso completo a la base de datos de Tasks</string>
     <string name="davx5_selection_description">Sincronice sus tareas con la aplicación DAVx⁵</string>
     <string name="account">Cuenta</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -587,7 +587,6 @@
     <string name="date_shortcut_tomorrow_night">Bihar gauez</string>
     <string name="date_shortcut_tomorrow_evening">Bihar arratsaldez</string>
     <string name="CFC_list_name">Zerrendan…</string>
-    <string name="manage_lists">Zerrendak kudeatu</string>
     <string name="permission_read_tasks">Tasks datu-basera sarbide osoa</string>
     <string name="sign_in_with_google">Hasi saioa Google-n</string>
     <string name="authorization_cancelled">Autorizazioa ezeztatuta</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -575,5 +575,4 @@
     <string name="open_last_viewed_list">Avaa viimeksi katsottu lista</string>
     <string name="on_launch">Käynnistettäessä</string>
     <string name="CFC_list_name">listalla…</string>
-    <string name="manage_lists">Hallitse listoja</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -582,7 +582,6 @@
     <string name="date_shortcut_tomorrow_evening">Demain soir</string>
     <string name="date_shortcut_tomorrow_night">Nuit prochaine</string>
     <string name="reset_sort_order">Réinitialiser l’ordre de tri</string>
-    <string name="manage_lists">Gérer les listes</string>
     <string name="permission_read_tasks">Accès complet à la base de données de Tasks</string>
     <string name="davx5_selection_description">Synchroniser vos tâches avec l’application DAVx⁵</string>
     <string name="account">Compte</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -7,7 +7,6 @@
     <string name="backup_BPr_header">Sigurnosne kopije</string>
     <string name="EPr_edit_screen_options">Postavke zaslona za uređivanje</string>
     <string name="backup_BAc_import">Uvezi sigurnosnu kopiju</string>
-    <string name="manage_lists">Upravljaj popisima</string>
     <string name="always_display_full_date">Prikaži puni datum</string>
     <string name="EPr_fullTask_title">Prikaži puni naslov zadatka</string>
     <string name="EPr_beastMode_reset">Vrati na zadane vrijednosti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -585,7 +585,6 @@
     <string name="date_shortcut_tomorrow_night">Holnap éjszaka</string>
     <string name="date_shortcut_tomorrow_evening">Holnap este</string>
     <string name="reset_sort_order">Sorbarendezés visszaállítása</string>
-    <string name="manage_lists">Listák kezelése</string>
     <string name="permission_read_tasks">Teljes hozzáférés a Tasks adatbázishoz</string>
     <string name="davx5_selection_description">Feladatok szinkronizálása DAVx⁵ alkalmazással</string>
     <string name="account">Fiók</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -467,7 +467,6 @@
     <string name="TEA_timer_est">Perkiraan %s</string>
     <string name="TEA_elapsedDuration_label">Waktu telah terpakai</string>
     <string name="sort_created">Berdasarkan waktu pembuatan</string>
-    <string name="manage_lists">Kelola Daftar</string>
     <string name="WID_dateButtonUnset">Klik untuk mengatur</string>
     <string name="cancel">Batal</string>
     <string name="ok">Oke</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -587,7 +587,6 @@
     <string name="reset_sort_order">Ripristina ordinamento</string>
     <string name="date_shortcut_tomorrow_night">Domani notte</string>
     <string name="date_shortcut_tomorrow_evening">Domani sera</string>
-    <string name="manage_lists">Gestisci liste</string>
     <string name="permission_read_tasks">Accesso completo al database di Tasks</string>
     <string name="davx5_selection_description">Sincronizza le tue attività con l\'app DAVx⁵</string>
     <string name="backup_location_warning">ATTENZIONE: i file che si trovano in %s verranno eliminati quando si disinstalla Tasks. Si consiglia di scegliere una posizione alternativa per evitare tale evenienza.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -569,7 +569,6 @@
     <string name="today_lowercase">היום</string>
     <string name="CFC_list_name">ברשימה…</string>
     <string name="EPr_temp_completed_tasks_not_showing">המשימות תיעלמנה מיידית מהרשימה עם השלמתן</string>
-    <string name="manage_lists">ניהול רשימות</string>
     <string name="display_name">שם תצוגה</string>
     <string name="lists">רשימות</string>
     <string name="open_last_viewed_list">פתיחת הרשימה האחרונה שנצפתה</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -600,7 +600,6 @@
     <string name="repeat_type_completion_capitalized">완료일</string>
     <string name="astrid_sort_order_summary">\'나의 할일\', \'오늘\', 태그 화면에서 Astrid 수동 정렬을 사용할 수 있습니다. 추후 업데이트 시 \'순서 직접 정렬\' 을 이 방식으로 대체할 예정입니다</string>
     <string name="astrid_sort_order">Astrid 수동 정렬</string>
-    <string name="manage_lists">목록 관리</string>
     <string name="authorization_cancelled">인증 취소됨</string>
     <string name="current_subscription">현재 구독: %s</string>
     <string name="price_per_year">$%s/년</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -18,7 +18,6 @@
     <string name="TLA_no_items">ഇവിടെ ടാസ്‌ക്കുകളൊന്നുമില്ല.</string>
     <string name="TLA_menu_search">തിരയുക</string>
     <string name="TLA_menu_settings">ക്രമീകരണങ്ങൾ</string>
-    <string name="manage_lists">ലിസ്റ്റുകൾ നിയന്ത്രിക്കുക</string>
     <string name="action_open">തുറക്കുക</string>
     <string name="SSD_sort_alpha">ശീർഷക പ്രകാരം</string>
     <string name="SSD_sort_due">നിശ്ചിത തീയതി</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -578,7 +578,6 @@
     <string name="improve_performance">Forbedret ytelse</string>
     <string name="whats_new">Hva er nytt</string>
     <string name="CFC_list_name">På listen…</string>
-    <string name="manage_lists">Håndter lister</string>
     <string name="date_shortcut_tomorrow_evening">I morgen på kvelden</string>
     <string name="disable_sort_groups">Skru av sorteringsgrupper</string>
     <string name="improve_performance_summary">Skru av sorteringsgrupper og sammenfoldbare gjøremålssteg for å forbedre programmets ytelse</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -581,7 +581,6 @@
     <string name="CFC_list_name">In lijst…</string>
     <string name="date_shortcut_tomorrow_night">Morgennacht</string>
     <string name="date_shortcut_tomorrow_evening">Morgenavond</string>
-    <string name="manage_lists">Beheer lijsten</string>
     <string name="reset_sort_order">Sorteervolgorde resetten</string>
     <string name="permission_read_tasks">Volledige toegang tot Tasks database</string>
     <string name="davx5_selection_description">Synchroniseer je taken met de DAVx⁵ applicatie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -599,7 +599,6 @@
     <string name="CFC_list_name">Na liście…</string>
     <string name="astrid_sort_order_summary">Aktywuje ręczny (jak w Astrid) tryb sortowania dla \'Moich zadań\', \'Dzisiaj\' oraz tagów. Ten tryb sortowania będzie zastąpiony przez \'Ręczne\' w kolejnych aktualizacjach</string>
     <string name="astrid_sort_order">Ręczne sortowanie (jak w Astrid)</string>
-    <string name="manage_lists">Zarządzaj listami</string>
     <string name="davx5_selection_description">Synchronizuj swoje zadania z aplikacją DAVx⁵</string>
     <string name="backup_location_warning">OSTRZEŻENIE: Pliki znajdujące się w %s zostaną usunięte, jeśli aplikacja Tasks zostanie odinstalowana! Wybierz własną lokalizację, aby zapobiec usunięciu plików przez system Android.</string>
     <string name="backups_ignore_warnings_summary">Ignoruj ostrzeżenia dotyczące kopii zapasowych, jeśli nie potrzebujesz kopii zapasowych lub masz własne rozwiązanie do tworzenia kopii zapasowych</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -549,7 +549,6 @@
     <string name="astrid_sort_order_summary">Habilitar Ordenação Manual do Astrid para \'Minhas Tarefas\', \'Hoje\', e etiquetas. Esse modo de ordenação eventualmente sera substituito em uma atualização futura para \'Minha ordenação\'</string>
     <string name="astrid_sort_order">Ordenação Manual do Astrid</string>
     <string name="SSD_sort_my_order">Minha ordem</string>
-    <string name="manage_lists">Gerenciar Listas</string>
     <string name="backup_BPr_header">Cópia de Segurança</string>
     <string name="display_name">Mostrar nome</string>
     <string name="permission_read_tasks">Acesso completo ao base de dados do Tasks</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -443,7 +443,6 @@
     <string name="EPr_default_location_radius">Raio padrão</string>
     <string name="EPr_default_location_reminder_title">Lembretes de localização padrão</string>
     <string name="TEA_control_location">Localização</string>
-    <string name="manage_lists">Gerir Listas</string>
     <string name="date_shortcut_tomorrow_night">Amanhã à noite</string>
     <string name="date_shortcut_tomorrow_evening">Amanhã à tardinha</string>
     <string name="CFC_list_name">Na lista…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -604,7 +604,6 @@
     <string name="CFC_list_name">В списке…</string>
     <string name="astrid_sort_order_summary">Включите режим ручной сортировки Astrid для «Моих задач», «Сегодня» и тегов. Этот режим сортировки будет заменён на «Мой порядок» в будущем обновлении</string>
     <string name="astrid_sort_order">Ручная сортировка Astrid</string>
-    <string name="manage_lists">Управление списками</string>
     <string name="davx5_selection_description">Синхронизируйте свои задачи с приложением DAVx⁵</string>
     <string name="account">Учётная запись</string>
     <string name="device_settings">Настройки устройства</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -492,5 +492,4 @@
     <string name="tomorrow_lowercase">imorgon</string>
     <string name="today_lowercase">idag</string>
     <string name="CFC_list_name">I lista…</string>
-    <string name="manage_lists">Hantera listor</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -64,7 +64,6 @@
     <string name="SSD_sort_auto">ஸ்மார்ட் வகை</string>
     <string name="astrid_sort_order">ஆஸ்ட்ரிட் கையேடு வரிசையாக்கம்</string>
     <string name="SSD_sort_my_order">எனது ஆர்டர்</string>
-    <string name="manage_lists">பட்டியல்களை நிர்வகிக்கவும்</string>
     <string name="WID_dateButtonUnset">கிளிக் செய்து அமைக்கவும்</string>
     <string name="keep_editing">திருத்துவதைத் தொடருங்கள்</string>
     <string name="discard_confirmation">உங்கள் மாற்றங்களை நிராகரிக்க விரும்புகிறீர்களா\?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -587,7 +587,6 @@
     <string name="reset_sort_order">Sıra düzenini sıfırla</string>
     <string name="date_shortcut_tomorrow_night">Yarın gece</string>
     <string name="date_shortcut_tomorrow_evening">Yarın akşam</string>
-    <string name="manage_lists">Listeleri yönet</string>
     <string name="permission_read_tasks">Tasks veri tabanına tam erişim</string>
     <string name="davx5_selection_description">DAVx⁵ uygulamasıyla görevlerinizi eşzamanlayın</string>
     <string name="background_location">Ön plan konumu</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -682,7 +682,6 @@
     <string name="SSD_sort_start">За датою початку</string>
     <string name="astrid_sort_order_summary">Увімкніть режим ручного сортування Astria для «Моїх завдань», «Сьогодні» та міток. Цей режим сортування буде замінено на «Мій порядок» у майбутньому оновленні</string>
     <string name="astrid_sort_order">Ручне сортування Astrid</string>
-    <string name="manage_lists">Керування списками</string>
     <string name="filter_any_start_date">Будь-яка дата початку</string>
     <string name="CFC_startBefore_name">Дата початку…</string>
     <string name="CFC_startBefore_text">Дата початку: \?</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -38,7 +38,6 @@
     <string name="SSD_sort_my_order">میرا آرڈر</string>
     <string name="action_open">کھولیں</string>
     <string name="action_call">کال</string>
-    <string name="manage_lists">فہرستیں مینیج کریں</string>
     <string name="TAd_actionEditTask">ترمیم</string>
     <string name="TLA_menu_settings">سیٹنگز</string>
     <string name="TLA_menu_search">تلاش</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -578,7 +578,6 @@
     <string name="date_shortcut_tomorrow_night">明天晚上</string>
     <string name="date_shortcut_tomorrow_evening">明天傍晚</string>
     <string name="reset_sort_order">重置排列顺序</string>
-    <string name="manage_lists">管理列表</string>
     <string name="permission_read_tasks">对Tasks数据库的完全访问</string>
     <string name="davx5_selection_description">用 DAVx⁵应用同步你的任务</string>
     <string name="account">账户</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -215,7 +215,6 @@
     <string name="EPr_temp_completed_tasks_not_showing">工作完成後立刻從工作表刪除</string>
     <string name="TEA_add_subtask">加入副工作</string>
     <string name="action_call">通話</string>
-    <string name="manage_lists">管理清單</string>
     <string name="display_name">顯示名稱</string>
     <string name="filter_no_priority">無優先級</string>
     <string name="filter_low_priority">低優先級</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@ File %1$s contained %2$s.\n\n
   <string name="TLA_menu_search">Search</string>
   <string name="TLA_menu_settings">Settings</string>
   <string name="TAd_actionEditTask">Edit</string>
-  <string name="manage_lists">Manage lists</string>
+  <string name="manage_drawer">Manage drawer</string>
   <string name="action_call">Call</string>
   <string name="action_open">Open</string>
   <string name="SSD_sort_my_order">My order</string>


### PR DESCRIPTION
"Manage lists" is misleading as the page opened manages many things in addition to lists. If anybody has another string that they think is better than "manage drawer," please write it in a comment.