### PR TITLE
Allow disabling notifications for tasks without due times

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/alarms/AlarmCalculator.kt
+++ b/app/src/main/java/com/todoroo/astrid/alarms/AlarmCalculator.kt
@@ -10,13 +10,14 @@ import org.tasks.time.DateTimeUtils.withMillisOfDay
 import javax.inject.Inject
 
 class AlarmCalculator(
+    private val preferences: Preferences,
     private val random: Random,
     private val defaultTimeProvider: () -> Int,
 ){
     @Inject
     internal constructor(
         preferences: Preferences
-    ) : this(Random(), { preferences.defaultDueTime })
+    ) : this(preferences, Random(), { preferences.defaultDueTime })
 
     fun toAlarmEntry(task: Task, alarm: Alarm): AlarmEntry? {
         val trigger = when (alarm.type) {
@@ -36,7 +37,7 @@ class AlarmCalculator(
                 when {
                     task.hasDueTime() ->
                         task.dueDate + alarm.time
-                    task.hasDueDate() ->
+                    task.hasDueDate() && preferences.isDefaultDueTimeEnabled ->
                         task.dueDate.withMillisOfDay(defaultTimeProvider()) + alarm.time
                     else ->
                         AlarmService.NO_ALARM

--- a/app/src/main/java/org/tasks/preferences/Preferences.kt
+++ b/app/src/main/java/org/tasks/preferences/Preferences.kt
@@ -87,6 +87,9 @@ class Preferences @JvmOverloads constructor(
 
     private fun quietHoursEnabled(): Boolean = getBoolean(R.string.p_rmd_enable_quiet, false)
 
+    val isDefaultDueTimeEnabled: Boolean
+        get() = getBoolean(R.string.p_rmd_time_enabled, true)
+
     val defaultDueTime: Int
         get() = getInt(R.string.p_rmd_time, TimeUnit.HOURS.toMillis(18).toInt())
 

--- a/app/src/main/java/org/tasks/preferences/fragments/Notifications.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/Notifications.kt
@@ -55,6 +55,7 @@ class Notifications : InjectingPreferenceFragment() {
     override suspend fun setupPreferences(savedInstanceState: Bundle?) {
         rescheduleNotificationsOnChange(
             false,
+            R.string.p_rmd_time_enabled,
             R.string.p_rmd_time,
             R.string.p_rmd_enable_quiet,
             R.string.p_rmd_quietStart,

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -69,6 +69,7 @@
   <string name="p_rmd_quietEnd">notif_qend_new</string>
 
   <!-- reminder time when task doesn't have a due time (hour of day) -->
+  <string name="p_rmd_time_enabled">reminder_time_new_enabled</string>
   <string name="p_rmd_time">reminder_time_new</string>
 
   <!-- whether "clear all notifications" clears astrid notifications -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,7 +155,7 @@ File %1$s contained %2$s.\n\n
   <string name="snooze_all">Snooze all</string>
   <string name="rmd_EPr_quiet_hours_start_title">Quiet hours start</string>
   <string name="rmd_EPr_quiet_hours_end_title">Quiet hours end</string>
-  <string name="rmd_EPr_rmd_time_title">Default reminder</string>
+  <string name="rmd_EPr_rmd_time_title">Reminder time</string>
   <string name="rmd_EPr_rmd_time_desc">Notifications for tasks without due times will appear at %s</string>
   <string name="persistent_notifications">Persistent notifications</string>
   <string name="persistent_notifications_description">Persistent notifications cannot be cleared</string>
@@ -438,6 +438,7 @@ File %1$s contained %2$s.\n\n
   <string name="error_adding_account">Error: %s</string>
   <string name="notification_disable_battery_optimizations_description">Battery optimizations may delay notifications</string>
   <string name="bundle_notifications">Bundle notifications</string>
+  <string name="default_reminder">Default Reminder</string>
   <string name="badges">Badges</string>
   <string name="list">List</string>
   <string name="repeats_from">Repeats from</string>
@@ -462,6 +463,7 @@ File %1$s contained %2$s.\n\n
   <string name="list_separator_with_space">,\u0020</string>
   <string name="dont_add_to_calendar">Don\'t add to calendar</string>
   <string name="default_calendar">Default calendar</string>
+  <string name="rmd_time_description">Show notifications for tasks without due times</string>
   <string name="badges_description">Display a task count on Tasks\' launcher icon. Not all launchers support badges.</string>
   <string name="bundle_notifications_summary">Combine multiple notifications into one</string>
   <string name="repeat_monthly_same_day_each_month">on the same day each month</string>

--- a/app/src/main/res/xml/preferences_notifications.xml
+++ b/app/src/main/res/xml/preferences_notifications.xml
@@ -19,17 +19,11 @@
 
   </Preference>
 
-  <org.tasks.ui.TimePreference
-    android:defaultValue="@integer/default_remind_time"
-    android:key="@string/p_rmd_time"
-    android:title="@string/rmd_EPr_rmd_time_title"
-    app:allowDividerAbove="true"
-    app:time_summary="@string/rmd_EPr_rmd_time_desc" />
-
   <Preference
       android:defaultValue="content://settings/system/notification_sound"
       android:key="@string/p_completion_ringtone"
-      android:title="@string/completion_sound" />
+      android:title="@string/completion_sound"
+      app:allowDividerAbove="true" />
 
   <SwitchPreferenceCompat
     android:defaultValue="true"
@@ -85,6 +79,23 @@
     </intent>
 
   </Preference>
+
+  <PreferenceCategory android:title="@string/default_reminder">
+
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="@string/p_rmd_time_enabled"
+        android:summary="@string/rmd_time_description"
+        android:title="@string/enabled" />
+
+    <org.tasks.ui.TimePreference
+        android:dependency="@string/p_rmd_time_enabled"
+        android:defaultValue="@integer/default_remind_time"
+        android:key="@string/p_rmd_time"
+        android:title="@string/rmd_EPr_rmd_time_title"
+        app:time_summary="@string/rmd_EPr_rmd_time_desc" />
+
+  </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/badges">
 


### PR DESCRIPTION
It can be very useful to have the option to disable notifications for tasks without due times. I personally would love this feature as I'm using the widget to show my tasks, and I don't need a notification every time I create a task without a due time.

This is how the notification settings screen will look like:
![image](https://user-images.githubusercontent.com/32670283/190844884-47e8957f-5da6-4faa-b9f5-8c964194ef39.png)

I moved the new default reminder category down because it looks better along with the other categories, but its position doesn't matter and is up to you, of course.