### PR TITLE
Don't forget parent when copying tasks.

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/service/TaskDuplicator.kt
+++ b/app/src/main/java/com/todoroo/astrid/service/TaskDuplicator.kt
@@ -71,7 +71,13 @@ class TaskDuplicator @Inject constructor(
         }
         val caldavTask = caldavDao.getTask(originalId)
         if (caldavTask != null) {
-            caldavDao.insert(clone, CaldavTask(clone.id, caldavTask.calendar), addToTop)
+            val newDavTask = CaldavTask(clone.id, caldavTask.calendar)
+            if (parentId != 0L)
+            {
+                val remoteParent = caldavDao.getRemoteIdForTask(parentId)
+                newDavTask.remoteParent = remoteParent
+            }
+            caldavDao.insert(clone, newDavTask, addToTop)
         }
         for (g in locationDao.getGeofencesForTask(originalId)) {
             locationDao.insert(


### PR DESCRIPTION
Fixes #1407.

When copying tasks the `RemoteParent` was never set for for `CaldavTask` in the newly created tasks but it was set correctly for the internal representation. This caused the new tasks to be synced without hierarchy and the local hierarchy would then be lost on the next sync.

A similar issue (with a similar fix) might also affect `GoogleTask` a couple of lines up but I don't have a test setup for this and so didn't change it.