### PR TITLE
WIP: Change inheritance to fix stackoverflow in DBObject

### DIFF
--- a/app/src/main/java/com/todoroo/andlib/data/Table.kt
+++ b/app/src/main/java/com/todoroo/andlib/data/Table.kt
@@ -2,7 +2,7 @@ package com.todoroo.andlib.data
 
 import com.todoroo.andlib.sql.DBObject
 
-class Table private constructor(private val name: String, alias: String?) : DBObject<Table>(name) {
+class Table private constructor(private val name: String, alias: String?) : DBObject(name) {
 
     constructor(name: String) : this(name, null)
 

--- a/app/src/main/java/com/todoroo/andlib/sql/DBObject.kt
+++ b/app/src/main/java/com/todoroo/andlib/sql/DBObject.kt
@@ -2,18 +2,10 @@ package com.todoroo.andlib.sql
 
 import java.util.*
 
-abstract class DBObject<T : DBObject<T>> internal constructor(val expression: String) : Cloneable {
+abstract class DBObject internal constructor(val expression: String) : Cloneable {
     var alias: String? = null
 
-    open fun `as`(newAlias: String): T {
-        return try {
-            val clone = clone() as T
-            clone.alias = newAlias
-            clone
-        } catch (e: CloneNotSupportedException) {
-            throw RuntimeException(e)
-        }
-    }
+    abstract fun `as`(newAlias: String): DBObject
 
     protected fun hasAlias() = alias != null
 
@@ -21,7 +13,7 @@ abstract class DBObject<T : DBObject<T>> internal constructor(val expression: St
         if (this === other) {
             return true
         }
-        if (other !is DBObject<*>) {
+        if (other !is DBObject) {
             return false
         }
         return expression == other.expression && alias == other.alias

--- a/app/src/main/java/com/todoroo/andlib/sql/Field.kt
+++ b/app/src/main/java/com/todoroo/andlib/sql/Field.kt
@@ -1,10 +1,20 @@
 package com.todoroo.andlib.sql
 
-open class Field(expression: String) : DBObject<Field>(expression) {
+open class Field(expression: String) : DBObject(expression) {
     fun eq(value: Any?): Criterion = if (value == null) {
         UnaryCriterion.isNull(this)
     } else {
         UnaryCriterion.eq(this, value)
+    }
+
+    override fun `as`(newAlias: String): Field {
+        return try {
+            val clone = clone() as Field
+            clone.alias = newAlias
+            clone
+        } catch (e: CloneNotSupportedException) {
+            throw RuntimeException(e)
+        }
     }
 
     fun gt(value: Any?): Criterion = UnaryCriterion.gt(this, value)


### PR DESCRIPTION
DBObject initialization was resulting in a loop causing a StackOverflow, ultimately resulting in the app crashing (issue 1528). Remove recursive class inheritance to hopefully fix this issue.