### PR TITLE
Refactor: Change deprecated code in Fragment onAttach

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
+++ b/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
@@ -206,8 +206,8 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
         }
     }
 
-    override fun onAttach(activity: Activity) {
-        super.onAttach(activity)
+    override fun onAttach(context: Context) {
+        super.onAttach(requireContext())
         callbacks = activity as TaskListFragmentCallbackHandler
     }
 


### PR DESCRIPTION
Change onAttach(activity:Activity) to onAttach(context:Context)
because of support onAttach(context:Context) in google