### PR TITLE
Fix chunking of SQLite queries in case of task deletion

### DIFF
--- a/app/src/main/java/org/tasks/data/GoogleTaskDao.kt
+++ b/app/src/main/java/org/tasks/data/GoogleTaskDao.kt
@@ -93,7 +93,7 @@ abstract class GoogleTaskDao {
     abstract suspend fun getChildren(ids: List<Long>): List<Long>
 
     suspend fun hasRecurringParent(ids: List<Long>): List<Long> =
-            ids.chunkedMap { internalHasRecurringParent(ids) }
+            ids.chunkedMap { internalHasRecurringParent(it) }
 
     @Query("""
 SELECT gt_task


### PR DESCRIPTION
When having a lot of (> 999) completed tasks in a list, selecting
"Remove all completed tasks" causes a crash of the app with:

SQLiteLog: (1) too many SQL variables

This is due to a bug that accidentally bypasses the chunking of
the db queries to stay below the limit.

This solves #1661.