### PR TITLE
Generate proper UUID strings for new tasks

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/helper/UUIDHelper.java
+++ b/app/src/main/java/com/todoroo/astrid/helper/UUIDHelper.java
@@ -3,15 +3,8 @@ package com.todoroo.astrid.helper;
 import java.util.UUID;
 
 public class UUIDHelper {
-
-  private static final long MIN_UUID = 100000000;
-
-  /** @return a pair consisting of the newly generated uuid and the corresponding proof text */
+  /** @return a newly generated uuid */
   public static String newUUID() {
-    long uuid;
-    do {
-      uuid = UUID.randomUUID().getLeastSignificantBits() & 0x7fffffffffffffffL;
-    } while (uuid < MIN_UUID);
-    return Long.toString(uuid);
+    return UUID.randomUUID().toString();
   }
 }


### PR DESCRIPTION
Tasks app works fine with tasks created in other applications, pulled from
CalDav etc. When new events are created, it generates a UUID that's not really
a UUID form due to how UUIDHelper is written.

This change simplifies the helper and just returns the UUID generated by java
util. The code had comments suggesting the method was originally returning
something else besides the UUID string itself and possibly for other use cases.

The underlying reason for my case is that one piece of software I
use (org-caldav) is arguably buggy and expecting actual UUID. However other
software I've been using generates/uses UUID so I feel like this should be a
compatible/easy change that only affects new items.