### PR TITLE
Add option to snooze until next arrival/departure

### DIFF
--- a/app/src/main/java/org/tasks/reminders/SnoozeActivity.kt
+++ b/app/src/main/java/org/tasks/reminders/SnoozeActivity.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import org.tasks.activities.DateAndTimePickerActivity
 import org.tasks.dialogs.MyTimePickerDialog
 import org.tasks.injection.InjectingAppCompatActivity
+import org.tasks.notifications.NotificationManager
 import org.tasks.themes.ThemeAccent
 import org.tasks.time.DateTime
 import javax.inject.Inject
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class SnoozeActivity : InjectingAppCompatActivity(), SnoozeCallback, DialogInterface.OnCancelListener {
     @Inject lateinit var taskDao: TaskDao
     @Inject lateinit var alarmService: AlarmService
+    @Inject lateinit var notificationManager: NotificationManager
     @Inject lateinit var themeAccent: ThemeAccent
 
     private val taskIds: MutableList<Long> = ArrayList()
@@ -59,6 +61,14 @@ class SnoozeActivity : InjectingAppCompatActivity(), SnoozeCallback, DialogInter
     override fun snoozeForTime(time: DateTime) {
         lifecycleScope.launch(NonCancellable) {
             alarmService.snooze(time.millis, taskIds)
+        }
+        setResult(Activity.RESULT_OK)
+        finish()
+    }
+
+    override fun snoozeNextVisit() {
+        lifecycleScope.launch(NonCancellable) {
+            notificationManager.cancel(taskIds)
         }
         setResult(Activity.RESULT_OK)
         finish()

--- a/app/src/main/java/org/tasks/reminders/SnoozeCallback.java
+++ b/app/src/main/java/org/tasks/reminders/SnoozeCallback.java
@@ -6,5 +6,7 @@ interface SnoozeCallback {
 
   void snoozeForTime(DateTime time);
 
+  void snoozeNextVisit();
+
   void pickDateTime();
 }

--- a/app/src/main/java/org/tasks/reminders/SnoozeDialog.java
+++ b/app/src/main/java/org/tasks/reminders/SnoozeDialog.java
@@ -96,6 +96,7 @@ public class SnoozeDialog extends DialogFragment {
     }
 
     items.add(getString(R.string.pick_a_date_and_time));
+    items.add(getString(R.string.next_arrival_departure));
 
     return dialogBuilder
         .newDialog(R.string.rmd_NoA_snooze)
@@ -113,6 +114,10 @@ public class SnoozeDialog extends DialogFragment {
                 case 5:
                   dialog.dismiss();
                   snoozeCallback.pickDateTime();
+                  break;
+                case 6:
+                  dialog.dismiss();
+                  snoozeCallback.snoozeNextVisit();
                   break;
               }
             })

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -747,4 +747,5 @@
     <string name="consent_agree">Souhlasím</string>
     <string name="consent_deny">Teď ne</string>
     <string name="sign_in">Přihlásit se</string>
+    <string name="next_arrival_departure">Příští příchod/odchod</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -738,4 +738,5 @@ File %1$s contained %2$s.\n\n
   <string name="sort_ascending">Ascending</string>
   <string name="sort_descending">Descending</string>
   <string name="sort_not_available">Not available for tags, filters, or places</string>
+  <string name="next_arrival_departure">Next arrival/departure</string>
 </resources>


### PR DESCRIPTION
This change will allow users to snooze notifications for location-based tasks (Issue #2013).

Since the geofence record stays even after triggering, it's only needed to dismiss the notification. If the user arrives again at the given location, the task notification will trigger again.

Possible improvements:

- Only show "Next arrival/departure" option when the task has actually location set
  - This would require fetching the task model in SnoozeDialog
- Only show this option when AndroidGeofenceTransitionIntentService actually triggered the notification
  - This would require passing reason/source of the notification trigger which is not implemented

Let me know if you think these two improvements should be implemented...