### PR TITLE
Sending local broadcast refresh event for refreshing nav drawer menu …

### DIFF
--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -36,6 +36,7 @@ import com.todoroo.astrid.dao.Database
 import com.todoroo.astrid.data.Task
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings
 import org.tasks.data.Filter
@@ -58,6 +59,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var locale: Locale
     @Inject lateinit var database: Database
     @Inject lateinit var filterCriteriaProvider: FilterCriteriaProvider
+    @Inject lateinit var localBroadcastManager: LocalBroadcastManager
 
     private lateinit var name: TextInputEditText
     private lateinit var nameLayout: TextInputLayout
@@ -258,6 +260,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
             } else {
                 filterDao.update(f)
             }
+            localBroadcastManager.broadcastRefresh()
             setResult(
                     Activity.RESULT_OK,
                     Intent(TaskListFragment.ACTION_RELOAD)

--- a/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.data.CaldavAccount
@@ -35,6 +36,7 @@ import javax.inject.Inject
 class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var googleTaskListDao: GoogleTaskListDao
     @Inject lateinit var taskDeleter: TaskDeleter
+    @Inject lateinit var localBroadcastManager: LocalBroadcastManager
 
     private lateinit var name: TextInputEditText
     private lateinit var progressView: ProgressBar
@@ -115,6 +117,7 @@ class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
                     gtasksList.color = selectedColor
                     gtasksList.setIcon(selectedIcon)
                     googleTaskListDao.insertOrReplace(gtasksList)
+                    localBroadcastManager.broadcastRefresh()
                     setResult(
                             Activity.RESULT_OK,
                             Intent(TaskListFragment.ACTION_RELOAD)

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -121,6 +121,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmen
             radius = slider.value.toInt(),
         )
         locationDao.update(place)
+        localBroadcastManager.broadcastRefresh()
         setResult(
                 Activity.RESULT_OK,
                 Intent(TaskListFragment.ACTION_RELOAD)

--- a/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
@@ -18,6 +18,7 @@ import com.todoroo.astrid.activity.TaskListFragment
 import com.todoroo.astrid.api.TagFilter
 import com.todoroo.astrid.helper.UUIDHelper
 import dagger.hilt.android.AndroidEntryPoint
+import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.data.TagDao
@@ -32,6 +33,7 @@ import javax.inject.Inject
 class TagSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var tagDataDao: TagDataDao
     @Inject lateinit var tagDao: TagDao
+    @Inject lateinit var localBroadcastManager: LocalBroadcastManager
 
     private lateinit var name: TextInputEditText
     private lateinit var nameLayout: TextInputLayout
@@ -89,6 +91,7 @@ class TagSettingsActivity : BaseListSettingsActivity() {
             tagData.setColor(selectedColor)
             tagData.setIcon(selectedIcon)
             tagDataDao.createNew(tagData)
+            localBroadcastManager.broadcastRefresh()
             setResult(Activity.RESULT_OK, Intent().putExtra(MainActivity.OPEN_FILTER, TagFilter(tagData)))
         } else if (hasChanges()) {
             tagData.name = newName
@@ -96,6 +99,7 @@ class TagSettingsActivity : BaseListSettingsActivity() {
             tagData.setIcon(selectedIcon)
             tagDataDao.update(tagData)
             tagDao.rename(tagData.remoteId!!, newName)
+            localBroadcastManager.broadcastRefresh()
             setResult(
                     Activity.RESULT_OK,
                     Intent(TaskListFragment.ACTION_RELOAD)


### PR DESCRIPTION
Fixes #2772

### Issue : 
TaskListDrawer is not updated while changes on filter, tags, local lists, places is updated via NavigationDrawerCustomisation.

**Issue recording**: https://github.com/tasks/tasks/assets/75371296/fc11437c-8185-4757-a5dd-21859fb97396

### Steps to reproduce issue :
1. open menu
2. click on Manage drawer
3. click on filter and update name, save it
4. changes are seen on manage drawer
5. navigate back to menu, changes are not updated on the menu.
6. Similar senario can be observed for other filters on the menu (tags, places, local lists).

### Fix : 
Sending a refresh event via local broadcast receiver to refresh the filter list to MainViewModel