### PR TITLE
Use ISO 8601 date formatting

### DIFF
--- a/app/src/main/java/org/tasks/backup/BackupConstants.kt
+++ b/app/src/main/java/org/tasks/backup/BackupConstants.kt
@@ -10,7 +10,7 @@ object BackupConstants {
     const val EXPORT_FILE_NAME = "user.%s.json"
     const val BACKUP_FILE_NAME = "auto.%s.json"
 
-    private val MATCHER = Pattern.compile("""(auto|user)\.(\d{2})(\d{2})(\d{2})-(\d{2})(\d{2})\.json""")
+    private val MATCHER = Pattern.compile("""(auto|user)\.(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})\.json""")
 
     fun isBackupFile(name: String?) = name?.let { MATCHER.matcher(it).matches() } ?: false
 
@@ -32,7 +32,7 @@ object BackupConstants {
                 .takeIf { it.matches() }
                 ?.let {
                     DateTime(
-                            2000 + it.group(2)!!.toInt(),
+                            it.group(2)!!.toInt(),
                             it.group(3)!!.toInt(),
                             it.group(4)!!.toInt(),
                             it.group(5)!!.toInt(),

--- a/app/src/main/java/org/tasks/backup/TasksJsonExporter.kt
+++ b/app/src/main/java/org/tasks/backup/TasksJsonExporter.kt
@@ -169,6 +169,6 @@ class TasksJsonExporter @Inject constructor(
         private const val MIME = "application/json"
         private const val EXTENSION = ".json"
         private val dateForExport: String
-            get() = newDateTime().toString("yyMMdd-HHmm")
+            get() = newDateTime().toString("yyyyMMdd'T'HHmm")
     }
 }

--- a/app/src/main/java/org/tasks/time/DateTime.java
+++ b/app/src/main/java/org/tasks/time/DateTime.java
@@ -429,6 +429,6 @@ public class DateTime {
 
   @Override
   public String toString() {
-    return toString("yyyy-MM-dd HH:mm:ss.SSSZ");
+    return toString("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   }
 }


### PR DESCRIPTION
Update TasksJsonExporter and the default toString() method in DateTime to use the ISO 8601 standard (in particular, using four-digit years and splitting the date from the time with the character "T").