### PR TITLE
Point collased chevron to the left instead of upwards

### DIFF
--- a/wear/src/main/java/org/tasks/presentation/components/Chevron.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/Chevron.kt
@@ -14,7 +14,7 @@ import androidx.wear.compose.material.MaterialTheme
 @Composable
 fun Chevron(collapsed: Boolean) {
     val rotation by animateFloatAsState(
-        targetValue = if (collapsed) 0f else 180f,
+        targetValue = if (collapsed) 270f else 180f,
         animationSpec = tween(250),
         label = "arrow rotation",
     )


### PR DESCRIPTION
See https://ux.stackexchange.com/questions/37686/how-should-you-show-that-an-accordion-is-expanded#answer-37688 for some discussion.

But really, having the chevron point upward makes no sense to me, and I am trying to get acquainted to the codebase, so this one seemed a really easy target.