### PR TITLE
Use startOfDay when time isn't specified

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/data/Task.kt
+++ b/app/src/main/java/com/todoroo/astrid/data/Task.kt
@@ -576,9 +576,7 @@ class Task : Parcelable {
             }
             var dueDate = DateTimeUtils.newDateTime(date).withMillisOfSecond(0)
             dueDate = if (setting != URGENCY_SPECIFIC_DAY_TIME) {
-                dueDate
-                        .withHourOfDay(12)
-                        .withMinuteOfHour(0)
+                dueDate.startOfDay()
                         .withSecondOfMinute(0) // Seconds == 0 means no due time
             } else {
                 dueDate.withSecondOfMinute(1) // Seconds > 0 means due time exists

--- a/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
+++ b/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
@@ -111,7 +111,8 @@ class TaskCreator @Inject constructor(
             when (key) {
                 Tag.KEY -> tags.add(value as String)
                 GoogleTask.KEY, CaldavTask.KEY, Place.KEY -> task.putTransitory(key, value)
-                DUE_DATE.name -> value.substitute()?.toLongOrNull()?.let { task.dueDate = it }
+                DUE_DATE.name -> value.substitute()?.toLongOrNull()?.let { task.dueDate =
+                    createDueDate(Task.URGENCY_SPECIFIC_DAY, it) }
                 IMPORTANCE.name -> value.substitute()?.toIntOrNull()?.let { task.priority = it }
                 HIDE_UNTIL.name ->
                     value.substitute()?.toLongOrNull()?.let { task.hideUntil = it.startOfDay() }

--- a/app/src/main/java/org/tasks/dialogs/DateTimePicker.kt
+++ b/app/src/main/java/org/tasks/dialogs/DateTimePicker.kt
@@ -189,7 +189,7 @@ class DateTimePicker : BaseDateTimePicker() {
     fun pickTime() {
         val time = if (selectedTime == MULTIPLE_TIMES
                 || !Task.hasDueTime(today.withMillisOfDay(selectedTime).millis)) {
-            today.noon().millisOfDay
+            today.startOfDay().millisOfDay
         } else {
             selectedTime
         }

--- a/app/src/main/java/org/tasks/ui/TimePreference.java
+++ b/app/src/main/java/org/tasks/ui/TimePreference.java
@@ -31,8 +31,8 @@ public class TimePreference extends Preference {
   @Override
   public void onSetInitialValue(boolean restoreValue, Object defaultValue) {
     if (restoreValue) {
-      int noon = new DateTime().startOfDay().withHourOfDay(12).getMillisOfDay();
-      millisOfDay = getPersistedInt(noon);
+      int startOfDay = new DateTime().startOfDay().getMillisOfDay();
+      millisOfDay = getPersistedInt(startOfDay);
     } else {
       millisOfDay = (Integer) defaultValue;
     }


### PR DESCRIPTION
When specifying a date without a particular time, use midnight rather than noon as the default time.

Makes #1545 work a bit better, since with the "Now" filter, this change means that tasks with a due date of today (but no start time) will show up in the filter. Previously, they would only appear after noon.