### PR TITLE
[Feature] Add an option to allow adding tasks without unlock

### DIFF
--- a/app/src/main/java/com/todoroo/andlib/utility/AndroidUtilities.java
+++ b/app/src/main/java/com/todoroo/andlib/utility/AndroidUtilities.java
@@ -160,6 +160,10 @@ public class AndroidUtilities {
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
   }
 
+  public static boolean atLeastOreoMR1() {
+    return Build.VERSION.SDK_INT >= VERSION_CODES.O_MR1;
+  }
+
   public static boolean atLeastP() {
     return VERSION.SDK_INT >= Build.VERSION_CODES.P;
   }

--- a/app/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.kt
+++ b/app/src/main/java/com/todoroo/astrid/activity/TaskEditFragment.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.Behavior.DragCallback
 import com.google.android.material.composethemeadapter.MdcTheme
+import com.todoroo.andlib.utility.AndroidUtilities.atLeastOreoMR1
 import com.todoroo.andlib.utility.DateUtilities
 import com.todoroo.astrid.dao.TaskDao
 import com.todoroo.astrid.data.Task
@@ -149,6 +150,9 @@ class TaskEditFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             } else {
                 discardButtonClick()
             }
+        }
+        if (atLeastOreoMR1()) {
+            activity?.setShowWhenLocked(preferences.showEditScreenWithoutUnlock)
         }
 
         binding = FragmentTaskEditBinding.inflate(inflater)
@@ -303,6 +307,13 @@ class TaskEditFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             editViewModel.selectedList.update { filter }
         }
         return view
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (atLeastOreoMR1()) {
+            activity?.setShowWhenLocked(false)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/tasks/preferences/Preferences.kt
+++ b/app/src/main/java/org/tasks/preferences/Preferences.kt
@@ -176,6 +176,9 @@ class Preferences @JvmOverloads constructor(
             return if (firstDayOfWeek < 1 || firstDayOfWeek > 7) 0 else firstDayOfWeek
         }
 
+    val showEditScreenWithoutUnlock: Boolean
+        get() = getBoolean(R.string.p_show_edit_screen_without_unlock, false)
+
     @SuppressLint("ApplySharedPref")
     fun clear() {
         prefs.edit().clear().commit()

--- a/app/src/main/java/org/tasks/preferences/fragments/TaskEditPreferences.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/TaskEditPreferences.kt
@@ -2,6 +2,7 @@ package org.tasks.preferences.fragments
 
 import android.os.Bundle
 import androidx.appcompat.content.res.AppCompatResources
+import com.todoroo.andlib.utility.AndroidUtilities.atLeastOreoMR1
 import dagger.hilt.android.AndroidEntryPoint
 import org.tasks.R
 import org.tasks.injection.InjectingPreferenceFragment
@@ -21,5 +22,7 @@ class TaskEditPreferences : InjectingPreferenceFragment() {
             tint = context.getColor(R.color.icon_tint_with_alpha)
             iconVisible = true
         }
+
+        findPreference(R.string.p_show_edit_screen_without_unlock).isVisible = atLeastOreoMR1()
     }
 }

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -98,6 +98,7 @@
 
   <!-- show comments in task edit -->
   <string name="p_show_task_edit_comments">p_show_task_edit_comments</string>
+  <string name="p_show_edit_screen_without_unlock">show_edit_screen_without_unlock</string>
 
   <string-array name="EPr_reminder_random_hours">
     <!-- values (in hours) associated with random reminders above. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,7 @@ File %1$s contained %2$s.\n\n
   <string name="url_invalid_scheme">Must begin with http(s)://</string>
   <string name="no_title">(No title)</string>
   <string name="back_button_saves_task">Back button saves task</string>
+  <string name="show_edit_screen_without_unlock">Show edit screen without unlock</string>
   <string name="default_list">Default list</string>
   <string name="default_tags">Default tags</string>
   <string name="default_recurrence">Default recurrence</string>

--- a/app/src/main/res/xml/preferences_task_edit.xml
+++ b/app/src/main/res/xml/preferences_task_edit.xml
@@ -35,4 +35,10 @@
         android:title="@string/EPr_show_task_edit_comments"
         app:singleLineTitle="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/p_show_edit_screen_without_unlock"
+        android:title="@string/show_edit_screen_without_unlock"
+        app:singleLineTitle="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
I often find myself picking up the phone just to write down a task, so I've added a notification drawer quick setting to speed things up. However, when I use this button from the lock screen, I have to unlock my device first, which is annoying. I would like to be able to add (not view) tasks without the need to unlock my phone.

This PR adds such an optional feature for devices running Android 8.1+. Note that I am not an Android developer, so the implementation is probably not perfect. However, from my testing on an emulator, this code seems to do just what I want.