### PR TITLE
Don't show "Improve Tasks" preference in F-Droid build

### DIFF
--- a/app/src/main/java/org/tasks/injection/InjectingPreferenceFragment.kt
+++ b/app/src/main/java/org/tasks/injection/InjectingPreferenceFragment.kt
@@ -87,9 +87,7 @@ abstract class InjectingPreferenceFragment : PreferenceFragmentCompat() {
     private fun remove(preferenceGroup: PreferenceGroup, resIds: IntArray) {
         for (resId in resIds) {
             val preference: Preference? = preferenceGroup.findPreference(getString(resId))
-            if (preference != null) {
-                preferenceGroup.removePreference(preference)
-            }
+            preference?.parent?.removePreference(preference)
         }
     }
 


### PR DESCRIPTION
`Preference` instances that were not direct children of the `Fragment`'s root `PreferenceScreen` were not removed. This lead to e.g. the "Improve Tasks" preference being shown in the F-Droid build.

Before and after:

<img src="https://user-images.githubusercontent.com/218061/187438229-ee7ab74a-6fe4-4908-af1f-b8024f36e392.png" alt="tasks_settings_before" width=300> <img src="https://user-images.githubusercontent.com/218061/187438234-5c1e553b-59bd-45d5-9990-080d1b83e53d.png" alt="tasks_settings_after" width=300>
