### PR TITLE
Save task when ime action done is triggered

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.kt
+++ b/app/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.kt
@@ -90,6 +90,7 @@ import java.time.format.FormatStyle
 import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
+import android.view.inputmethod.EditorInfo
 
 @AndroidEntryPoint
 class TaskEditFragment : Fragment(), Toolbar.OnMenuItemClickListener {
@@ -177,6 +178,14 @@ class TaskEditFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                 textWatcher?.invoke(it)
             }
         )
+        title.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                lifecycleScope.launch {
+                    save()
+                }
+                true
+            } else false
+        }
         title.setText(model.title)
         title.setHorizontallyScrolling(false)
         title.maxLines = 5


### PR DESCRIPTION
This is a small enhancement that makes quickly adding tasks more straight forard. The keyboard shows a checkmark icon which before this change was just hiding it. With this triggering the done action will save the task and close the editing view.
