### PR TITLE
[GitHub] Add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ on:
       - 'fastlane/**'
       - .github/FUNDING.yml
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ on:
       - 'fastlane/**'
       - .github/FUNDING.yml
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest


### PR DESCRIPTION
## Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 
All GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
Here is an example of the permissions in one of the workflows:
https://github.com/tasks/tasks/runs/8000032077?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for each workflow. 

## Motivation
- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>