### PR TITLE
Base list setting activity compose rebased

### DIFF
--- a/app/generic/release/output-metadata.json
+++ b/app/generic/release/output-metadata.json
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "org.tasks.ak",
+  "variantName": "genericRelease",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "attributes": [],
+      "versionCode": 130804,
+      "versionName": "14.0.6",
+      "outputFile": "app-generic-release.apk"
+    }
+  ],
+  "elementType": "File"
+}

--- a/app/src/googleplay/java/org/tasks/location/GoogleMapFragment.kt
+++ b/app/src/googleplay/java/org/tasks/location/GoogleMapFragment.kt
@@ -2,6 +2,7 @@ package org.tasks.location
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -23,14 +24,18 @@ class GoogleMapFragment @Inject constructor(
     private var map: GoogleMap? = null
     private var circle: Circle? = null
 
-    override fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean) {
+    override fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean, parent: ViewGroup?) {
         this.callback = callback
         this.dark = dark
         val fragmentManager = activity.supportFragmentManager
         var mapFragment = fragmentManager.findFragmentByTag(FRAG_TAG_MAP) as SupportMapFragment?
         if (mapFragment == null) {
             mapFragment = SupportMapFragment()
-            fragmentManager.beginTransaction().replace(R.id.map, mapFragment).commit()
+            if (parent == null) {
+                fragmentManager.beginTransaction().replace(R.id.map, mapFragment).commit()
+            } else {
+                fragmentManager.beginTransaction().add(parent, mapFragment, null).commit()
+            }
         }
         mapFragment.getMapAsync(this)
     }

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -18,10 +18,10 @@ import org.tasks.compose.Constants
 import org.tasks.compose.DeleteButton
 import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
 import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
-import org.tasks.compose.ListSettings.ListSettingsProgressBar
+import org.tasks.compose.ListSettings.ProgressBar
 import org.tasks.compose.ListSettings.ListSettingsSurface
-import org.tasks.compose.ListSettings.ListSettingsTitleInput
-import org.tasks.compose.ListSettings.ListSettingsToolbar
+import org.tasks.compose.ListSettings.TitleInput
+import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.PromptAction
 import org.tasks.compose.ListSettings.SelectColorRow
 import org.tasks.compose.ListSettings.SelectIconRow
@@ -35,6 +35,7 @@ import org.tasks.themes.ColorProvider
 import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
+
 
 abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
     @Inject lateinit var colorProvider: ColorProvider
@@ -123,6 +124,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
         themeColor.applyToNavigationBar(this)
     }
 
+    /** Standard @Compose view content for descendants. TaskTheme must be set up by client */
     @Composable
     protected fun baseSettingsContent(
         title: String = toolbarTitle ?: "",
@@ -130,39 +132,37 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
         optionButton: @Composable () -> Unit = { if (!isNew) DeleteButton { promptDelete() } },
         extensionContent: @Composable ColumnScope.() -> Unit = {}
     ) {
-        TasksTheme {
-            ListSettingsSurface {
-                ListSettingsToolbar(
-                    title = title,
-                    save = { lifecycleScope.launch { save() } },
-                    optionButton = optionButton
-                )
-                ListSettingsProgressBar(showProgress)
-                ListSettingsTitleInput(
-                    text = textState, error = errorState, requestKeyboard = requestKeyboard,
-                    modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
-                )
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    SelectColorRow(
-                        color = colorState,
-                        selectColor = { showThemePicker() },
-                        clearColor = { clearColor() })
-                    SelectIconRow(
-                        icon = selectedIcon,
-                        selectIcon = { showIconPicker() })
-                    extensionContent()
+        ListSettingsSurface {
+            Toolbar(
+                title = title,
+                save = { lifecycleScope.launch { save() } },
+                optionButton = optionButton
+            )
+            ProgressBar(showProgress)
+            TitleInput(
+                text = textState, error = errorState, requestKeyboard = requestKeyboard,
+                modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
+            )
+            Column(modifier = Modifier.fillMaxWidth()) {
+                SelectColorRow(
+                    color = colorState,
+                    selectColor = { showThemePicker() },
+                    clearColor = { clearColor() })
+                SelectIconRow(
+                    icon = selectedIcon,
+                    selectIcon = { showIconPicker() })
+                extensionContent()
 
-                    PromptAction(
-                        showDialog = promptDelete,
-                        title = stringResource(id = R.string.delete_tag_confirmation, title),
-                        onAction = { lifecycleScope.launch { delete() } }
-                    )
-                    PromptAction(
-                        showDialog = promptDiscard,
-                        title = stringResource(id = R.string.discard_changes),
-                        onAction = { lifecycleScope.launch { finish() } }
-                    )
-                }
+                PromptAction(
+                    showDialog = promptDelete,
+                    title = stringResource(id = R.string.delete_tag_confirmation, title),
+                    onAction = { lifecycleScope.launch { delete() } }
+                )
+                PromptAction(
+                    showDialog = promptDiscard,
+                    title = stringResource(id = R.string.discard_changes),
+                    onAction = { lifecycleScope.launch { finish() } }
+                )
             }
         }
     }

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -42,9 +42,12 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     protected var selectedColor = 0
     protected var selectedIcon = mutableStateOf<String?>(null)
 
+    protected abstract val defaultIcon: Int
+
     protected val textState = mutableStateOf("")
     protected val errorState = mutableStateOf("")
     protected val colorState = mutableStateOf(Color.Unspecified)
+    protected val iconState = mutableIntStateOf(R.drawable.ic_outline_not_interested_24px)
     protected val showProgress = mutableStateOf(false)
     protected val promptDelete = mutableStateOf(false)
     protected val promptDiscard = mutableStateOf(false)

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -19,7 +19,7 @@ import org.tasks.compose.DeleteButton
 import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
 import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
 import org.tasks.compose.ListSettings.ProgressBar
-import org.tasks.compose.ListSettings.ListSettingsSurface
+import org.tasks.compose.ListSettings.SettingsSurface
 import org.tasks.compose.ListSettings.TitleInput
 import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.PromptAction
@@ -32,7 +32,6 @@ import org.tasks.dialogs.ColorWheelPicker
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider
-import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 
@@ -124,7 +123,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
         themeColor.applyToNavigationBar(this)
     }
 
-    /** Standard @Compose view content for descendants. TaskTheme must be set up by client */
+    /** Standard @Compose view content for descendants. Caller must wrap it to TasksTheme{} */
     @Composable
     protected fun baseSettingsContent(
         title: String = toolbarTitle ?: "",
@@ -132,7 +131,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
         optionButton: @Composable () -> Unit = { if (!isNew) DeleteButton { promptDelete() } },
         extensionContent: @Composable ColumnScope.() -> Unit = {}
     ) {
-        ListSettingsSurface {
+        SettingsSurface {
             Toolbar(
                 title = title,
                 save = { lifecycleScope.launch { save() } },

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -1,12 +1,18 @@
 package org.tasks.activities
 
+import android.content.DialogInterface
 import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
-import android.widget.TextView
-import androidx.appcompat.widget.Toolbar
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
@@ -19,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.composethemeadapter.MdcTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,6 +33,15 @@ import org.tasks.R
 import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
 import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
 import org.tasks.compose.components.TasksIcon
+import org.tasks.compose.Constants
+import org.tasks.compose.DeleteButton
+import org.tasks.compose.ListSettings.ListSettingsProgressBar
+import org.tasks.compose.ListSettings.ListSettingsSurface
+import org.tasks.compose.ListSettings.ListSettingsTitleInput
+import org.tasks.compose.ListSettings.ListSettingsToolbar
+import org.tasks.compose.ListSettings.PromptAction
+import org.tasks.compose.ListSettings.SelectColorRow
+import org.tasks.compose.ListSettings.SelectIconRow
 import org.tasks.dialogs.ColorPalettePicker
 import org.tasks.dialogs.ColorPalettePicker.Companion.newColorPalette
 import org.tasks.dialogs.ColorPickerAdapter.Palette
@@ -34,67 +50,40 @@ import org.tasks.dialogs.DialogBuilder
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider
+import org.tasks.themes.CustomIcons.getIconResId
 import org.tasks.themes.DrawableUtil
 import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 
-abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Toolbar.OnMenuItemClickListener, ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
+abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), IconPickerCallback, ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
     @Inject lateinit var dialogBuilder: DialogBuilder
     @Inject lateinit var colorProvider: ColorProvider
     protected abstract val defaultIcon: String
     protected var selectedColor = 0
     protected var selectedIcon = MutableStateFlow<String?>(null)
 
-    private lateinit var clear: View
-    private lateinit var color: TextView
-    protected lateinit var toolbar: Toolbar
-    protected lateinit var colorRow: ViewGroup
+    protected abstract val defaultIcon: Int
+
+    protected val textState = mutableStateOf("")
+    protected val errorState = mutableStateOf("")
+    protected val colorState = mutableStateOf(Color.Unspecified)
+    protected val iconState = mutableIntStateOf(R.drawable.ic_outline_not_interested_24px)
+    protected val showProgress = mutableStateOf(false)
+    protected val promptDelete = mutableStateOf(false)
+    protected val promptDiscard = mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val view = bind()
-        setContentView(view)
-        clear = findViewById<View>(R.id.clear).apply {
-            setOnClickListener { clearColor() }
-        }
-        color = findViewById(R.id.color)
-        colorRow = findViewById<ViewGroup>(R.id.color_row).apply {
-            setOnClickListener { showThemePicker() }
-        }
-        findViewById<ComposeView>(R.id.icon).setContent {
-            TasksTheme(theme = tasksTheme.themeBase.index) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    TasksIcon(
-                        label = selectedIcon.collectAsStateWithLifecycle().value ?: defaultIcon
-                    )
-                    Spacer(modifier = Modifier.width(34.dp))
-                    Text(
-                        text = "Icon",
-                        style = MaterialTheme.typography.bodyLarge.copy(
-                            fontSize = 18.sp,
-                        ),
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-            }
-        }
-        findViewById<View>(R.id.icon_row).setOnClickListener { showIconPicker() }
-        toolbar = view.findViewById(R.id.toolbar)
+
+        /* defaultIcon is initialized in the descendant's constructor so it can not be used
+           in constructor of the base class. So valid initial value for iconState is set here  */
+        iconState.intValue = getIconResId(defaultIcon)!!
+
         if (savedInstanceState != null) {
             selectedColor = savedInstanceState.getInt(EXTRA_SELECTED_THEME)
             selectedIcon.update { savedInstanceState.getString(EXTRA_SELECTED_ICON) }
         }
-        toolbar.title = toolbarTitle
-        toolbar.navigationIcon = getDrawable(R.drawable.ic_outline_save_24px)
-        toolbar.setNavigationOnClickListener { lifecycleScope.launch { save() } }
-        if (!isNew) {
-            toolbar.inflateMenu(R.menu.menu_tag_settings)
-        }
-        toolbar.setOnMenuItemClickListener(this)
-
         addBackPressedCallback {
             discard()
         }
@@ -111,24 +100,17 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), To
     protected abstract val isNew: Boolean
     protected abstract val toolbarTitle: String?
     protected abstract suspend fun delete()
-    protected abstract fun bind(): View
+    //protected abstract fun bind(): View
     protected open fun discard() {
-        if (!hasChanges()) {
-            finish()
-        } else {
-            dialogBuilder
-                    .newDialog(R.string.discard_changes)
-                    .setPositiveButton(R.string.discard) { _, _ -> finish() }
-                    .setNegativeButton(R.string.cancel, null)
-                    .show()
-        }
+        if (hasChanges())  promptDiscard.value = true
+        else finish()
     }
 
-    private fun clearColor() {
+    protected fun clearColor() {
         onColorPicked(0)
     }
 
-    private fun showThemePicker() {
+    protected fun showThemePicker() {
         newColorPalette(null, 0, selectedColor, Palette.COLORS)
                 .show(supportFragmentManager, FRAG_TAG_COLOR_PICKER)
     }
@@ -139,6 +121,11 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), To
 
     private fun showIconPicker() {
         launcher.launchIconPicker(this, selectedIcon.value)
+
+    override fun onSelected(dialogInterface: DialogInterface, icon: Int) {
+        selectedIcon = icon
+        dialogInterface.dismiss()
+        updateTheme()
     }
 
     override fun onColorPicked(color: Int) {
@@ -146,38 +133,65 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), To
         updateTheme()
     }
 
-    override fun onMenuItemClick(item: MenuItem): Boolean {
-        if (item.itemId == R.id.delete) {
-            promptDelete()
-            return true
-        }
-        return onOptionsItemSelected(item)
-    }
-
-    protected open fun promptDelete() {
-        dialogBuilder
-                .newDialog(R.string.delete_tag_confirmation, toolbarTitle)
-                .setPositiveButton(R.string.delete) { _, _ -> lifecycleScope.launch { delete() } }
-                .setNegativeButton(R.string.cancel, null)
-                .show()
-    }
+    protected open fun promptDelete() { promptDelete.value = true }
 
     protected fun updateTheme() {
-        val themeColor: ThemeColor
-        if (selectedColor == 0) {
-            themeColor = this.themeColor
-            DrawableUtil.setLeftDrawable(this, color, R.drawable.ic_outline_not_interested_24px)
-            DrawableUtil.getLeftDrawable(color).setTint(getColor(R.color.icon_tint_with_alpha))
-            clear.visibility = View.GONE
-        } else {
-            themeColor = colorProvider.getThemeColor(selectedColor, true)
-            DrawableUtil.setLeftDrawable(this, color, R.drawable.color_picker)
-            val leftDrawable = DrawableUtil.getLeftDrawable(color)
-            (if (leftDrawable is LayerDrawable) leftDrawable.getDrawable(0) else leftDrawable)
-                    .setTint(themeColor.primaryColor)
-            clear.visibility = View.VISIBLE
-        }
+
+        val themeColor: ThemeColor =
+            if (selectedColor == 0) this.themeColor
+            else colorProvider.getThemeColor(selectedColor, true)
+
+        colorState.value =
+            if (selectedColor == 0) Color.Unspecified
+            else Color((colorProvider.getThemeColor(selectedColor, true)).primaryColor)
+
+        iconState.intValue = (getIconResId(selectedIcon) ?: getIconResId(defaultIcon))!!
+
         themeColor.applyToNavigationBar(this)
+    }
+
+    @Composable
+    protected fun baseSettingsContent(
+        title: String = toolbarTitle ?: "",
+        requestKeyboard: Boolean = isNew,
+        optionButton: @Composable () -> Unit = { if (!isNew) DeleteButton { promptDelete() } },
+        extensionContent: @Composable ColumnScope.() -> Unit = {}
+    ) {
+        MdcTheme {
+            ListSettingsSurface {
+                ListSettingsToolbar(
+                    title = title,
+                    save = { lifecycleScope.launch { save() } },
+                    optionButton = optionButton
+                )
+                ListSettingsProgressBar(showProgress)
+                ListSettingsTitleInput(
+                    text = textState, error = errorState, requestKeyboard = requestKeyboard,
+                    modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
+                )
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    SelectColorRow(
+                        color = colorState,
+                        selectColor = { showThemePicker() },
+                        clearColor = { clearColor() })
+                    SelectIconRow(
+                        icon = iconState,
+                        selectIcon = { showIconPicker() })
+                    extensionContent()
+
+                    PromptAction(
+                        showDialog = promptDelete,
+                        title = stringResource(id = R.string.delete_tag_confirmation, title),
+                        onAction = { lifecycleScope.launch { delete() } }
+                    )
+                    PromptAction(
+                        showDialog = promptDiscard,
+                        title = stringResource(id = R.string.discard_changes),
+                        onAction = { lifecycleScope.launch { finish() } }
+                    )
+                }
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -42,8 +42,6 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     protected var selectedColor = 0
     protected var selectedIcon = mutableStateOf<String?>(null)
 
-    protected abstract val defaultIcon: Int
-
     protected val textState = mutableStateOf("")
     protected val errorState = mutableStateOf("")
     protected val colorState = mutableStateOf(Color.Unspecified)

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -1,7 +1,5 @@
 package org.tasks.activities
 
-import android.content.DialogInterface
-import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -13,28 +11,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.composethemeadapter.MdcTheme
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.tasks.R
-import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
-import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
-import org.tasks.compose.components.TasksIcon
 import org.tasks.compose.Constants
 import org.tasks.compose.DeleteButton
+import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
+import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
 import org.tasks.compose.ListSettings.ListSettingsProgressBar
 import org.tasks.compose.ListSettings.ListSettingsSurface
 import org.tasks.compose.ListSettings.ListSettingsTitleInput
@@ -50,14 +33,12 @@ import org.tasks.dialogs.DialogBuilder
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider
-import org.tasks.themes.CustomIcons.getIconResId
-import org.tasks.themes.DrawableUtil
 import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 
-abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), IconPickerCallback, ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
-    @Inject lateinit var dialogBuilder: DialogBuilder
+abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
+    //lateinit var dialogBuilder: DialogBuilder
     @Inject lateinit var colorProvider: ColorProvider
     protected abstract val defaultIcon: String
     protected var selectedColor = 0
@@ -78,11 +59,11 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Ic
 
         /* defaultIcon is initialized in the descendant's constructor so it can not be used
            in constructor of the base class. So valid initial value for iconState is set here  */
-        iconState.intValue = getIconResId(defaultIcon)!!
+        selectedIcon.value = defaultIcon
 
         if (savedInstanceState != null) {
             selectedColor = savedInstanceState.getInt(EXTRA_SELECTED_THEME)
-            selectedIcon.update { savedInstanceState.getString(EXTRA_SELECTED_ICON) }
+            selectedIcon.value = savedInstanceState.getString(EXTRA_SELECTED_ICON) ?: defaultIcon
         }
         addBackPressedCallback {
             discard()
@@ -119,13 +100,8 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Ic
         selectedIcon.update { selected }
     }
 
-    private fun showIconPicker() {
+    fun showIconPicker() {
         launcher.launchIconPicker(this, selectedIcon.value)
-
-    override fun onSelected(dialogInterface: DialogInterface, icon: Int) {
-        selectedIcon = icon
-        dialogInterface.dismiss()
-        updateTheme()
     }
 
     override fun onColorPicked(color: Int) {
@@ -145,7 +121,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Ic
             if (selectedColor == 0) Color.Unspecified
             else Color((colorProvider.getThemeColor(selectedColor, true)).primaryColor)
 
-        iconState.intValue = (getIconResId(selectedIcon) ?: getIconResId(defaultIcon))!!
+        //iconState.intValue = (getIconResId(selectedIcon) ?: getIconResId(defaultIcon))!!
 
         themeColor.applyToNavigationBar(this)
     }
@@ -157,7 +133,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Ic
         optionButton: @Composable () -> Unit = { if (!isNew) DeleteButton { promptDelete() } },
         extensionContent: @Composable ColumnScope.() -> Unit = {}
     ) {
-        MdcTheme {
+        TasksTheme {
             ListSettingsSurface {
                 ListSettingsToolbar(
                     title = title,
@@ -175,7 +151,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Ic
                         selectColor = { showThemePicker() },
                         clearColor = { clearColor() })
                     SelectIconRow(
-                        icon = iconState,
+                        icon = selectedIcon,
                         selectIcon = { showIconPicker() })
                     extensionContent()
 

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -45,7 +45,6 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     protected val textState = mutableStateOf("")
     protected val errorState = mutableStateOf("")
     protected val colorState = mutableStateOf(Color.Unspecified)
-    protected val iconState = mutableIntStateOf(R.drawable.ic_outline_not_interested_24px)
     protected val showProgress = mutableStateOf(false)
     protected val promptDelete = mutableStateOf(false)
     protected val promptDiscard = mutableStateOf(false)

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -29,7 +29,6 @@ import org.tasks.dialogs.ColorPalettePicker
 import org.tasks.dialogs.ColorPalettePicker.Companion.newColorPalette
 import org.tasks.dialogs.ColorPickerAdapter.Palette
 import org.tasks.dialogs.ColorWheelPicker
-import org.tasks.dialogs.DialogBuilder
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -32,6 +32,7 @@ import org.tasks.dialogs.ColorWheelPicker
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider
+import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -37,7 +37,6 @@ import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 
 abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), ColorPalettePicker.ColorPickedCallback, ColorWheelPicker.ColorPickedCallback {
-    //lateinit var dialogBuilder: DialogBuilder
     @Inject lateinit var colorProvider: ColorProvider
     protected abstract val defaultIcon: String
     protected var selectedColor = 0
@@ -80,7 +79,6 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     protected abstract val isNew: Boolean
     protected abstract val toolbarTitle: String?
     protected abstract suspend fun delete()
-    //protected abstract fun bind(): View
     protected open fun discard() {
         if (hasChanges())  promptDiscard.value = true
         else finish()

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -19,7 +19,7 @@ import org.tasks.compose.DeleteButton
 import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
 import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
 import org.tasks.compose.ListSettings.ProgressBar
-import org.tasks.compose.ListSettings.ListSettingsSurface
+import org.tasks.compose.ListSettings.SettingsSurface
 import org.tasks.compose.ListSettings.TitleInput
 import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.PromptAction
@@ -32,7 +32,6 @@ import org.tasks.dialogs.ColorWheelPicker
 import org.tasks.extensions.addBackPressedCallback
 import org.tasks.injection.ThemedInjectingAppCompatActivity
 import org.tasks.themes.ColorProvider
-import org.tasks.themes.TasksTheme
 import org.tasks.themes.ThemeColor
 import javax.inject.Inject
 

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -40,9 +40,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     @Inject lateinit var colorProvider: ColorProvider
     protected abstract val defaultIcon: String
     protected var selectedColor = 0
-    protected var selectedIcon = MutableStateFlow<String?>(null)
-
-    protected abstract val defaultIcon: Int
+    protected var selectedIcon = mutableStateOf<String?>(null)
 
     protected val textState = mutableStateOf("")
     protected val errorState = mutableStateOf("")
@@ -94,7 +92,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
     }
 
     val launcher = registerForIconPickerResult { selected ->
-        selectedIcon.update { selected }
+        selectedIcon.value = selected
     }
 
     fun showIconPicker() {
@@ -148,7 +146,7 @@ abstract class BaseListSettingsActivity : ThemedInjectingAppCompatActivity(), Co
                     selectColor = { showThemePicker() },
                     clearColor = { clearColor() })
                 SelectIconRow(
-                    icon = selectedIcon,
+                    icon = selectedIcon.value ?: defaultIcon,
                     selectIcon = { showIconPicker() })
                 extensionContent()
 

--- a/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/BaseListSettingsActivity.kt
@@ -19,7 +19,7 @@ import org.tasks.compose.DeleteButton
 import org.tasks.compose.IconPickerActivity.Companion.launchIconPicker
 import org.tasks.compose.IconPickerActivity.Companion.registerForIconPickerResult
 import org.tasks.compose.ListSettings.ProgressBar
-import org.tasks.compose.ListSettings.SettingsSurface
+import org.tasks.compose.ListSettings.ListSettingsSurface
 import org.tasks.compose.ListSettings.TitleInput
 import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.PromptAction

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -19,23 +19,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.composethemeadapter.MdcTheme
-import org.tasks.data.sql.Field
-import org.tasks.data.sql.Query
-import org.tasks.data.sql.UnaryCriterion
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import com.todoroo.astrid.api.BooleanCriterion
-import org.tasks.filters.CustomFilter
 import com.todoroo.astrid.api.CustomFilterCriterion
 import com.todoroo.astrid.api.MultipleSelectCriterion
 import com.todoroo.astrid.api.PermaSql
 import com.todoroo.astrid.api.TextInputCriterion
 import com.todoroo.astrid.core.CriterionInstance
-import org.tasks.data.db.Database
-import org.tasks.data.entity.Task
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
@@ -46,17 +38,23 @@ import org.tasks.compose.FilterCondition.InputTextOption
 import org.tasks.compose.FilterCondition.NewCriterionFAB
 import org.tasks.compose.FilterCondition.SelectCriterionType
 import org.tasks.compose.FilterCondition.SelectFromList
-import org.tasks.data.entity.Filter
-import org.tasks.data.dao.FilterDao
 import org.tasks.data.NO_ORDER
+import org.tasks.data.dao.FilterDao
 import org.tasks.data.dao.TaskDao.TaskCriteria.activeAndVisible
+import org.tasks.data.db.Database
+import org.tasks.data.entity.Filter
+import org.tasks.data.entity.Task
 import org.tasks.data.rawQuery
-import org.tasks.databinding.FilterSettingsActivityBinding
+import org.tasks.data.sql.Field
+import org.tasks.data.sql.Query
+import org.tasks.data.sql.UnaryCriterion
 import org.tasks.db.QueryUtils
 import org.tasks.extensions.Context.openUri
+import org.tasks.filters.CustomFilter
 import org.tasks.filters.FilterCriteriaProvider
 import org.tasks.filters.mapToSerializedString
 import org.tasks.themes.TasksIcons
+import org.tasks.themes.TasksTheme
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.max
@@ -84,8 +82,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null && filter != null) {
             selectedColor = filter!!.tint
-            selectedIcon = filter!!.icon
-            selectedIcon.update { filter!!.icon }
+            selectedIcon.value =  filter!!.icon ?: defaultIcon
             textState.value = filter!!.title ?: ""
         }
         when {
@@ -260,7 +257,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     @Composable
     private fun activityContent ()
     {
-        MdcTheme {
+        TasksTheme {
             Box(  // to layout FAB over the main content
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.TopStart

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -6,8 +6,8 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Help
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -121,7 +121,11 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
         fabExtended.value = isNew || criteria.size <= 1
         updateList()
 
-        this.setContent { activityContent() }
+        this.setContent {
+            TasksTheme {
+                activityContent()
+            }
+        }
     }
 
     private fun onDelete(index: Int) {

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -122,9 +122,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
         updateList()
 
         this.setContent {
-            TasksTheme {
-                activityContent()
-            }
+            TasksTheme { ActivityContent() }
         }
     }
 
@@ -222,13 +220,13 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     private fun help() = openUri(R.string.url_filters)
 
     private fun updateList() = lifecycleScope.launch {
-        val newList: MutableList<CriterionInstance> = emptyList<CriterionInstance>().toMutableStateList()
+        val newList = emptyList<CriterionInstance>().toMutableList()
         var max = 0
         var last = -1
         val sql = StringBuilder(Query.select(Field.COUNT).from(Task.TABLE).toString())
                 .append(" WHERE ")
-        newList.addAll(criteria)
-        for (instance in newList) {
+
+        for (instance in criteria) {
             when (instance.type) {
                 CriterionInstance.TYPE_ADD -> sql.append("OR ")
                 CriterionInstance.TYPE_SUBTRACT -> sql.append("AND NOT ")
@@ -254,6 +252,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                 last = instance.end
                 max = max(max, last)
             }
+            newList.add(instance)
         }
         for (instance in newList) {
             instance.max = max
@@ -263,7 +262,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     }
 
     @Composable
-    private fun activityContent ()
+    private fun ActivityContent ()
     {
         TasksTheme {
             Box(  // to layout FAB over the main content
@@ -318,8 +317,6 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                             }
                             if (criterionInstance.type != type) {
                                 criterionInstance.type = type
-                                //criteria.removeAt(index)  // remove - add pair triggers the item recomposition
-                                //criteria.add(index, criterionInstance)
                                 updateList()
                             }
                             editCriterionType.value = null

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -260,7 +260,6 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
         }
         criteria.clear()
         criteria.addAll(newList)
-        //criteria = criteria.toMutableStateList()
     }
 
     @Composable
@@ -284,6 +283,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                         items = criteria,
                         onDelete = { index -> onDelete(index) },
                         doSwap = { from, to -> onMove(from, to) },
+                        onComplete = { updateList() },
                         onClick = { id -> editCriterionType.value = id }
                     )
                 }

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -1,21 +1,25 @@
 package org.tasks.activities
 
 import android.app.Activity
-import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
-import android.view.MenuItem
-import android.widget.EditText
-import android.widget.FrameLayout
-import androidx.core.widget.addTextChangedListener
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Help
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.button.MaterialButtonToggleGroup
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-import com.google.android.material.textfield.TextInputEditText
-import com.google.android.material.textfield.TextInputLayout
+import com.google.android.material.composethemeadapter.MdcTheme
 import org.tasks.data.sql.Field
 import org.tasks.data.sql.Query
 import org.tasks.data.sql.UnaryCriterion
@@ -28,8 +32,6 @@ import com.todoroo.astrid.api.MultipleSelectCriterion
 import com.todoroo.astrid.api.PermaSql
 import com.todoroo.astrid.api.TextInputCriterion
 import com.todoroo.astrid.core.CriterionInstance
-import com.todoroo.astrid.core.CustomFilterAdapter
-import com.todoroo.astrid.core.CustomFilterItemTouchHelper
 import org.tasks.data.db.Database
 import org.tasks.data.entity.Task
 import dagger.hilt.android.AndroidEntryPoint
@@ -38,6 +40,12 @@ import kotlinx.coroutines.launch
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings
+import org.tasks.compose.DeleteButton
+import org.tasks.compose.FilterCondition.FilterCondition
+import org.tasks.compose.FilterCondition.InputTextOption
+import org.tasks.compose.FilterCondition.NewCriterionFAB
+import org.tasks.compose.FilterCondition.SelectCriterionType
+import org.tasks.compose.FilterCondition.SelectFromList
 import org.tasks.data.entity.Filter
 import org.tasks.data.dao.FilterDao
 import org.tasks.data.NO_ORDER
@@ -45,9 +53,7 @@ import org.tasks.data.dao.TaskDao.TaskCriteria.activeAndVisible
 import org.tasks.data.rawQuery
 import org.tasks.databinding.FilterSettingsActivityBinding
 import org.tasks.db.QueryUtils
-import org.tasks.extensions.Context.hideKeyboard
 import org.tasks.extensions.Context.openUri
-import org.tasks.extensions.hideKeyboard
 import org.tasks.filters.FilterCriteriaProvider
 import org.tasks.filters.mapToSerializedString
 import org.tasks.themes.TasksIcons
@@ -63,23 +69,24 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var filterCriteriaProvider: FilterCriteriaProvider
     @Inject lateinit var localBroadcastManager: LocalBroadcastManager
 
-    private lateinit var name: TextInputEditText
-    private lateinit var nameLayout: TextInputLayout
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var fab: ExtendedFloatingActionButton
-    
+
     private var filter: CustomFilter? = null
-    private lateinit var adapter: CustomFilterAdapter
-    private var criteria: MutableList<CriterionInstance> = ArrayList()
     override val defaultIcon = TasksIcons.FILTER_LIST
+
+    private var criteria: SnapshotStateList<CriterionInstance> = emptyList<CriterionInstance>().toMutableStateList()
+    private val fabExtended = mutableStateOf(false)
+    private val editCriterionType: MutableState<String?> = mutableStateOf(null)
+    private val newCriterionTypes: MutableState<List<CustomFilterCriterion>?> = mutableStateOf(null)
+    private val newCriterionOptions: MutableState<CriterionInstance?> = mutableStateOf(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         filter = intent.getParcelableExtra(TOKEN_FILTER)
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null && filter != null) {
             selectedColor = filter!!.tint
+            selectedIcon = filter!!.icon
             selectedIcon.update { filter!!.icon }
-            name.setText(filter!!.title)
+            textState.value = filter!!.title ?: ""
         }
         when {
             savedInstanceState != null -> lifecycleScope.launch {
@@ -93,36 +100,31 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                 setCriteria(filterCriteriaProvider.fromString(filter!!.criterion))
             }
             intent.hasExtra(EXTRA_CRITERIA) -> lifecycleScope.launch {
-                name.setText(intent.getStringExtra(EXTRA_TITLE))
+                textState.value = intent.getStringExtra(EXTRA_TITLE) ?: ""
                 setCriteria(
                     filterCriteriaProvider.fromString(intent.getStringExtra(EXTRA_CRITERIA)!!)
                 )
             }
             else -> setCriteria(universe())
         }
-        recyclerView.layoutManager = LinearLayoutManager(this)
-        ItemTouchHelper(
-                CustomFilterItemTouchHelper(this, this::onMove, this::onDelete, this::updateList))
-                .attachToRecyclerView(recyclerView)
-        if (isNew) {
-            toolbar.inflateMenu(R.menu.menu_help)
-        }
+
         updateTheme()
-    }
+
+    } /* end onCreate */
 
     private fun universe() = listOf(CriterionInstance().apply {
         criterion = filterCriteriaProvider.startingUniverse
         type = CriterionInstance.TYPE_UNIVERSE
     })
 
-    private fun setCriteria(criteria: List<CriterionInstance>) {
-        this.criteria = criteria
+    private fun setCriteria(criteriaList: List<CriterionInstance>) {
+        criteria = criteriaList
                 .ifEmpty { universe() }
-                .toMutableList()
-        adapter = CustomFilterAdapter(criteria, locale) { replaceId: String -> onClick(replaceId) }
-        recyclerView.adapter = adapter
-        fab.isExtended = isNew || adapter.itemCount <= 1
+                .toMutableStateList()
+        fabExtended.value = isNew || criteria.size <= 1
         updateList()
+
+        this.setContent { activityContent() }
     }
 
     private fun onDelete(index: Int) {
@@ -133,95 +135,13 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     private fun onMove(from: Int, to: Int) {
         val criterion = criteria.removeAt(from)
         criteria.add(to, criterion)
-        adapter.notifyItemMoved(from, to)
     }
 
-    private fun onClick(replaceId: String) {
-        val criterionInstance = criteria.find { it.id == replaceId }!!
-        val view = layoutInflater.inflate(R.layout.dialog_custom_filter_row_edit, recyclerView, false)
-        val group: MaterialButtonToggleGroup = view.findViewById(R.id.button_toggle)
-        val selected = getSelected(criterionInstance)
-        group.check(selected)
-        dialogBuilder
-                .newDialog(criterionInstance.titleFromCriterion)
-                .setView(view)
-                .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.ok) { _, _ ->
-                    criterionInstance.type = getType(group.checkedButtonId)
-                    updateList()
-                }
-                .setNeutralButton(R.string.help) { _, _ -> help() }
-                .show()
-    }
-
-    private fun getSelected(instance: CriterionInstance): Int =
-        when (instance.type) {
-            CriterionInstance.TYPE_ADD -> R.id.button_or
-            CriterionInstance.TYPE_SUBTRACT -> R.id.button_not
-            else -> R.id.button_and
-        }
-
-    private fun getType(selected: Int): Int =
-        when (selected) {
-            R.id.button_or -> CriterionInstance.TYPE_ADD
-            R.id.button_not -> CriterionInstance.TYPE_SUBTRACT
-            else -> CriterionInstance.TYPE_INTERSECT
-        }
-
-    private fun addCriteria() {
-        hideKeyboard()
-        fab.shrink()
+    private fun newCriterion() {
+        fabExtended.value = false // a.k.a. fab.shrink()
         lifecycleScope.launch {
-            val all = filterCriteriaProvider.all()
-            val names = all.map(CustomFilterCriterion::getName)
-            dialogBuilder.newDialog()
-                    .setItems(names) { dialog: DialogInterface, which: Int ->
-                        val instance = CriterionInstance()
-                        instance.criterion = all[which]
-                        showOptionsFor(instance) {
-                            criteria.add(instance)
-                            updateList()
-                        }
-                        dialog.dismiss()
-                    }
-                    .show()
+            newCriterionTypes.value = filterCriteriaProvider.all()
         }
-    }
-
-    /** Show options menu for the given criterioninstance  */
-    private fun showOptionsFor(item: CriterionInstance, onComplete: Runnable?) {
-        if (item.criterion is BooleanCriterion) {
-            onComplete?.run()
-            return
-        }
-        val dialog = dialogBuilder.newDialog(item.criterion.name)
-        if (item.criterion is MultipleSelectCriterion) {
-            val multiSelectCriterion = item.criterion as MultipleSelectCriterion
-            val titles = multiSelectCriterion.entryTitles
-            val listener = DialogInterface.OnClickListener { _: DialogInterface?, which: Int ->
-                item.selectedIndex = which
-                onComplete?.run()
-            }
-            dialog.setItems(titles, listener)
-        } else if (item.criterion is TextInputCriterion) {
-            val textInCriterion = item.criterion as TextInputCriterion
-            val frameLayout = FrameLayout(this)
-            frameLayout.setPadding(10, 0, 10, 0)
-            val editText = EditText(this)
-            editText.setText(item.selectedText)
-            editText.hint = textInCriterion.hint
-            frameLayout.addView(
-                    editText,
-                    FrameLayout.LayoutParams(
-                            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT))
-            dialog
-                    .setView(frameLayout)
-                    .setPositiveButton(R.string.ok) { _, _ ->
-                        item.selectedText = editText.text.toString()
-                        onComplete?.run()
-                    }
-        }
-        dialog.show()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -232,15 +152,16 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     override val isNew: Boolean
         get() = filter == null
 
-    override val toolbarTitle: String?
-        get() = if (isNew) getString(R.string.FLA_new_filter) else filter!!.title
+    override val toolbarTitle: String
+        get() = if (isNew) getString(R.string.FLA_new_filter) else filter?.title ?: ""
 
     override suspend fun save() {
         val newName = newName
         if (Strings.isNullOrEmpty(newName)) {
-            nameLayout.error = getString(R.string.name_cannot_be_empty)
+            errorState.value = getString(R.string.name_cannot_be_empty)
             return
         }
+
         if (hasChanges()) {
             var f = Filter(
                 id = filter?.id ?: 0L,
@@ -272,7 +193,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     }
 
     private val newName: String
-        get() = name.text.toString().trim { it <= ' ' }
+        get() = textState.value.trim { it <= ' ' }
 
     override fun hasChanges(): Boolean {
         return if (isNew) {
@@ -287,22 +208,7 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     }
 
     override fun finish() {
-        hideKeyboard(name)
         super.finish()
-    }
-
-    override fun bind() = FilterSettingsActivityBinding.inflate(layoutInflater).let {
-        name = it.name.apply {
-            addTextChangedListener(
-                onTextChanged = { _, _, _, _ -> nameLayout.error = null }
-            )
-        }
-        nameLayout = it.nameLayout
-        recyclerView = it.recyclerView
-        fab = it.fab.apply {
-            setOnClickListener { addCriteria() }
-        }
-        it.root
     }
 
     override suspend fun delete() {
@@ -311,14 +217,6 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                 Activity.RESULT_OK, Intent(TaskListFragment.ACTION_DELETED).putExtra(TOKEN_FILTER, filter))
         finish()
     }
-
-    override fun onMenuItemClick(item: MenuItem): Boolean =
-        if (item.itemId == R.id.menu_help) {
-            help()
-            true
-        } else {
-            super.onMenuItemClick(item)
-        }
 
     private fun help() = openUri(R.string.url_filters)
 
@@ -357,8 +255,132 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
         for (instance in criteria) {
             instance.max = max
         }
-        adapter.submitList(criteria)
     }
+
+    @Composable
+    private fun activityContent ()
+    {
+        MdcTheme {
+            Box(  // to layout FAB over the main content
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopStart
+            ) {
+                baseSettingsContent(
+                    optionButton = {
+                        if (isNew) {
+                            IconButton(onClick = { help() }) {
+                                Icon(imageVector = Icons.Outlined.Help, contentDescription = "")
+                            }
+                        } else DeleteButton{ promptDelete() }
+                    }
+                ) {
+                    FilterCondition(
+                        items = criteria,
+                        onDelete = { index -> onDelete(index) },
+                        doSwap = { from, to -> onMove(from, to) },
+                        onClick = { id -> editCriterionType.value = id }
+                    )
+                }
+
+                NewCriterionFAB(fabExtended) { newCriterion() }
+
+                /** edit given criterion type (AND|OR|NOT) **/
+                editCriterionType.value?.let { itemId ->
+                    val index = criteria.indexOfFirst { it.id == itemId }
+                    assert(index >= 0)
+                    val criterionInstance = criteria[index]
+                    if (criterionInstance.type != CriterionInstance.TYPE_UNIVERSE) {
+                        SelectCriterionType(
+                            title = criterionInstance.titleFromCriterion,
+                            selected = when (criterionInstance.type) {
+                                CriterionInstance.TYPE_INTERSECT -> 0
+                                CriterionInstance.TYPE_ADD -> 1
+                                else -> 2
+                            },
+                            types = listOf(
+                                stringResource(R.string.custom_filter_and),
+                                stringResource(R.string.custom_filter_or),
+                                stringResource(R.string.custom_filter_not)
+                            ),
+                            help = { help() },
+                            onCancel = { editCriterionType.value = null }
+                        ) { selected ->
+                            val type = when (selected) {
+                                0 -> CriterionInstance.TYPE_INTERSECT
+                                1 -> CriterionInstance.TYPE_ADD
+                                else -> CriterionInstance.TYPE_SUBTRACT
+                            }
+                            if (criterionInstance.type != type) {
+                                criterionInstance.type = type
+                                criteria.removeAt(index)  // remove - add pair triggers the item recomposition
+                                criteria.add(index, criterionInstance)
+                                updateList()
+                            }
+                            editCriterionType.value = null
+                        }
+                    }
+                } /* end (AND|OR|NOT) dialog */
+
+                /** dialog to select new criterion category **/
+                newCriterionTypes.value?.let  { list ->
+                    SelectFromList(
+                        names = list.map(CustomFilterCriterion::getName),
+                        onCancel = { newCriterionTypes.value = null },
+                        onSelected = { which ->
+                            val instance = CriterionInstance()
+                            instance.criterion = list[which]
+                            newCriterionTypes.value = null
+                            if (instance.criterion is BooleanCriterion) {
+                                criteria.add(instance)
+                                updateList()
+                            } else
+                                newCriterionOptions.value = instance
+                        }
+                    )
+                } /* end dialog  */
+
+                /** Show options menu for the given CriterionInstance  */
+                newCriterionOptions.value?.let { instance ->
+
+                    when (instance.criterion) {
+                        is MultipleSelectCriterion -> {
+                            val multiSelectCriterion = instance.criterion as MultipleSelectCriterion
+                            val list = multiSelectCriterion.entryTitles.toList()
+                            SelectFromList(
+                                names = list,
+                                title = instance.criterion.name,
+                                onCancel = { newCriterionOptions.value = null },
+                                onSelected = { which ->
+                                    instance.selectedIndex = which
+                                    criteria.add(instance)
+                                    updateList()
+                                    newCriterionOptions.value = null
+                                }
+                            )
+                        }
+
+                        is TextInputCriterion -> {
+                            val textInCriterion = instance.criterion as TextInputCriterion
+                            InputTextOption (
+                                title = textInCriterion.name,
+                                onCancel = { newCriterionOptions.value = null },
+                                onDone = { text ->
+                                    text.trim().takeIf{ it != "" }?. let { text ->
+                                        instance.selectedText = text
+                                        criteria.add(instance)
+                                        updateList()
+                                    }
+                                    newCriterionOptions.value = null
+                                }
+                            )
+                        }
+
+                        else -> assert(false) { "Unexpected Criterion type" }
+                    }
+                } /* end given criteria options dialog */
+            }
+        }
+    } /* activityContent */
 
     companion object {
         const val TOKEN_FILTER = "token_filter"

--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -222,11 +222,13 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
     private fun help() = openUri(R.string.url_filters)
 
     private fun updateList() = lifecycleScope.launch {
+        val newList: MutableList<CriterionInstance> = emptyList<CriterionInstance>().toMutableStateList()
         var max = 0
         var last = -1
         val sql = StringBuilder(Query.select(Field.COUNT).from(Task.TABLE).toString())
                 .append(" WHERE ")
-        for (instance in criteria) {
+        newList.addAll(criteria)
+        for (instance in newList) {
             when (instance.type) {
                 CriterionInstance.TYPE_ADD -> sql.append("OR ")
                 CriterionInstance.TYPE_SUBTRACT -> sql.append("AND NOT ")
@@ -253,9 +255,12 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                 max = max(max, last)
             }
         }
-        for (instance in criteria) {
+        for (instance in newList) {
             instance.max = max
         }
+        criteria.clear()
+        criteria.addAll(newList)
+        //criteria = criteria.toMutableStateList()
     }
 
     @Composable
@@ -313,8 +318,8 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                             }
                             if (criterionInstance.type != type) {
                                 criterionInstance.type = type
-                                criteria.removeAt(index)  // remove - add pair triggers the item recomposition
-                                criteria.add(index, criterionInstance)
+                                //criteria.removeAt(index)  // remove - add pair triggers the item recomposition
+                                //criteria.add(index, criterionInstance)
                                 updateList()
                             }
                             editCriterionType.value = null

--- a/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
-import org.tasks.compose.ListSettings.SettingsSnackBar
+import org.tasks.compose.ListSettings.Toaster
 import org.tasks.data.dao.GoogleTaskListDao
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
@@ -71,7 +71,7 @@ class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
         setContent {
             TasksTheme {
                 baseSettingsContent()
-                SettingsSnackBar(state = snackbar)
+                Toaster(state = snackbar)
             }
         }
 

--- a/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
@@ -7,32 +7,24 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.material.SnackbarHostState
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.api.services.tasks.model.TaskList
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import com.todoroo.astrid.service.TaskDeleter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.compose.ListSettings.ListSettingsSnackBar
-import org.tasks.data.CaldavAccount
-import org.tasks.data.CaldavCalendar
-import org.tasks.data.GoogleTaskListDao
-import org.tasks.themes.CustomIcons
 import org.tasks.data.dao.GoogleTaskListDao
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
-import org.tasks.databinding.ActivityGoogleTaskListSettingsBinding
-import org.tasks.extensions.Context.hideKeyboard
-import org.tasks.extensions.Context.toast
 import org.tasks.filters.GtasksFilter
 import org.tasks.themes.TasksIcons
+import org.tasks.themes.TasksTheme
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -61,7 +53,7 @@ class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null) {
             selectedColor = gtasksList.color
-            selectedIcon.update { gtasksList.icon }
+            selectedIcon.value = gtasksList.icon ?: defaultIcon
         }
 
         if (!isNewList) textState.value = gtasksList.name!!
@@ -77,7 +69,7 @@ class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
         deleteListViewModel.observe(this, this::onListDeleted, this::requestFailed)
 
         setContent {
-            MdcTheme {
+            TasksTheme {
                 baseSettingsContent()
 
                 ListSettingsSnackBar(state = snackbar)

--- a/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.lifecycleScope
 import com.google.api.services.tasks.model.TaskList
 import com.todoroo.astrid.activity.MainActivity

--- a/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/GoogleTaskListSettingsActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
-import org.tasks.compose.ListSettings.ListSettingsSnackBar
+import org.tasks.compose.ListSettings.SettingsSnackBar
 import org.tasks.data.dao.GoogleTaskListDao
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
@@ -71,9 +71,7 @@ class GoogleTaskListSettingsActivity : BaseListSettingsActivity() {
         setContent {
             TasksTheme {
                 baseSettingsContent()
-
-                ListSettingsSnackBar(state = snackbar)
-
+                SettingsSnackBar(state = snackbar)
             }
         }
 

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -23,25 +23,21 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.update
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.data.dao.LocationDao
-import org.tasks.data.displayName
 import org.tasks.data.entity.Place
 import org.tasks.data.mapPosition
-import org.tasks.databinding.ActivityLocationSettingsBinding
 import org.tasks.extensions.formatNumber
 import org.tasks.filters.PlaceFilter
 import org.tasks.location.MapFragment
 import org.tasks.preferences.Preferences
 import org.tasks.themes.TasksIcons
+import org.tasks.themes.TasksTheme
 import java.util.Locale
 import javax.inject.Inject
 
@@ -86,7 +82,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
         if (savedInstanceState == null) {
             textState.value = place.displayName
             selectedColor = place.color
-            selectedIcon.update { place.icon }
+            selectedIcon.value = place.icon ?: defaultIcon
         }
 
         sliderPos.floatValue = (place.radius / STEP * STEP).toFloat()
@@ -97,7 +93,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
         updateTheme()
 
         setContent {
-            MdcTheme {
+            TasksTheme {
                 baseSettingsContent()
                 {
                     Row(

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -29,6 +29,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
+import org.tasks.compose.Constants
 import org.tasks.data.dao.LocationDao
 import org.tasks.data.entity.Place
 import org.tasks.data.mapPosition
@@ -40,6 +41,7 @@ import org.tasks.themes.TasksIcons
 import org.tasks.themes.TasksTheme
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @AndroidEntryPoint
 class PlaceSettingsActivity : BaseListSettingsActivity(),
@@ -94,40 +96,39 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
 
         setContent {
             TasksTheme {
-                baseSettingsContent()
-                {
+                baseSettingsContent() {
                     Row(
                         modifier = Modifier
                             .requiredHeight(56.dp)
                             .fillMaxWidth()
-                            .padding(horizontal = 12.dp),
+                            .padding(horizontal = Constants.KEYLINE_FIRST),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween
-                    )
-                    {
+                    ) {
                         Text(stringResource(id = R.string.geofence_radius))
                         Row(horizontalArrangement = Arrangement.End) {
-                            Text(
-                                getString(
+                            Text(getString(
                                     R.string.location_radius_meters,
                                     locale.formatNumber(sliderPos.floatValue.toInt())
-                                )
-                            )
+                                ))
                         }
-
                     }
                     Slider(
                         modifier = Modifier.fillMaxWidth(),
                         value = sliderPos.floatValue,
                         valueRange = (MIN_RADIUS.toFloat()..MAX_RADIUS.toFloat()),
-                        steps = (MAX_RADIUS - MIN_RADIUS) / STEP,
+                        steps = (MAX_RADIUS - MIN_RADIUS) / STEP - 1,
                         onValueChange = { sliderPos.floatValue = it },
                         colors = SliderDefaults.colors(
                             thumbColor = MaterialTheme.colorScheme.secondary,
                             activeTrackColor = MaterialTheme.colorScheme.secondary,
                             inactiveTrackColor = colorResource(id = R.color.text_tertiary),
                             activeTickColor = MaterialTheme.colorScheme.secondary,
-                            inactiveTickColor = colorResource(id = R.color.text_tertiary)
+                            inactiveTickColor = colorResource(id = R.color.text_tertiary),
+                            disabledActiveTrackColor = MaterialTheme.colorScheme.secondary,
+                            disabledInactiveTrackColor = colorResource(id = R.color.text_tertiary),
+                            disabledActiveTickColor = MaterialTheme.colorScheme.secondary,
+                            disabledInactiveTickColor = colorResource(id = R.color.text_tertiary)
                         )
                     )
 
@@ -171,7 +172,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
             name = newName,
             color = selectedColor,
             icon = selectedIcon.value,
-            radius = sliderPos.floatValue.toInt(),
+            radius = sliderPos.floatValue.roundToInt(),
         )
         locationDao.update(place)
         localBroadcastManager.broadcastRefresh()

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -109,7 +109,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                         Row(horizontalArrangement = Arrangement.End) {
                             Text(getString(
                                     R.string.location_radius_meters,
-                                    locale.formatNumber(sliderPos.floatValue.toInt())
+                                    locale.formatNumber(sliderPos.floatValue.roundToInt())
                                 ))
                         }
                     }

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -3,13 +3,31 @@ package org.tasks.activities
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.widget.addTextChangedListener
-import com.google.android.material.slider.Slider
-import com.google.android.material.textfield.TextInputEditText
-import com.google.android.material.textfield.TextInputLayout
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.LinearLayout
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Slider
+import androidx.compose.material.SliderDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.material.composethemeadapter.MdcTheme
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.update
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
@@ -26,22 +44,17 @@ import org.tasks.preferences.Preferences
 import org.tasks.themes.TasksIcons
 import java.util.Locale
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 @AndroidEntryPoint
-class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmentCallback,
-    Slider.OnChangeListener {
+class PlaceSettingsActivity : BaseListSettingsActivity(),
+    MapFragment.MapFragmentCallback {
 
     companion object {
         const val EXTRA_PLACE = "extra_place"
         private const val MIN_RADIUS = 75
         private const val MAX_RADIUS = 1000
-        private const val STEP = 25.0
+        private const val STEP = 25
     }
-
-    private lateinit var name: TextInputEditText
-    private lateinit var nameLayout: TextInputLayout
-    private lateinit var slider: Slider
 
     @Inject lateinit var locationDao: LocationDao
     @Inject lateinit var map: MapFragment
@@ -51,6 +64,9 @@ class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmen
 
     private lateinit var place: Place
     override val defaultIcon = TasksIcons.PLACE
+
+    private val sliderPos = mutableFloatStateOf(100f)
+    private lateinit var viewHolder: ViewGroup
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (intent?.hasExtra(EXTRA_PLACE) != true) {
@@ -68,52 +84,90 @@ class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmen
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState == null) {
-            name.setText(place.displayName)
+            textState.value = place.displayName
             selectedColor = place.color
             selectedIcon.update { place.icon }
         }
 
+        sliderPos.floatValue = (place.radius / STEP * STEP).toFloat()
+
         val dark = preferences.mapTheme == 2
                 || preferences.mapTheme == 0 && tasksTheme.themeBase.isDarkTheme(this)
 
-        map.init(this, this, dark)
-
         updateTheme()
-    }
 
-    override fun bind() = ActivityLocationSettingsBinding.inflate(layoutInflater).let {
-        name = it.name.apply {
-            addTextChangedListener(
-                onTextChanged = { _, _, _, _ -> nameLayout.error = null }
-            )
-        }
-        nameLayout = it.nameLayout
-        slider = it.slider.apply {
-            setLabelFormatter { value ->
-                getString(
-                    R.string.location_radius_meters,
-                    locale.formatNumber(value.toInt())
-                )
+        setContent {
+            MdcTheme {
+                baseSettingsContent()
+                {
+                    Row(
+                        modifier = Modifier
+                            .requiredHeight(56.dp)
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    )
+                    {
+                        Text(stringResource(id = R.string.geofence_radius))
+                        Row(horizontalArrangement = Arrangement.End) {
+                            Text(
+                                getString(
+                                    R.string.location_radius_meters,
+                                    locale.formatNumber(sliderPos.floatValue.toInt())
+                                )
+                            )
+                        }
+
+                    }
+                    Slider(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = sliderPos.floatValue,
+                        valueRange = (MIN_RADIUS.toFloat()..MAX_RADIUS.toFloat()),
+                        steps = (MAX_RADIUS - MIN_RADIUS) / STEP,
+                        onValueChange = { sliderPos.floatValue = it },
+                        colors = SliderDefaults.colors(
+                            thumbColor = MaterialTheme.colors.secondary,
+                            activeTrackColor = MaterialTheme.colors.secondary,
+                            inactiveTrackColor = colorResource(id = R.color.text_tertiary),
+                            activeTickColor = MaterialTheme.colors.secondary,
+                            inactiveTickColor = colorResource(id = R.color.text_tertiary)
+                        )
+                    )
+
+                    AndroidView(
+                        factory = { ctx ->
+                            viewHolder = LinearLayout(ctx).apply {
+                                layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+                            }
+                            map.init(
+                                this@PlaceSettingsActivity,
+                                this@PlaceSettingsActivity,
+                                dark,
+                                viewHolder
+                            )
+                            viewHolder
+                        },
+                        update = { updateGeofenceCircle(sliderPos.floatValue) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .requiredHeight(300.dp)
+                            .padding(horizontal = 8.dp)
+                    )
+                }
             }
-            valueTo = MAX_RADIUS.toFloat()
-            valueFrom = MIN_RADIUS.toFloat()
-            stepSize = STEP.toFloat()
-            haloRadius = 0
-            value = (place.radius / STEP * STEP).roundToInt().toFloat()
         }
-        slider.addOnChangeListener(this)
-        it.root
     }
 
-    override fun hasChanges() = name.text.toString() != place.displayName
+    override fun hasChanges() = textState.value != place.displayName
                     || selectedColor != place.color
                     || selectedIcon.value != place.icon
 
     override suspend fun save() {
-        val newName: String = name.text.toString()
+        val newName: String = textState.value
 
         if (isNullOrEmpty(newName)) {
-            nameLayout.error = getString(R.string.name_cannot_be_empty)
+            errorState.value = getString(R.string.name_cannot_be_empty)
             return
         }
 
@@ -121,7 +175,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmen
             name = newName,
             color = selectedColor,
             icon = selectedIcon.value,
-            radius = slider.value.toInt(),
+            radius = sliderPos.floatValue.toInt(),
         )
         locationDao.update(place)
         localBroadcastManager.broadcastRefresh()
@@ -151,16 +205,13 @@ class PlaceSettingsActivity : BaseListSettingsActivity(), MapFragment.MapFragmen
         map.setMarkers(listOf(place))
         map.disableGestures()
         map.movePosition(place.mapPosition, false)
-        updateGeofenceCircle()
+        updateGeofenceCircle(sliderPos.floatValue)
     }
 
     override fun onPlaceSelected(place: Place) {}
-    override fun onValueChange(slider: Slider, value: Float, fromUser: Boolean) {
-        updateGeofenceCircle()
-    }
 
-    private fun updateGeofenceCircle() {
-        val radius = slider.value.toDouble()
+    private fun updateGeofenceCircle(radius: Float) {
+        val radius = radius.toDouble()
         val zoom = when (radius) {
             in 0f..300f -> 15f
             in 300f..500f -> 14.5f

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -118,7 +118,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                         value = sliderPos.floatValue,
                         valueRange = (MIN_RADIUS.toFloat()..MAX_RADIUS.toFloat()),
                         steps = (MAX_RADIUS - MIN_RADIUS) / STEP - 1,
-                        onValueChange = { sliderPos.floatValue = it },
+                        onValueChange = { sliderPos.floatValue = it; updateGeofenceCircle(sliderPos.floatValue) },
                         colors = SliderDefaults.colors(
                             thumbColor = MaterialTheme.colorScheme.secondary,
                             activeTrackColor = MaterialTheme.colorScheme.secondary,

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -12,10 +12,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Slider
-import androidx.compose.material.SliderDefaults
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -123,10 +123,10 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                         steps = (MAX_RADIUS - MIN_RADIUS) / STEP,
                         onValueChange = { sliderPos.floatValue = it },
                         colors = SliderDefaults.colors(
-                            thumbColor = MaterialTheme.colors.secondary,
-                            activeTrackColor = MaterialTheme.colors.secondary,
+                            thumbColor = MaterialTheme.colorScheme.secondary,
+                            activeTrackColor = MaterialTheme.colorScheme.secondary,
                             inactiveTrackColor = colorResource(id = R.color.text_tertiary),
-                            activeTickColor = MaterialTheme.colors.secondary,
+                            activeTickColor = MaterialTheme.colorScheme.secondary,
                             inactiveTickColor = colorResource(id = R.color.text_tertiary)
                         )
                     )

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -96,7 +96,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
 
         setContent {
             TasksTheme {
-                baseSettingsContent() {
+                baseSettingsContent {
                     Row(
                         modifier = Modifier
                             .requiredHeight(56.dp)
@@ -136,6 +136,7 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                         factory = { ctx ->
                             viewHolder = LinearLayout(ctx).apply {
                                 layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+                                id = R.id.map
                             }
                             map.init(
                                 this@PlaceSettingsActivity,
@@ -145,7 +146,6 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                             )
                             viewHolder
                         },
-                        update = { updateGeofenceCircle(sliderPos.floatValue) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .requiredHeight(300.dp)

--- a/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/PlaceSettingsActivity.kt
@@ -109,8 +109,8 @@ class PlaceSettingsActivity : BaseListSettingsActivity(),
                         Row(horizontalArrangement = Arrangement.End) {
                             Text(getString(
                                     R.string.location_radius_meters,
-                                    locale.formatNumber(sliderPos.floatValue.roundToInt())
-                                ))
+                                    locale.formatNumber(sliderPos.floatValue.roundToInt()
+                                )))
                         }
                     }
                     Slider(

--- a/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
@@ -20,6 +20,7 @@ import org.tasks.data.dao.TagDataDao
 import org.tasks.data.entity.TagData
 import org.tasks.filters.TagFilter
 import org.tasks.themes.TasksIcons
+import org.tasks.themes.TasksTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -47,7 +48,9 @@ class TagSettingsActivity : BaseListSettingsActivity() {
         }
 
         setContent {
-            baseSettingsContent()
+            TasksTheme {
+                baseSettingsContent()
+            }
         }
         updateTheme()
     }

--- a/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/TagSettingsActivity.kt
@@ -12,21 +12,12 @@ import androidx.activity.compose.setContent
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.update
 import org.tasks.LocalBroadcastManager
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
-import org.tasks.data.TagDao
-import org.tasks.data.TagData
-import org.tasks.data.TagDataDao
-import org.tasks.themes.CustomIcons
-import org.tasks.compose.drawer.BaseSettingsDrawer
-import org.tasks.compose.drawer.BaseSettingsDrawerParam
 import org.tasks.data.dao.TagDao
 import org.tasks.data.dao.TagDataDao
 import org.tasks.data.entity.TagData
-import org.tasks.databinding.ActivityTagSettingsBinding
-import org.tasks.extensions.Context.hideKeyboard
 import org.tasks.filters.TagFilter
 import org.tasks.themes.TasksIcons
 import javax.inject.Inject
@@ -37,7 +28,6 @@ class TagSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var tagDao: TagDao
     @Inject lateinit var localBroadcastManager: LocalBroadcastManager
 
-    private var isNewTag = false
     private lateinit var tagData: TagData
     private val isNewTag: Boolean
         get() = tagData.id == null
@@ -46,18 +36,14 @@ class TagSettingsActivity : BaseListSettingsActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         tagData = intent.getParcelableExtra(EXTRA_TAG_DATA) ?: TagData()
-        tagData = intent.getParcelableExtra(EXTRA_TAG_DATA)
-                ?: TagData().apply {
-                    isNewTag = true
-                    remoteId = UUIDHelper.newUUID()
-                }
+
         if (!isNewTag) textState.value = tagData.name!!
 
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState == null) {
             selectedColor = tagData.color ?: 0
-            selectedIcon.update { tagData.icon }
+            selectedIcon.value = tagData.icon ?: defaultIcon
         }
 
         setContent {

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -17,7 +17,7 @@ import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
 import org.tasks.compose.DeleteButton
-import org.tasks.compose.ListSettings.SettingsSnackBar
+import org.tasks.compose.ListSettings.Toaster
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount
@@ -206,7 +206,7 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
             optionButton = optionButton,
             extensionContent = extensionContent
         )
-        SettingsSnackBar(state = snackbar)
+        Toaster(state = snackbar)
     }
 
     companion object {

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -11,23 +11,17 @@ import at.bitfire.dav4jvm.exception.HttpException
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import com.todoroo.astrid.service.TaskDeleter
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
 import org.tasks.compose.DeleteButton
 import org.tasks.compose.ListSettings.ListSettingsSnackBar
-import org.tasks.data.CaldavAccount
-import org.tasks.data.CaldavCalendar
-import org.tasks.data.CaldavDao
-import org.tasks.themes.CustomIcons
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
-import org.tasks.databinding.ActivityCaldavCalendarSettingsBinding
-import org.tasks.extensions.Context.hideKeyboard
 import org.tasks.filters.CaldavFilter
 import org.tasks.themes.TasksIcons
 import org.tasks.ui.DisplayableException
@@ -58,7 +52,7 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
             if (caldavCalendar != null) {
                 textState.value = caldavCalendar!!.name ?: ""
                 selectedColor = caldavCalendar!!.color
-                selectedIcon.update { caldavCalendar?.icon }
+                selectedIcon.value = caldavCalendar?.icon ?: defaultIcon
             }
         }
         updateTheme()

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -1,18 +1,13 @@
 package org.tasks.caldav
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.view.inputmethod.InputMethodManager
-import android.widget.LinearLayout
-import android.widget.ProgressBar
-import androidx.core.widget.addTextChangedListener
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.lifecycleScope
 import at.bitfire.dav4jvm.exception.HttpException
-import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.textfield.TextInputEditText
-import com.google.android.material.textfield.TextInputLayout
 import com.todoroo.astrid.activity.MainActivity
 import com.todoroo.astrid.activity.TaskListFragment
 import com.todoroo.astrid.service.TaskDeleter
@@ -21,6 +16,12 @@ import kotlinx.coroutines.runBlocking
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
+import org.tasks.compose.DeleteButton
+import org.tasks.compose.ListSettings.ListSettingsSnackBar
+import org.tasks.data.CaldavAccount
+import org.tasks.data.CaldavCalendar
+import org.tasks.data.CaldavDao
+import org.tasks.themes.CustomIcons
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount
@@ -37,27 +38,12 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
     @Inject lateinit var caldavDao: CaldavDao
     @Inject lateinit var taskDeleter: TaskDeleter
 
-    private lateinit var root: LinearLayout
-    private lateinit var name: TextInputEditText
-    protected lateinit var nameLayout: TextInputLayout
-    protected lateinit var progressView: ProgressBar
-
     protected var caldavCalendar: CaldavCalendar? = null
 
     protected lateinit var caldavAccount: CaldavAccount
     override val defaultIcon = TasksIcons.LIST
 
-    override fun bind() = ActivityCaldavCalendarSettingsBinding.inflate(layoutInflater).let {
-        root = it.rootLayout
-        name = it.name.apply {
-            addTextChangedListener(
-                onTextChanged = { _, _, _, _ -> nameLayout.error = null }
-            )
-        }
-        nameLayout = it.nameLayout
-        progressView = it.progressBar.progressBar
-        it.root
-    }
+    protected val snackbar = SnackbarHostState() // to be used by descendants
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val intent = intent
@@ -70,15 +56,10 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
         }
         if (savedInstanceState == null) {
             if (caldavCalendar != null) {
-                name.setText(caldavCalendar!!.name)
+                textState.value = caldavCalendar!!.name ?: ""
                 selectedColor = caldavCalendar!!.color
                 selectedIcon.update { caldavCalendar?.icon }
             }
-        }
-        if (caldavCalendar == null) {
-            name.requestFocus()
-            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.showSoftInput(name, InputMethodManager.SHOW_IMPLICIT)
         }
         updateTheme()
     }
@@ -95,7 +76,7 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
         }
         val name = newName
         if (isNullOrEmpty(name)) {
-            nameLayout.error = getString(R.string.name_cannot_be_empty)
+            errorState.value = getString(R.string.name_cannot_be_empty)
             return
         }
         when {
@@ -121,17 +102,11 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
         caldavAccount: CaldavAccount, caldavCalendar: CaldavCalendar
     )
 
-    private fun showProgressIndicator() {
-        progressView.visibility = View.VISIBLE
-    }
+    private fun showProgressIndicator() { showProgress.value = true }
 
-    private fun hideProgressIndicator() {
-        progressView.visibility = View.GONE
-    }
+    private fun hideProgressIndicator() { showProgress.value = false }
 
-    protected fun requestInProgress(): Boolean {
-        return progressView.visibility == View.VISIBLE
-    }
+    protected fun requestInProgress(): Boolean = showProgress.value
 
     protected fun requestFailed(t: Throwable) {
         hideProgressIndicator()
@@ -146,17 +121,11 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
     }
 
     private fun showSnackbar(resId: Int, vararg formatArgs: Any) {
-        showSnackbar(getString(resId, *formatArgs))
+        lifecycleScope.launch { snackbar.showSnackbar( getString(resId, *formatArgs) ) }
     }
 
     private fun showSnackbar(message: String?) {
-        val snackbar = Snackbar.make(root, message!!, 8000)
-                .setTextColor(getColor(R.color.snackbar_text_color))
-                .setActionTextColor(getColor(R.color.snackbar_action_color))
-        snackbar
-                .view
-                .setBackgroundColor(getColor(R.color.snackbar_background))
-        snackbar.show()
+        lifecycleScope.launch { snackbar.showSnackbar( message!! ) }
     }
 
     protected suspend fun createSuccessful(url: String?) {
@@ -202,10 +171,10 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
     private fun iconChanged(): Boolean = selectedIcon.value != caldavCalendar!!.icon
 
     private val newName: String
-        get() = name.text.toString().trim { it <= ' ' }
+        get() = textState.value.trim { it <= ' '}
 
     override fun finish() {
-        hideKeyboard(name)
+        // hideKeyboard(name)
         super.finish()
     }
 
@@ -232,6 +201,18 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
             setResult(Activity.RESULT_OK, Intent(TaskListFragment.ACTION_DELETED))
             finish()
         }
+    }
+
+    @Composable
+    fun baseCaldavSettingsContent (
+        optionButton: @Composable () -> Unit = { if (!isNew) DeleteButton { promptDelete() } },
+        extensionContent: @Composable ColumnScope.() -> Unit = {}
+    ) {
+        baseSettingsContent (
+            optionButton = optionButton,
+            extensionContent = extensionContent
+        )
+        ListSettingsSnackBar(state = snackbar)
     }
 
     companion object {

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.lifecycleScope
 import at.bitfire.dav4jvm.exception.HttpException

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.lifecycleScope
 import at.bitfire.dav4jvm.exception.HttpException
@@ -16,8 +16,6 @@ import kotlinx.coroutines.runBlocking
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
-import org.tasks.compose.DeleteButton
-import org.tasks.compose.ListSettings.Toaster
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.runBlocking
 import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
+import org.tasks.compose.DeleteButton
+import org.tasks.compose.ListSettings.SettingsSnackBar
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -17,7 +17,7 @@ import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
 import org.tasks.compose.DeleteButton
-import org.tasks.compose.ListSettings.SettingsSnackBar
+import org.tasks.compose.ListSettings.Toaster
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount

--- a/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/BaseCaldavCalendarSettingsActivity.kt
@@ -17,7 +17,7 @@ import org.tasks.R
 import org.tasks.Strings.isNullOrEmpty
 import org.tasks.activities.BaseListSettingsActivity
 import org.tasks.compose.DeleteButton
-import org.tasks.compose.ListSettings.ListSettingsSnackBar
+import org.tasks.compose.ListSettings.SettingsSnackBar
 import org.tasks.data.UUIDHelper
 import org.tasks.data.dao.CaldavDao
 import org.tasks.data.entity.CaldavAccount
@@ -206,7 +206,7 @@ abstract class BaseCaldavCalendarSettingsActivity : BaseListSettingsActivity() {
             optionButton = optionButton,
             extensionContent = extensionContent
         )
-        ListSettingsSnackBar(state = snackbar)
+        SettingsSnackBar(state = snackbar)
     }
 
     companion object {

--- a/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
@@ -138,7 +138,7 @@ class CaldavCalendarSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                             Icon(
                                 painter = painterResource(R.drawable.ic_outline_person_add_24),
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onPrimary,
+                                tint = MaterialTheme.colorScheme.onSecondary,
                             )
                         }
                     }

--- a/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
@@ -133,7 +133,8 @@ class CaldavCalendarSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                         }
                         FloatingActionButton(
                             onClick = { openDialog.value = true },
-                            containerColor = MaterialTheme.colorScheme.primary
+                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
+                            containerColor = MaterialTheme.colorScheme.secondary
                         ) {
                             Icon(
                                 painter = painterResource(R.drawable.ic_outline_person_add_24),

--- a/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/CaldavCalendarSettingsActivity.kt
@@ -6,14 +6,12 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.Text
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
@@ -9,6 +9,7 @@ import org.tasks.compose.DeleteButton
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
 import org.tasks.data.dao.CaldavDao
+import org.tasks.themes.TasksTheme
 
 @AndroidEntryPoint
 class LocalListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
@@ -20,9 +21,11 @@ class LocalListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         val canDelete = runBlocking { caldavDao.getCalendarsByAccount(CaldavDao.LOCAL).size > 1 }
 
         setContent {
-            baseCaldavSettingsContent (
-                optionButton = { if (!isNew && canDelete) DeleteButton { promptDelete() } }
-            )
+            TasksTheme {
+                baseCaldavSettingsContent (
+                    optionButton = { if (!isNew && canDelete) DeleteButton { promptDelete() } }
+                )
+            }
         }
     }
 

--- a/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
@@ -24,8 +24,6 @@ class LocalListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                 optionButton = { if (!isNew && canDelete) DeleteButton { promptDelete() } }
             )
         }
-        toolbar.menu.findItem(R.id.delete)?.isVisible =
-                runBlocking { caldavDao.getCalendarsByAccount(CaldavDao.LOCAL).size > 1 }
     }
 
     override suspend fun createCalendar(caldavAccount: CaldavAccount, name: String, color: Int) =

--- a/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
@@ -1,9 +1,11 @@
 package org.tasks.caldav
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.runBlocking
 import org.tasks.R
+import org.tasks.compose.DeleteButton
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
 import org.tasks.data.dao.CaldavDao
@@ -11,9 +13,17 @@ import org.tasks.data.dao.CaldavDao
 @AndroidEntryPoint
 class LocalListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
 
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val canDelete = runBlocking { caldavDao.getCalendarsByAccount(CaldavDao.LOCAL).size > 1 }
+
+        setContent {
+            baseCaldavSettingsContent (
+                optionButton = { if (!isNew && canDelete) DeleteButton { promptDelete() } }
+            )
+        }
         toolbar.menu.findItem(R.id.delete)?.isVisible =
                 runBlocking { caldavDao.getCalendarsByAccount(CaldavDao.LOCAL).size > 1 }
     }

--- a/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/caldav/LocalListSettingsActivity.kt
@@ -14,7 +14,6 @@ import org.tasks.themes.TasksTheme
 @AndroidEntryPoint
 class LocalListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/tasks/compose/DragSortList.kt
+++ b/app/src/main/java/org/tasks/compose/DragSortList.kt
@@ -1,0 +1,196 @@
+package org.tasks.compose
+
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Drag - drop to reorder elements of LazyColumn
+ *
+ * Implementation is based on:
+ *      https://github.com/realityexpander/DragDropColumnCompose
+ *
+ * Scheme of use:
+ *      1. Hoist state of the LazyColumn (create your own and set it as LazyColumn parameter)
+ *      2. Create and remember DragDropState object by call to "rememberDragDropState"
+ *      3. Use Modifier.doDrag in the LazyColumn
+ *      4. enclose LazyList items into DraggableItem
+ * **/
+
+class DragDropState internal constructor(
+    val state: LazyListState,
+    private val scope: CoroutineScope,
+    private val confirmDrag: (Int) -> Boolean,
+    private val onSwap: (Int, Int) -> Unit
+) {
+    /* primary ID of the item being dragged */
+    var draggedItemIndex by mutableStateOf<Int?>(null)
+
+    private var draggedDistance by mutableFloatStateOf(0f)
+    private var draggingElementOffset: Int = 0 // cached drugged element offset and size
+    private var draggingElementSize: Int = -1  // size must not be negative when dragging is in progress
+
+    private var overscrollJob by mutableStateOf<Job?>( null )
+
+    /* sibling of draggingElementOffset, not cached, for use in animation  */
+    internal val draggingItemOffset: Float
+        get() = state.layoutInfo.visibleItemsInfo
+            .firstOrNull { it.index == draggedItemIndex }
+            ?.let { item ->
+                draggingElementOffset + draggedDistance - item.offset
+            } ?: 0f
+
+    fun itemAtOffset(offsetY: Float): LazyListItemInfo? =
+        state.layoutInfo.visibleItemsInfo.firstOrNull {
+                item -> offsetY.toInt() in item.offset..(item.offset + item.size)
+        }
+
+    fun startDragging(item: LazyListItemInfo?) {
+        //Log.d("HADY", "start dragging ${item}")
+        if (item != null && confirmDrag(item.index)) {
+            draggedItemIndex = item.index
+            draggingElementOffset = item.offset
+            draggingElementSize = item.size
+            assert(item.size >= 0) { "Invalid size of element ${item.size}" }
+        }
+    }
+
+    fun stopDragging() {
+        draggedDistance = 0f
+        draggedItemIndex = null
+        draggingElementOffset = 0
+        draggingElementSize = -1
+        overscrollJob?.cancel()
+    }
+
+    fun onDrag(offset: Offset) {
+
+        draggedDistance += offset.y
+
+        //if (draggedDistance != 0f) {
+        if (draggedItemIndex != null) {
+            assert(draggingElementSize >= 0) { "FATAL: Invalid dragging element" }
+
+            val startOffset = draggingElementOffset + draggedDistance
+            val endOffset = startOffset + draggingElementSize
+
+            val draggedIndex = draggedItemIndex
+            val dragged = draggedIndex?.let { index ->
+                state.layoutInfo.visibleItemsInfo.getOrNull(
+                    index - state.layoutInfo.visibleItemsInfo.first().index
+                )
+            }
+            if (dragged != null) {
+                val up = (startOffset - dragged.offset) > 0
+                val hovered =
+                    if (up) itemAtOffset(startOffset + 0.1f * draggingElementSize)
+                    else itemAtOffset(endOffset - 0.1f * draggingElementSize)
+
+                if (hovered != null) {
+                    scope.launch { onSwap(draggedIndex, hovered.index) }
+                    draggedItemIndex = hovered.index
+                }
+
+                if (overscrollJob?.isActive != true) {
+                    val overscroll = when {
+                        draggedDistance > 0 -> max(endOffset - state.layoutInfo.viewportEndOffset+50f, 0f)
+                        draggedDistance < 0 -> min(startOffset - state.layoutInfo.viewportStartOffset-50f, 0f)
+                        else -> 0f
+                    }
+                    if (overscroll != 0f) {
+                        overscrollJob = scope.launch {
+                            state.animateScrollBy(
+                                overscroll * 1.3f, tween(easing = FastOutLinearInEasing)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    } /* end onDrag */
+} /* end DragDropState */
+
+@Composable
+fun rememberDragDropState(
+    lazyListState: LazyListState,
+    confirmDrag: (Int) -> Boolean = { true },
+    onSwap: (Int, Int) -> Unit
+): DragDropState {
+    val scope = rememberCoroutineScope()
+    val state = remember(lazyListState) {
+        DragDropState(
+            state = lazyListState,
+            onSwap = onSwap,
+            scope = scope,
+            confirmDrag = confirmDrag
+        )
+    }
+    return state
+}
+
+fun Modifier.doDrag(dragDropState: DragDropState): Modifier =
+    this.pointerInput(dragDropState) {
+        detectDragGesturesAfterLongPress(
+            onDragStart = { offset ->
+                dragDropState.startDragging(dragDropState.itemAtOffset(offset.y))
+            },
+            onDrag = { change, offset ->
+                change.consume()
+                dragDropState.onDrag(offset)
+            },
+            onDragEnd = { dragDropState.stopDragging() },
+            onDragCancel = { dragDropState.stopDragging() }
+        )
+    }
+
+@ExperimentalFoundationApi
+@Composable
+fun LazyItemScope.DraggableItem(
+    dragDropState: DragDropState,
+    index: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable (isDragging: Boolean) -> Unit
+) {
+    val current: Float by animateFloatAsState(
+        targetValue = dragDropState.draggingItemOffset * 0.67f
+    )
+
+    val dragging = index == dragDropState.draggedItemIndex
+
+    val draggingModifier = if (dragging) {
+        Modifier
+            .zIndex(1f)
+            .graphicsLayer { translationY = current }
+    } else {
+        Modifier.animateItemPlacement(
+            tween(easing = FastOutLinearInEasing)
+        )
+    }
+    Box(modifier = modifier.then(draggingModifier)) {
+        content(dragging)
+    }
+}

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -30,7 +30,7 @@ import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
-import androidx.compose.material.OutlinedTextField
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -1,0 +1,447 @@
+package org.tasks.compose
+
+/**
+ *  Composables for FilterSettingActivity
+ **/
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.Abc
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.core.os.ConfigurationCompat
+import com.todoroo.astrid.core.CriterionInstance
+import org.tasks.R
+import org.tasks.compose.ListSettings.ListSettingRow
+import org.tasks.compose.SwipeOut.SwipeOut
+import org.tasks.extensions.formatNumber
+import java.util.Locale
+
+@Composable
+@Preview (showBackground = true)
+fun ToggleGroupPreview ()
+{
+    FilterCondition.ToggleGroup (
+        items = listOf("AND","OR","NOT")
+    )
+}
+
+object FilterCondition {
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun FilterCondition(
+        items: SnapshotStateList<CriterionInstance>,
+        onDelete: (Int) -> Unit,
+        doSwap: (Int, Int) -> Unit,
+        onClick: (String) -> Unit
+    ) {
+
+        val getIcon: (CriterionInstance) -> Int = { criterion ->
+            when (criterion.type) {
+                CriterionInstance.TYPE_ADD -> R.drawable.ic_call_split_24px
+                CriterionInstance.TYPE_SUBTRACT -> R.drawable.ic_outline_not_interested_24px
+                CriterionInstance.TYPE_INTERSECT -> R.drawable.ic_outline_add_24px
+                else -> {
+                    0
+                }  /* assert */
+            }
+        }
+        val listState = rememberLazyListState()
+        val dragDropState = rememberDragDropState(
+            lazyListState = listState,
+            confirmDrag = { index -> index != 0 }
+        ) { fromIndex, toIndex ->
+            if (fromIndex != 0 && toIndex != 0) doSwap(fromIndex, toIndex)
+        }
+
+        Row {
+            Text(
+                text = stringResource(id = R.string.custom_filter_criteria),
+                color = MaterialTheme.colors.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(Constants.KEYLINE_FIRST)
+            )
+        }
+        Row {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .doDrag(dragDropState),
+                userScrollEnabled = true,
+                state = listState
+            ) {
+                itemsIndexed(
+                    items = items,
+                    key = { _, item -> item.id }
+                ) { index, criterion ->
+                    if (index == 0) {
+                        FilterConditionRow(criterion, false, getIcon, onClick)
+                    } else {
+                        DraggableItem(
+                            dragDropState = dragDropState, index = index
+                        ) { dragging ->
+                            SwipeOut(
+                                decoration = { SwipeOutDecoration() },
+                                onSwipe = { index -> onDelete(index) },
+                                index = index
+                            ) {
+                                FilterConditionRow(criterion, dragging, getIcon, onClick)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } /* FilterCondition */
+
+    @Composable
+    private fun FilterConditionRow(
+        criterion: CriterionInstance,
+        dragging: Boolean,
+        getIcon: (CriterionInstance) -> Int,
+        onClick: (String) -> Unit
+    ) {
+        Divider(
+            color = when (criterion.type) {
+                CriterionInstance.TYPE_ADD -> Color.Gray
+                else -> Color.Transparent
+            }
+        )
+        val modifier =
+            if (dragging) Modifier.background(Color.LightGray)
+            else Modifier
+        ListSettingRow(
+            modifier = modifier.clickable { onClick(criterion.id) },
+            left = {
+                Box(
+                    modifier = Modifier.size(56.dp),
+                    contentAlignment = Alignment.Center
+                )
+                {
+                    if (criterion.type != CriterionInstance.TYPE_UNIVERSE) {
+                        Icon(
+                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
+                            painter = painterResource(id = getIcon(criterion)),
+                            contentDescription = null
+                        )
+                    }
+                }
+            },
+            center = {
+                Text(
+                    text = criterion.titleFromCriterion,
+                    fontSize = 18.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(0.8f)
+                        .padding(start = 16.dp, top = 16.dp, bottom = 16.dp)
+                )
+            },
+            right = {
+                val context = LocalContext.current
+                val locale = remember {
+                    ConfigurationCompat
+                        .getLocales(context.resources.configuration)
+                        .get(0)
+                        ?: Locale.getDefault()
+                }
+                Text(
+                    text = locale.formatNumber(criterion.max),
+                    modifier = Modifier.padding(end = Constants.KEYLINE_FIRST),
+                    color = Color.Gray,
+                    fontSize = 14.sp,
+                    textAlign = TextAlign.End
+                )
+            }
+        )
+    }
+
+    @Composable
+    private fun SwipeOutDecoration() {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.secondary)
+        ) {
+
+            @Composable
+            fun deleteIcon() {
+                Icon(
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = "Delete",
+                    tint = Color.White
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .height(56.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Bottom
+            ) {
+                deleteIcon()
+                deleteIcon()
+            }
+        }
+    } /* end SwipeOutDecoration */
+
+    @Composable
+    fun NewCriterionFAB(
+        isExtended: MutableState<Boolean>,
+        onClick: () -> Unit
+    ) {
+
+        Box( // lays out over main content as a space to layout FAB
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.BottomEnd
+        ) {
+            FloatingActionButton(
+                onClick = onClick,
+                modifier = Modifier.padding(16.dp),
+                shape = RoundedCornerShape(50),
+                backgroundColor = MaterialTheme.colors.secondary,
+                contentColor = Color.White,
+            ) {
+                val extended = isExtended.value
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Filled.Add,
+                        contentDescription = "New Criteria",
+                        modifier = Modifier.padding(
+                            start = if (extended) 16.dp else 0.dp
+                        )
+                    )
+                    if (extended)
+                        Text(
+                            text = LocalContext.current.getString(R.string.CFA_button_add),
+                            modifier = Modifier.padding(end = 16.dp)
+                        )
+                }
+            } /* end FloatingActionButton */
+        }
+    } /* end NewCriterionFAB */
+
+    @Composable
+    fun SelectCriterionType(
+        title: String,
+        selected: Int,
+        types: List<String>,
+        onCancel: () -> Unit,
+        help: () -> Unit = {},
+        onSelected: (Int) -> Unit
+    ) {
+        val selected = remember { mutableIntStateOf(selected) }
+
+        Dialog(onDismissRequest = onCancel)
+        {
+            Card(
+                backgroundColor = MaterialTheme.colors.background
+            ) {
+                Column(modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)) {
+                    Text(
+                        text = title,
+                        color = MaterialTheme.colors.onSurface,
+                        style = MaterialTheme.typography.h6,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .padding(top = 16.dp)
+                    )
+                    ToggleGroup(items = types, selected = selected)
+                    Row(
+                        modifier = Modifier.height(48.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(contentAlignment = Alignment.CenterStart) {
+                            Constants.TextButton(text = R.string.help, onClick = help)
+                        }
+                        Box(
+                            contentAlignment = Alignment.CenterEnd,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row {
+                                Constants.TextButton(text = R.string.cancel, onClick = onCancel)
+                                Constants.TextButton(text = R.string.ok) { onSelected(selected.intValue) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } /* end SelectCriterionType */
+
+    @Composable
+    fun ToggleGroup(
+        items: List<String>,
+        selected: MutableIntState = remember { mutableIntStateOf(0) }
+    ) {
+        assert(selected.intValue in items.indices)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Row {
+                for (index in items.indices) {
+                    val highlight = (index == selected.intValue)
+                    val color =
+                        if (highlight) MaterialTheme.colors.secondary.copy(alpha = 0.5f)
+                        else MaterialTheme.colors.onBackground.copy(alpha = 0.5f)
+                    OutlinedButton(
+                        onClick = { selected.intValue = index },
+                        border = BorderStroke(1.dp, SolidColor(color.copy(alpha = 0.5f))),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            backgroundColor = color.copy(alpha = 0.2f),
+                            contentColor = MaterialTheme.colors.onBackground),
+                        shape = RoundedCornerShape(Constants.HALF_KEYLINE)
+                    ) {
+                        Text(items[index])
+                    }
+                    if (index<items.size-1) Spacer(modifier = Modifier.size(2.dp))
+                }
+            }
+        }
+    } /* end ToggleGroup */
+
+
+    @Composable
+    fun SelectFromList(
+        names: List<String>,
+        title: String? = null,
+        onCancel: () -> Unit,
+        onSelected: (Int) -> Unit
+    ) {
+        Dialog(onDismissRequest = onCancel) {
+            Card(backgroundColor = MaterialTheme.colors.background) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = Constants.KEYLINE_FIRST)
+                        .padding(bottom = Constants.KEYLINE_FIRST)
+                ) {
+                    title?.let { title ->
+                        Text(
+                            text = title,
+                            color = MaterialTheme.colors.onSurface,
+                            style = MaterialTheme.typography.h6,
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp)
+                                .padding(top = Constants.KEYLINE_FIRST)
+                        )
+                    }
+                    names.forEachIndexed { index, name ->
+                        Text(
+                            text = name,
+                            color = MaterialTheme.colors.onSurface,
+                            style = MaterialTheme.typography.body1,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp)
+                                .padding(top = Constants.KEYLINE_FIRST)
+                                .clickable { onSelected(index) }
+                        )
+                    }
+                }
+            }
+        }
+    } /* end SelectFromList */
+
+
+    @Composable
+    fun InputTextOption(
+        title: String,
+        onCancel: () -> Unit,
+        onDone: (String) -> Unit
+    ) {
+        val text = remember { mutableStateOf("") }
+        AlertDialog(
+            onDismissRequest = onCancel,
+            confirmButton = {
+                Constants.TextButton(
+                    text = R.string.ok,
+                    onClick = { onDone(text.value) })
+            },
+            dismissButton = { Constants.TextButton(text = R.string.cancel, onClick = onCancel) },
+            text = {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        title,
+                        style = MaterialTheme.typography.h6,
+                    )
+                    Spacer(Modifier.height(Constants.KEYLINE_FIRST))
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = text.value,
+                        label = { Text(title) },
+                        onValueChange = { text.value = it },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Abc,
+                                contentDescription = null
+                            )
+                        },
+                        textStyle = MaterialTheme.typography.body1,
+                        colors = Constants.textFieldColors(),
+                    )
+                }
+
+            }
+        )
+    } /* end InputTextOption */
+}

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -116,52 +116,6 @@ private fun FabPreview () {
     }
 }
 
-private fun CriterionTypeSelectPreview () {
-    TasksTheme {
-        FilterCondition.SelectCriterionType(
-            title = "Select criterion type",
-            selected = 1,
-            types = listOf("AND", "OR", "NOT"),
-            onCancel = { /*TODO*/ }) {
-        }
-    }
-}
-
-@Composable
-@Preview (showBackground = true)
-private fun InputTextPreview () {
-    TasksTheme {
-        FilterCondition.InputTextOption(title = "Task name contains...", onCancel = { /*TODO*/ }
-        ) {
-
-        }
-    }
-}
-
-@Composable
-@Preview (showBackground = true)
-private fun SwipeOutDecorationPreview () {
-    TasksTheme {
-        Box(modifier = Modifier
-            .height(56.dp)
-            .fillMaxWidth()) {
-            FilterCondition.SwipeOutDecoration()
-        }
-    }
-}
-
-@Composable
-@Preview (showBackground = true)
-private fun FabPreview () {
-    TasksTheme {
-        FilterCondition.NewCriterionFAB(
-            isExtended = remember { mutableStateOf(true) }
-        ) {
-
-        }
-    }
-}
-
 object FilterCondition {
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
@@ -284,7 +238,7 @@ object FilterCondition {
                         ?: Locale.getDefault()
                 }
                 Text(
-                    text = locale.formatNumber(criterion.end),
+                    text = locale.formatNumber(criterion.max),
                     modifier = Modifier.padding(end = Constants.KEYLINE_FIRST),
                     color = Color.Gray,
                     fontSize = 14.sp,

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -163,7 +163,7 @@ object FilterCondition {
             ) {
                 itemsIndexed(
                     items = items,
-                    key = { _, item -> item.id }
+                    key = { _, item -> item.id + item.type }
                 ) { index, criterion ->
                     if (index == 0) {
                         FilterConditionRow(criterion, false, getIcon, onClick)

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -61,7 +62,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.core.os.ConfigurationCompat
 import com.todoroo.astrid.core.CriterionInstance
 import org.tasks.R
-import org.tasks.compose.ListSettings.ListSettingRow
+import org.tasks.compose.ListSettings.SettingRow
 import org.tasks.compose.SwipeOut.SwipeOut
 import org.tasks.extensions.formatNumber
 import org.tasks.themes.TasksTheme
@@ -200,7 +201,7 @@ object FilterCondition {
         val modifier =
             if (dragging) Modifier.background(Color.LightGray)
             else Modifier
-        ListSettingRow(
+        SettingRow(
             modifier = modifier.clickable { onClick(criterion.id) },
             left = {
                 Box(
@@ -250,7 +251,8 @@ object FilterCondition {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.secondary)
+                .background(colorResource(id = org.tasks.kmp.R.color.red_a400))
+                //.background(MaterialTheme.colorScheme.secondary)
         ) {
 
             @Composable

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -69,11 +69,50 @@ import java.util.Locale
 
 @Composable
 @Preview (showBackground = true)
-fun ToggleGroupPreview ()
-{
-    FilterCondition.ToggleGroup (
-        items = listOf("AND","OR","NOT")
-    )
+private fun CriterionTypeSelectPreview () {
+    TasksTheme {
+        FilterCondition.SelectCriterionType(
+            title = "Select criterion type",
+            selected = 1,
+            types = listOf("AND", "OR", "NOT"),
+            onCancel = { /*TODO*/ }) {
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun InputTextPreview () {
+    TasksTheme {
+        FilterCondition.InputTextOption(title = "Task name contains...", onCancel = { /*TODO*/ }
+        ) {
+
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun SwipeOutDecorationPreview () {
+    TasksTheme {
+        Box(modifier = Modifier
+            .height(56.dp)
+            .fillMaxWidth()) {
+            FilterCondition.SwipeOutDecoration()
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun FabPreview () {
+    TasksTheme {
+        FilterCondition.NewCriterionFAB(
+            isExtended = remember { mutableStateOf(true) }
+        ) {
+
+        }
+    }
 }
 
 private fun CriterionTypeSelectPreview () {
@@ -259,7 +298,7 @@ object FilterCondition {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colors.secondary)
+                .background(MaterialTheme.colorScheme.secondary)
         ) {
 
             @Composable

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -70,6 +69,13 @@ import java.util.Locale
 
 @Composable
 @Preview (showBackground = true)
+fun ToggleGroupPreview ()
+{
+    FilterCondition.ToggleGroup (
+        items = listOf("AND","OR","NOT")
+    )
+}
+
 private fun CriterionTypeSelectPreview () {
     TasksTheme {
         FilterCondition.SelectCriterionType(
@@ -239,6 +245,7 @@ object FilterCondition {
                 }
                 Text(
                     text = locale.formatNumber(criterion.end),
+                    text = locale.formatNumber(criterion.max),
                     modifier = Modifier.padding(end = Constants.KEYLINE_FIRST),
                     color = Color.Gray,
                     fontSize = 14.sp,
@@ -253,8 +260,7 @@ object FilterCondition {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colorResource(id = org.tasks.kmp.R.color.red_a400))
-                //.background(MaterialTheme.colorScheme.secondary)
+                .background(MaterialTheme.colors.secondary)
         ) {
 
             @Composable

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -223,9 +223,7 @@ object FilterCondition {
                     fontSize = 18.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .weight(0.8f)
-                        .padding(start = 16.dp, top = 16.dp, bottom = 16.dp)
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp)
                 )
             },
             right = {

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -163,7 +163,7 @@ object FilterCondition {
             ) {
                 itemsIndexed(
                     items = items,
-                    key = { _, item -> item.id + item.type }
+                    key = { _, item -> item.id + " " + item.type + " " + item.end}
                 ) { index, criterion ->
                     if (index == 0) {
                         FilterConditionRow(criterion, false, getIcon, onClick)
@@ -236,7 +236,7 @@ object FilterCondition {
                         ?: Locale.getDefault()
                 }
                 Text(
-                    text = locale.formatNumber(criterion.max),
+                    text = locale.formatNumber(criterion.end),
                     modifier = Modifier.padding(end = Constants.KEYLINE_FIRST),
                     color = Color.Gray,
                     fontSize = 14.sp,

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -123,6 +123,7 @@ object FilterCondition {
         items: SnapshotStateList<CriterionInstance>,
         onDelete: (Int) -> Unit,
         doSwap: (Int, Int) -> Unit,
+        onComplete: () -> Unit,
         onClick: (String) -> Unit
     ) {
 
@@ -139,7 +140,8 @@ object FilterCondition {
         val listState = rememberLazyListState()
         val dragDropState = rememberDragDropState(
             lazyListState = listState,
-            confirmDrag = { index -> index != 0 }
+            confirmDrag = { index -> index != 0 },
+            completeDragDrop = onComplete,
         ) { fromIndex, toIndex ->
             if (fromIndex != 0 && toIndex != 0) doSwap(fromIndex, toIndex)
         }

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -245,7 +245,6 @@ object FilterCondition {
                 }
                 Text(
                     text = locale.formatNumber(criterion.end),
-                    text = locale.formatNumber(criterion.max),
                     modifier = Modifier.padding(end = Constants.KEYLINE_FIRST),
                     color = Color.Gray,
                     fontSize = 14.sp,

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -22,20 +22,21 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Card
-import androidx.compose.material.Divider
-import androidx.compose.material.FloatingActionButton
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.Abc
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
@@ -63,15 +64,55 @@ import org.tasks.R
 import org.tasks.compose.ListSettings.ListSettingRow
 import org.tasks.compose.SwipeOut.SwipeOut
 import org.tasks.extensions.formatNumber
+import org.tasks.themes.TasksTheme
 import java.util.Locale
 
 @Composable
 @Preview (showBackground = true)
-fun ToggleGroupPreview ()
-{
-    FilterCondition.ToggleGroup (
-        items = listOf("AND","OR","NOT")
-    )
+private fun CriterionTypeSelectPreview () {
+    TasksTheme {
+        FilterCondition.SelectCriterionType(
+            title = "Select criterion type",
+            selected = 1,
+            types = listOf("AND", "OR", "NOT"),
+            onCancel = { /*TODO*/ }) {
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun InputTextPreview () {
+    TasksTheme {
+        FilterCondition.InputTextOption(title = "Task name contains...", onCancel = { /*TODO*/ }
+        ) {
+
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun SwipeOutDecorationPreview () {
+    TasksTheme {
+        Box(modifier = Modifier
+            .height(56.dp)
+            .fillMaxWidth()) {
+            FilterCondition.SwipeOutDecoration()
+        }
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun FabPreview () {
+    TasksTheme {
+        FilterCondition.NewCriterionFAB(
+            isExtended = remember { mutableStateOf(true) }
+        ) {
+
+        }
+    }
 }
 
 object FilterCondition {
@@ -105,7 +146,7 @@ object FilterCondition {
         Row {
             Text(
                 text = stringResource(id = R.string.custom_filter_criteria),
-                color = MaterialTheme.colors.secondary,
+                color = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(Constants.KEYLINE_FIRST)
@@ -150,7 +191,7 @@ object FilterCondition {
         getIcon: (CriterionInstance) -> Int,
         onClick: (String) -> Unit
     ) {
-        Divider(
+        HorizontalDivider(
             color = when (criterion.type) {
                 CriterionInstance.TYPE_ADD -> Color.Gray
                 else -> Color.Transparent
@@ -207,20 +248,20 @@ object FilterCondition {
     }
 
     @Composable
-    private fun SwipeOutDecoration() {
+    fun SwipeOutDecoration() {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colors.secondary)
+                .background(MaterialTheme.colorScheme.secondary)
         ) {
 
             @Composable
             fun deleteIcon() {
                 Icon(
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-                    imageVector = Icons.Filled.Delete,
+                    modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST),
+                    imageVector = Icons.Outlined.Delete,
                     contentDescription = "Delete",
-                    tint = Color.White
+                    tint = Color.White.copy(alpha = 0.6f)
                 )
             }
 
@@ -229,7 +270,7 @@ object FilterCondition {
                     .fillMaxSize()
                     .height(56.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Bottom
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 deleteIcon()
                 deleteIcon()
@@ -251,14 +292,14 @@ object FilterCondition {
                 onClick = onClick,
                 modifier = Modifier.padding(16.dp),
                 shape = RoundedCornerShape(50),
-                backgroundColor = MaterialTheme.colors.secondary,
+                containerColor = MaterialTheme.colorScheme.secondary,
                 contentColor = Color.White,
             ) {
                 val extended = isExtended.value
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                        imageVector = Icons.Filled.Add,
+                        imageVector = Icons.Outlined.Add,
                         contentDescription = "New Criteria",
                         modifier = Modifier.padding(
                             start = if (extended) 16.dp else 0.dp
@@ -288,18 +329,22 @@ object FilterCondition {
         Dialog(onDismissRequest = onCancel)
         {
             Card(
-                backgroundColor = MaterialTheme.colors.background
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
             ) {
-                Column(modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)) {
+                Column(modifier = Modifier
+                    .padding(horizontal = Constants.KEYLINE_FIRST)
+                    .padding(top = Constants.HALF_KEYLINE)
+                ) {
                     Text(
                         text = title,
-                        color = MaterialTheme.colors.onSurface,
-                        style = MaterialTheme.typography.h6,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.headlineSmall,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(48.dp)
                             .padding(top = 16.dp)
                     )
+                    Spacer(modifier = Modifier.height(Constants.HALF_KEYLINE))
                     ToggleGroup(items = types, selected = selected)
                     Row(
                         modifier = Modifier.height(48.dp),
@@ -340,14 +385,14 @@ object FilterCondition {
                 for (index in items.indices) {
                     val highlight = (index == selected.intValue)
                     val color =
-                        if (highlight) MaterialTheme.colors.secondary.copy(alpha = 0.5f)
-                        else MaterialTheme.colors.onBackground.copy(alpha = 0.5f)
+                        if (highlight) MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f)
+                        else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
                     OutlinedButton(
                         onClick = { selected.intValue = index },
                         border = BorderStroke(1.dp, SolidColor(color.copy(alpha = 0.5f))),
                         colors = ButtonDefaults.outlinedButtonColors(
-                            backgroundColor = color.copy(alpha = 0.2f),
-                            contentColor = MaterialTheme.colors.onBackground),
+                            containerColor = color.copy(alpha = 0.2f),
+                            contentColor = MaterialTheme.colorScheme.onBackground),
                         shape = RoundedCornerShape(Constants.HALF_KEYLINE)
                     ) {
                         Text(items[index])
@@ -367,7 +412,9 @@ object FilterCondition {
         onSelected: (Int) -> Unit
     ) {
         Dialog(onDismissRequest = onCancel) {
-            Card(backgroundColor = MaterialTheme.colors.background) {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+            ) {
                 Column(
                     modifier = Modifier
                         .padding(horizontal = Constants.KEYLINE_FIRST)
@@ -376,8 +423,8 @@ object FilterCondition {
                     title?.let { title ->
                         Text(
                             text = title,
-                            color = MaterialTheme.colors.onSurface,
-                            style = MaterialTheme.typography.h6,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Medium,
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -388,8 +435,8 @@ object FilterCondition {
                     names.forEachIndexed { index, name ->
                         Text(
                             text = name,
-                            color = MaterialTheme.colors.onSurface,
-                            style = MaterialTheme.typography.body1,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.bodyMedium,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(48.dp)
@@ -422,7 +469,7 @@ object FilterCondition {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Text(
                         title,
-                        style = MaterialTheme.typography.h6,
+                        style = MaterialTheme.typography.headlineSmall,
                     )
                     Spacer(Modifier.height(Constants.KEYLINE_FIRST))
                     OutlinedTextField(
@@ -436,7 +483,7 @@ object FilterCondition {
                                 contentDescription = null
                             )
                         },
-                        textStyle = MaterialTheme.typography.body1,
+                        textStyle = MaterialTheme.typography.bodyMedium,
                         colors = Constants.textFieldColors(),
                     )
                 }

--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -298,7 +299,8 @@ object FilterCondition {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.secondary)
+                .background(colorResource(id = org.tasks.kmp.R.color.red_a400))
+                //.background(MaterialTheme.colorScheme.secondary)
         ) {
 
             @Composable

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -150,7 +150,9 @@ object ListSettings {
 
     @Composable
     fun ProgressBar(showProgress: State<Boolean>) {
-        Box(modifier = Modifier.fillMaxWidth().requiredHeight(3.dp))
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .requiredHeight(3.dp))
         {
             if (showProgress.value) {
                 LinearProgressIndicator(
@@ -237,7 +239,6 @@ object ListSettings {
                 IconButton(onClick = { selectColor() }) {
                     if (color.value == Color.Unspecified) {
                         Icon(
-                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
                             imageVector = ImageVector.vectorResource(R.drawable.ic_outline_not_interested_24px),
                             tint = colorResource(R.color.icon_tint_with_alpha),
                             contentDescription = null
@@ -307,7 +308,7 @@ object ListSettings {
             Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
                 left()
             }
-            Box (
+            Box(
                 modifier = Modifier
                     .height(56.dp)
                     .weight(1f), contentAlignment = Alignment.CenterStart

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -1,12 +1,14 @@
 package org.tasks.compose
 
+/**
+ * Composables for BaseListSettingActivity
+*/
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -231,7 +233,7 @@ object ListSettings {
 
     @Composable
     fun SelectColorRow(color: State<Color>, selectColor: () -> Unit, clearColor: () -> Unit) =
-        ListSettingRow(
+        SettingRow(
             modifier = Modifier.clickable(onClick =  selectColor),
             left = {
                 IconButton(onClick = { selectColor() }) {
@@ -276,7 +278,7 @@ object ListSettings {
 
     @Composable
     fun SelectIconRow(icon: State<String>, selectIcon: () -> Unit) =
-        ListSettingRow(
+        SettingRow(
             modifier = Modifier.clickable(onClick =  selectIcon),
             left = {
                 IconButton(onClick = selectIcon) {
@@ -296,7 +298,7 @@ object ListSettings {
 
 
     @Composable
-    fun ListSettingRow(
+    fun SettingRow(
         left: @Composable () -> Unit,
         center: @Composable () -> Unit,
         right: @Composable (() -> Unit)? = null,
@@ -306,9 +308,11 @@ object ListSettings {
             Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
                 left()
             }
-            Box (modifier = Modifier
+            Box (
+                modifier = Modifier
                 .height(56.dp)
-                .weight(1f), contentAlignment = Alignment.CenterStart) {
+                .weight(1f), contentAlignment = Alignment.CenterStart
+            ) {
                 center()
             }
             right?.let {
@@ -320,7 +324,7 @@ object ListSettings {
     }
 
     @Composable
-    fun ListSettingsSurface(content: @Composable ColumnScope.() -> Unit) {
+    fun SettingsSurface(content: @Composable ColumnScope.() -> Unit) {
         ProvideTextStyle(LocalTextStyle.current.copy(fontSize = 18.sp)) {
             Surface(
                 color = colorResource(id = R.color.window_background),
@@ -332,7 +336,7 @@ object ListSettings {
     }
 
     @Composable
-    fun SettingsSnackBar(state: SnackbarHostState) {
+    fun Toaster(state: SnackbarHostState) {
         SnackbarHost(state) { data ->
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -361,8 +365,8 @@ object ListSettings {
             AlertDialog(
                 onDismissRequest = onCancel,
                 title = { Text(title, style = MaterialTheme.typography.headlineSmall) },
-                confirmButton = { Constants.TextButton(R.string.ok, onClick = onAction) },
-                dismissButton = { Constants.TextButton(text = R.string.cancel, onCancel) }
+                confirmButton = { Constants.TextButton(text = R.string.ok, onClick = onAction) },
+                dismissButton = { Constants.TextButton(text = R.string.cancel, onClick = onCancel) }
             )
         }
     }

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -14,20 +14,20 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Snackbar
-import androidx.compose.material.SnackbarHost
-import androidx.compose.material.SnackbarHostState
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -50,11 +50,35 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import org.tasks.R
 import org.tasks.compose.components.TasksIcon
+import org.tasks.themes.TasksTheme
+
+@Composable
+@Preview (showBackground = true)
+private fun TitleBarPreview() {
+    TasksTheme {
+        ListSettings.ListSettingsToolbar(
+            title = "Tollbar title",
+            save = { /*TODO*/ }, optionButton = { DeleteButton {} }
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun PromptActionPreview() {
+    TasksTheme {
+        ListSettings.PromptAction(
+            showDialog = remember { mutableStateOf(true) },
+            title = "Delete list?",
+            onAction = { /*TODO*/ })
+    }
+}
 
 object ListSettings {
     @Composable
@@ -110,8 +134,8 @@ object ListSettings {
 */
 
         Surface(
-            elevation = 4.dp,
-            color = colorResource(id = org.tasks.R.color.content_background),
+            shadowElevation = 4.dp,
+            color = colorResource(id = R.color.content_background),
             contentColor = colorResource(id = R.color.text_primary),
             modifier = Modifier.requiredHeight(56.dp)
         )
@@ -119,11 +143,10 @@ object ListSettings {
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = save) {
+                IconButton(onClick = save, modifier = Modifier.size(56.dp)) {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_outline_save_24px),
                         contentDescription = stringResource(id = R.string.save),
-                        modifier = Modifier.padding(Constants.KEYLINE_FIRST)
                     )
                 }
                 Text(
@@ -149,7 +172,7 @@ object ListSettings {
             if (showProgress.value) {
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxSize(),
-                    backgroundColor = LocalContentColor.current.copy(alpha = 0.3f),  //Color.LightGray,
+                    trackColor = LocalContentColor.current.copy(alpha = 0.3f),  //Color.LightGray,
                     color = colorResource(org.tasks.kmp.R.color.red_a400)
                 )
             }
@@ -163,7 +186,7 @@ object ListSettings {
         requestKeyboard: Boolean,
         modifier: Modifier = Modifier,
         label: String = stringResource(R.string.display_name),
-        errorState: Color = MaterialTheme.colors.secondary,
+        errorState: Color = MaterialTheme.colorScheme.secondary,
         activeState: Color = LocalContentColor.current.copy(alpha = 0.75f),
         inactiveState: Color = LocalContentColor.current.copy(alpha = 0.5f),
     ) {
@@ -206,7 +229,7 @@ object ListSettings {
                         .focusRequester(requester)
                         .onFocusChanged { focused.value = (it.isFocused) }
                 )
-                Divider(
+                HorizontalDivider(
                     color = labelColor,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
@@ -337,7 +360,7 @@ object ListSettings {
 
     @Composable
     fun ListSettingsSnackBar(state: SnackbarHostState) {
-        SnackbarHost(state) {
+        SnackbarHost(state) { data ->
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
@@ -345,11 +368,11 @@ object ListSettings {
                 Snackbar(
                     modifier = Modifier.padding(horizontal = 24.dp),
                     shape = RoundedCornerShape(10.dp),
-                    backgroundColor = colorResource(id = R.color.snackbar_background),
+                    containerColor = colorResource(id = R.color.snackbar_background),
                     contentColor = colorResource(id = R.color.snackbar_text_color),
-                    elevation = 8.dp
+                    //shadowElevation = 8.dp
                 ) {
-                    Text(text = it.message, fontSize = 18.sp)
+                    Text(text = data.visuals.message, fontSize = 18.sp)
                 }
             }
         }
@@ -365,7 +388,7 @@ object ListSettings {
         if (showDialog.value) {
             AlertDialog(
                 onDismissRequest = onCancel,
-                title = { Text(title, style = MaterialTheme.typography.h6) },
+                title = { Text(title, style = MaterialTheme.typography.headlineSmall) },
                 confirmButton = { Constants.TextButton(R.string.ok, onClick = onAction) },
                 dismissButton = { Constants.TextButton(text = R.string.cancel, onCancel) }
             )

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -149,9 +149,7 @@ object ListSettings {
 
     @Composable
     fun ProgressBar(showProgress: State<Boolean>) {
-        Box(modifier = Modifier
-            .fillMaxWidth()
-            .requiredHeight(3.dp))
+        Box(modifier = Modifier.fillMaxWidth().requiredHeight(3.dp))
         {
             if (showProgress.value) {
                 LinearProgressIndicator(

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -171,7 +170,7 @@ object ListSettings {
         requestKeyboard: Boolean,
         modifier: Modifier = Modifier,
         label: String = stringResource(R.string.display_name),
-        errorState: Color = MaterialTheme.colors.secondary,
+        errorState: Color = MaterialTheme.colorScheme.secondary,
         activeState: Color = LocalContentColor.current.copy(alpha = 0.75f),
         inactiveState: Color = LocalContentColor.current.copy(alpha = 0.3f),
     ) {

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -62,7 +62,7 @@ import org.tasks.themes.TasksTheme
 @Preview (showBackground = true)
 private fun TitleBarPreview() {
     TasksTheme {
-        ListSettings.ListSettingsToolbar(
+        ListSettings.Toolbar(
             title = "Tollbar title",
             save = { /*TODO*/ }, optionButton = { DeleteButton {} }
         )
@@ -100,15 +100,15 @@ object ListSettings {
     ) {
         ListSettingsSurface {
 
-            ListSettingsToolbar(
+            Toolbar(
                 title = title,
                 save = save,
                 optionButton = optionButton
             )
 
-            ListSettingsProgressBar(showProgress)
+            ProgressBar(showProgress)
 
-            ListSettingsTitleInput(
+            TitleInput(
                 text = text, error = error, requestKeyboard = requestKeyboard,
                 modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
             )
@@ -122,13 +122,13 @@ object ListSettings {
     }
 
     @Composable
-    fun ListSettingsToolbar(
+    fun Toolbar(
         title: String,
         save: () -> Unit,
         optionButton: @Composable () -> Unit,
     ) {
 
-        /*
+/*  Hady: reminder for the future
     val activity = LocalView.current.context as Activity
     activity.window.statusBarColor = colorResource(id = R.color.drawer_color_selected).toArgb()
 */
@@ -163,7 +163,7 @@ object ListSettings {
     } /* ListSettingsToolBar */
 
     @Composable
-    fun ListSettingsProgressBar(showProgress: State<Boolean>) {
+    fun ProgressBar(showProgress: State<Boolean>) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -180,7 +180,7 @@ object ListSettings {
     }
 
     @Composable
-    fun ListSettingsTitleInput(
+    fun TitleInput(
         text: MutableState<String>,
         error: MutableState<String>,
         requestKeyboard: Boolean,
@@ -359,7 +359,7 @@ object ListSettings {
     }
 
     @Composable
-    fun ListSettingsSnackBar(state: SnackbarHostState) {
+    fun SettingsSnackBar(state: SnackbarHostState) {
         SnackbarHost(state) { data ->
             Box(
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -89,7 +89,7 @@ private fun PromptActionPreview() {
 private fun IconSelectPreview () {
     TasksTheme {
         ListSettings.SelectIconRow(
-            icon = remember { mutableStateOf(TasksIcons.FILTER_LIST) },
+            icon = TasksIcons.FILTER_LIST,
             selectIcon = {}
         )
     }
@@ -277,13 +277,13 @@ object ListSettings {
         )
 
     @Composable
-    fun SelectIconRow(icon: State<String>, selectIcon: () -> Unit) =
+    fun SelectIconRow(icon: String, selectIcon: () -> Unit) =
         SettingRow(
             modifier = Modifier.clickable(onClick =  selectIcon),
             left = {
                 IconButton(onClick = selectIcon) {
                     TasksIcon(
-                        label = icon.value,
+                        label = icon,
                         tint = colorResource(R.color.icon_tint_with_alpha)
                     )
                 }

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import org.tasks.R
+import org.tasks.compose.components.TasksIcon
 
 object ListSettings {
     @Composable
@@ -63,7 +64,7 @@ object ListSettings {
         text: MutableState<String>,
         error: MutableState<String>,
         color: State<Color>,
-        icon: State<Int>,
+        icon: State<String>,
         save: () -> Unit = {},
         selectIcon: () -> Unit = {},
         clearColor: () -> Unit = {},
@@ -110,7 +111,7 @@ object ListSettings {
 
         Surface(
             elevation = 4.dp,
-            color = colorResource(id = R.color.content_background),
+            color = colorResource(id = org.tasks.R.color.content_background),
             contentColor = colorResource(id = R.color.text_primary),
             modifier = Modifier.requiredHeight(56.dp)
         )
@@ -149,7 +150,7 @@ object ListSettings {
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxSize(),
                     backgroundColor = LocalContentColor.current.copy(alpha = 0.3f),  //Color.LightGray,
-                    color = colorResource(R.color.red_a400)
+                    color = colorResource(org.tasks.kmp.R.color.red_a400)
                 )
             }
         }
@@ -279,15 +280,14 @@ object ListSettings {
         )
 
     @Composable
-    fun SelectIconRow(icon: State<Int>, selectIcon: () -> Unit) =
+    fun SelectIconRow(icon: State<String>, selectIcon: () -> Unit) =
         ListSettingRow(
             modifier = Modifier.clickable(onClick =  selectIcon),
             left = {
                 IconButton(onClick = selectIcon) {
-                    Icon(
+                    TasksIcon(
+                        label = icon.value,
                         modifier = Modifier.padding(Constants.KEYLINE_FIRST),
-                        imageVector = ImageVector.vectorResource(icon.value),
-                        contentDescription = null,
                         tint = colorResource(R.color.icon_tint_with_alpha)
                     )
                 }

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -1,0 +1,375 @@
+package org.tasks.compose
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import org.tasks.R
+
+object ListSettings {
+    @Composable
+    fun ListSettings(
+        title: String,
+        requestKeyboard: Boolean,
+        text: MutableState<String>,
+        error: MutableState<String>,
+        color: State<Color>,
+        icon: State<Int>,
+        save: () -> Unit = {},
+        selectIcon: () -> Unit = {},
+        clearColor: () -> Unit = {},
+        selectColor: () -> Unit = {},
+        optionButton: @Composable () -> Unit,
+        /** right button on toolbar, mostly, DeleteButton */
+        showProgress: State<Boolean> = remember { mutableStateOf(false) },
+        extensionContent: @Composable ColumnScope.() -> Unit = {}
+    ) {
+        ListSettingsSurface {
+
+            ListSettingsToolbar(
+                title = title,
+                save = save,
+                optionButton = optionButton
+            )
+
+            ListSettingsProgressBar(showProgress)
+
+            ListSettingsTitleInput(
+                text = text, error = error, requestKeyboard = requestKeyboard,
+                modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
+            )
+
+            Column(modifier = Modifier.fillMaxWidth()) {
+                SelectColorRow(color = color, selectColor = selectColor, clearColor = clearColor)
+                SelectIconRow(icon = icon, selectIcon = selectIcon)
+                extensionContent()
+            }
+        }
+    }
+
+    @Composable
+    fun ListSettingsToolbar(
+        title: String,
+        save: () -> Unit,
+        optionButton: @Composable () -> Unit,
+    ) {
+
+        /*
+    val activity = LocalView.current.context as Activity
+    activity.window.statusBarColor = colorResource(id = R.color.drawer_color_selected).toArgb()
+*/
+
+        Surface(
+            elevation = 4.dp,
+            color = colorResource(id = R.color.content_background),
+            contentColor = colorResource(id = R.color.text_primary),
+            modifier = Modifier.requiredHeight(56.dp)
+        )
+        {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = save) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_outline_save_24px),
+                        contentDescription = stringResource(id = R.string.save),
+                        modifier = Modifier.padding(Constants.KEYLINE_FIRST)
+                    )
+                }
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 20.sp,
+                    modifier = Modifier
+                        .weight(0.9f)
+                        .padding(start = Constants.KEYLINE_FIRST)
+                )
+                optionButton()
+            }
+        }
+    } /* ListSettingsToolBar */
+
+    @Composable
+    fun ListSettingsProgressBar(showProgress: State<Boolean>) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .requiredHeight(3.dp)
+        ) {
+            if (showProgress.value) {
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxSize(),
+                    backgroundColor = LocalContentColor.current.copy(alpha = 0.3f),  //Color.LightGray,
+                    color = colorResource(R.color.red_a400)
+                )
+            }
+        }
+    }
+
+    @Composable
+    fun ListSettingsTitleInput(
+        text: MutableState<String>,
+        error: MutableState<String>,
+        requestKeyboard: Boolean,
+        modifier: Modifier = Modifier,
+        label: String = stringResource(R.string.display_name),
+        errorState: Color = MaterialTheme.colors.secondary,
+        activeState: Color = LocalContentColor.current.copy(alpha = 0.75f),
+        inactiveState: Color = LocalContentColor.current.copy(alpha = 0.5f),
+    ) {
+        val keyboardController = LocalSoftwareKeyboardController.current
+        val requester = remember { FocusRequester() }
+
+        Row(
+            modifier = modifier
+        ) {
+            Column {
+                val focused = remember { mutableStateOf(false) }
+                val labelColor = when {
+                    (error.value != "") -> errorState
+                    (focused.value) -> activeState
+                    else -> inactiveState
+                }
+                val labelText = if (error.value != "") error.value else label
+                Text(
+                    modifier = Modifier.padding(top = 18.dp, bottom = 4.dp),
+                    text = labelText,
+                    fontSize = 12.sp,
+                    letterSpacing = 0.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = labelColor
+                )
+
+                BasicTextField(
+                    value = text.value,
+                    textStyle = TextStyle(
+                        fontSize = LocalTextStyle.current.fontSize,
+                        color = LocalContentColor.current
+                    ),
+                    onValueChange = {
+                        text.value = it
+                        if (error.value != "") error.value = ""
+                    },
+                    cursorBrush = SolidColor(LocalContentColor.current),
+                    modifier = Modifier
+                        .padding(bottom = 3.dp)
+                        .focusRequester(requester)
+                        .onFocusChanged { focused.value = (it.isFocused) }
+                )
+                Divider(
+                    color = labelColor,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+        }
+
+        if (requestKeyboard) {
+            LaunchedEffect(null) {
+                requester.requestFocus()
+
+                /* Part of requester.requestFocus logic is performed in separate coroutine,
+            so the actual view may not be really focused right upon return
+            from it, what makes the subsequent "IME.show" call to be ignored by the system.
+            The delay below is a workaround trick for it.
+            30ms period is not the guarantee but makes it working almost always */
+                delay(30)
+
+                keyboardController?.show()
+            }
+        }
+    } /* TextInput */
+
+    @Composable
+    fun SelectColorRow(color: State<Color>, selectColor: () -> Unit, clearColor: () -> Unit) =
+        ListSettingRow(
+            modifier = Modifier.clickable(onClick =  selectColor),
+            left = {
+                IconButton(onClick = { selectColor() }) {
+                    if (color.value == Color.Unspecified) {
+                        Icon(
+                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_outline_not_interested_24px),
+                            tint = colorResource(R.color.icon_tint_with_alpha),
+                            contentDescription = null
+                        )
+                    } else {
+                        val borderColor =
+                            colorResource(R.color.icon_tint_with_alpha)  // colorResource(R.color.text_tertiary)
+                        Box(
+                            modifier = Modifier.size(56.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Canvas(modifier = Modifier.size(24.dp)) {
+                                drawCircle(color = color.value)
+                                drawCircle(
+                                    color = borderColor, style = Stroke(width = 4.0f)
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            center = {
+                Text(
+                    text = LocalContext.current.getString(R.string.color),
+                    modifier = Modifier
+                        .weight(0.8f)
+                        .padding(start = Constants.KEYLINE_FIRST)
+                )
+            },
+            right = {
+                if (color.value != Color.Unspecified) {
+                    IconButton(onClick = clearColor) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_outline_clear_24px),
+                            contentDescription = null
+                        )
+                    }
+                }
+            }
+        )
+
+    @Composable
+    fun SelectIconRow(icon: State<Int>, selectIcon: () -> Unit) =
+        ListSettingRow(
+            modifier = Modifier.clickable(onClick =  selectIcon),
+            left = {
+                IconButton(onClick = selectIcon) {
+                    Icon(
+                        modifier = Modifier.padding(Constants.KEYLINE_FIRST),
+                        imageVector = ImageVector.vectorResource(icon.value),
+                        contentDescription = null,
+                        tint = colorResource(R.color.icon_tint_with_alpha)
+                    )
+                }
+            },
+            center = {
+                Text(
+                    text = LocalContext.current.getString(R.string.icon),
+                    modifier = Modifier
+                        .weight(0.8f)
+                        .padding(start = Constants.KEYLINE_FIRST)
+                )
+            }
+        )
+
+
+    @Composable
+    fun ListSettingRow(
+        left: @Composable RowScope.() -> Unit,
+        center: @Composable RowScope.() -> Unit,
+        right: @Composable (RowScope.() -> Unit)? = null,
+        modifier: Modifier = Modifier
+    ) {
+        Row(
+            modifier = modifier.requiredHeight(56.dp),
+            verticalAlignment = Alignment.CenterVertically
+        )
+        {
+            left()
+            center()
+            right?.invoke(this)
+        }
+    }
+
+
+    @Composable
+    fun ListSettingsSurface(content: @Composable ColumnScope.() -> Unit) {
+        ProvideTextStyle(LocalTextStyle.current.copy(fontSize = 18.sp)) {
+            Surface(
+                color = colorResource(id = R.color.window_background),
+                contentColor = colorResource(id = R.color.text_primary)
+            ) {
+                Column(modifier = Modifier.fillMaxSize())
+                { content() }
+            }
+        }
+    }
+
+    @Composable
+    fun ListSettingsSnackBar(state: SnackbarHostState) {
+        SnackbarHost(state) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Snackbar(
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    backgroundColor = colorResource(id = R.color.snackbar_background),
+                    contentColor = colorResource(id = R.color.snackbar_text_color),
+                    elevation = 8.dp
+                ) {
+                    Text(text = it.message, fontSize = 18.sp)
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun PromptAction(
+        showDialog: MutableState<Boolean>,
+        title: String,
+        onAction: () -> Unit,
+        onCancel: () -> Unit = { showDialog.value = false }
+    ) {
+        if (showDialog.value) {
+            AlertDialog(
+                onDismissRequest = onCancel,
+                title = { Text(title, style = MaterialTheme.typography.h6) },
+                confirmButton = { Constants.TextButton(R.string.ok, onClick = onAction) },
+                dismissButton = { Constants.TextButton(text = R.string.cancel, onCancel) }
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -302,14 +303,22 @@ object ListSettings {
         right: @Composable (() -> Unit)? = null,
         modifier: Modifier = Modifier
     ) {
-        Row(
-            modifier = modifier.requiredHeight(56.dp),
-            verticalAlignment = Alignment.CenterVertically
-        )
-        {
-            left()
-            center()
-            right?.invoke(this)
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
+            Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
+                left()
+            }
+            Box (
+                modifier = Modifier
+                    .height(56.dp)
+                    .weight(1f), contentAlignment = Alignment.CenterStart
+            ) {
+                center()
+            }
+            right?.let {
+                Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
+                    it.invoke()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -171,7 +171,7 @@ object ListSettings {
         requestKeyboard: Boolean,
         modifier: Modifier = Modifier,
         label: String = stringResource(R.string.display_name),
-        errorState: Color = colorResource(id = org.tasks.kmp.R.color.red_a400), //MaterialTheme.colorScheme.secondary,
+        errorState: Color = MaterialTheme.colors.secondary,
         activeState: Color = LocalContentColor.current.copy(alpha = 0.75f),
         inactiveState: Color = LocalContentColor.current.copy(alpha = 0.3f),
     ) {
@@ -239,6 +239,7 @@ object ListSettings {
                 IconButton(onClick = { selectColor() }) {
                     if (color.value == Color.Unspecified) {
                         Icon(
+                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
                             imageVector = ImageVector.vectorResource(R.drawable.ic_outline_not_interested_24px),
                             tint = colorResource(R.color.icon_tint_with_alpha),
                             contentDescription = null
@@ -304,22 +305,14 @@ object ListSettings {
         right: @Composable (() -> Unit)? = null,
         modifier: Modifier = Modifier
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
-            Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
-                left()
-            }
-            Box (
-                modifier = Modifier
-                .height(56.dp)
-                .weight(1f), contentAlignment = Alignment.CenterStart
-            ) {
-                center()
-            }
-            right?.let {
-                Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
-                    it.invoke()
-                }
-            }
+        Row(
+            modifier = modifier.requiredHeight(56.dp),
+            verticalAlignment = Alignment.CenterVertically
+        )
+        {
+            left()
+            center()
+            right?.invoke(this)
         }
     }
 

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -148,7 +148,9 @@ object ListSettings {
 
     @Composable
     fun ProgressBar(showProgress: State<Boolean>) {
-        Box(modifier = Modifier.fillMaxWidth().requiredHeight(3.dp))
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .requiredHeight(3.dp))
         {
             if (showProgress.value) {
                 LinearProgressIndicator(
@@ -167,23 +169,24 @@ object ListSettings {
         requestKeyboard: Boolean,
         modifier: Modifier = Modifier,
         label: String = stringResource(R.string.display_name),
-        errorState: Color = MaterialTheme.colorScheme.secondary,
+        errorState: Color = colorResource(id = org.tasks.kmp.R.color.red_a400), //MaterialTheme.colorScheme.secondary,
         activeState: Color = LocalContentColor.current.copy(alpha = 0.75f),
-        inactiveState: Color = LocalContentColor.current.copy(alpha = 0.5f),
+        inactiveState: Color = LocalContentColor.current.copy(alpha = 0.3f),
     ) {
         val keyboardController = LocalSoftwareKeyboardController.current
         val requester = remember { FocusRequester() }
+        val focused = remember { mutableStateOf(false) }
+        val labelColor = when {
+            (error.value != "") -> errorState
+            (focused.value) -> activeState
+            else -> inactiveState
+        }
+        val dividerColor = if (focused.value) errorState else labelColor
+        val labelText = if (error.value != "") error.value else label
 
         Row (modifier = modifier)
         {
             Column {
-                val focused = remember { mutableStateOf(false) }
-                val labelColor = when {
-                    (error.value != "") -> errorState
-                    (focused.value) -> activeState
-                    else -> inactiveState
-                }
-                val labelText = if (error.value != "") error.value else label
                 Text(
                     modifier = Modifier.padding(top = 18.dp, bottom = 4.dp),
                     text = labelText,
@@ -203,14 +206,15 @@ object ListSettings {
                         text.value = it
                         if (error.value != "") error.value = ""
                     },
-                    cursorBrush = SolidColor(LocalContentColor.current),
+                    cursorBrush = SolidColor(errorState), // SolidColor(LocalContentColor.current),
                     modifier = Modifier
+                        .fillMaxWidth()
                         .padding(bottom = 3.dp)
                         .focusRequester(requester)
                         .onFocusChanged { focused.value = (it.isFocused) }
                 )
                 HorizontalDivider(
-                    color = labelColor,
+                    color = dividerColor,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
             }
@@ -219,14 +223,7 @@ object ListSettings {
         if (requestKeyboard) {
             LaunchedEffect(null) {
                 requester.requestFocus()
-
-                /* Part of requester.requestFocus logic is performed in separate coroutine,
-            so the actual view may not be really focused right upon return
-            from it, what makes the subsequent "IME.show" call to be ignored by the system.
-            The delay below is a workaround trick for it.
-            30ms period is not the guarantee but makes it working almost always */
-                delay(30)
-
+                delay(30) // Workaround. Otherwise keyboard don't show in 4/5 tries
                 keyboardController?.show()
             }
         }
@@ -309,7 +306,9 @@ object ListSettings {
             Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
                 left()
             }
-            Box (modifier = Modifier.height(56.dp).weight(1f), contentAlignment = Alignment.CenterStart) {
+            Box (modifier = Modifier
+                .height(56.dp)
+                .weight(1f), contentAlignment = Alignment.CenterStart) {
                 center()
             }
             right?.let {

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import org.tasks.R
 import org.tasks.compose.components.TasksIcon
+import org.tasks.themes.TasksIcons
 import org.tasks.themes.TasksTheme
 
 @Composable
@@ -77,6 +78,17 @@ private fun PromptActionPreview() {
             showDialog = remember { mutableStateOf(true) },
             title = "Delete list?",
             onAction = { /*TODO*/ })
+    }
+}
+
+@Composable
+@Preview (showBackground = true)
+private fun IconSelectPreview () {
+    TasksTheme {
+        ListSettings.SelectIconRow(
+            icon = remember { mutableStateOf(TasksIcons.FILTER_LIST) },
+            selectIcon = {}
+        )
     }
 }
 
@@ -307,10 +319,9 @@ object ListSettings {
         ListSettingRow(
             modifier = Modifier.clickable(onClick =  selectIcon),
             left = {
-                IconButton(onClick = selectIcon) {
+                IconButton(onClick = selectIcon, modifier = Modifier.size(56.dp)) {
                     TasksIcon(
                         label = icon.value,
-                        modifier = Modifier.padding(Constants.KEYLINE_FIRST),
                         tint = colorResource(R.color.icon_tint_with_alpha)
                     )
                 }

--- a/app/src/main/java/org/tasks/compose/ListSettings.kt
+++ b/app/src/main/java/org/tasks/compose/ListSettings.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -92,46 +93,19 @@ private fun IconSelectPreview () {
     }
 }
 
-object ListSettings {
-    @Composable
-    fun ListSettings(
-        title: String,
-        requestKeyboard: Boolean,
-        text: MutableState<String>,
-        error: MutableState<String>,
-        color: State<Color>,
-        icon: State<String>,
-        save: () -> Unit = {},
-        selectIcon: () -> Unit = {},
-        clearColor: () -> Unit = {},
-        selectColor: () -> Unit = {},
-        optionButton: @Composable () -> Unit,
-        /** right button on toolbar, mostly, DeleteButton */
-        showProgress: State<Boolean> = remember { mutableStateOf(false) },
-        extensionContent: @Composable ColumnScope.() -> Unit = {}
-    ) {
-        ListSettingsSurface {
-
-            Toolbar(
-                title = title,
-                save = save,
-                optionButton = optionButton
-            )
-
-            ProgressBar(showProgress)
-
-            TitleInput(
-                text = text, error = error, requestKeyboard = requestKeyboard,
-                modifier = Modifier.padding(horizontal = Constants.KEYLINE_FIRST)
-            )
-
-            Column(modifier = Modifier.fillMaxWidth()) {
-                SelectColorRow(color = color, selectColor = selectColor, clearColor = clearColor)
-                SelectIconRow(icon = icon, selectIcon = selectIcon)
-                extensionContent()
-            }
-        }
+@Composable
+@Preview (showBackground = true)
+private fun ColorSelectPreview () {
+    TasksTheme {
+        ListSettings.SelectColorRow(
+            color = remember { mutableStateOf(Color.Red) },
+            selectColor = {},
+            clearColor = {}
+        )
     }
+}
+
+object ListSettings {
 
     @Composable
     fun Toolbar(
@@ -152,9 +126,7 @@ object ListSettings {
             modifier = Modifier.requiredHeight(56.dp)
         )
         {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 IconButton(onClick = save, modifier = Modifier.size(56.dp)) {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_outline_save_24px),
@@ -172,15 +144,12 @@ object ListSettings {
                 optionButton()
             }
         }
-    } /* ListSettingsToolBar */
+    } /* ToolBar */
 
     @Composable
     fun ProgressBar(showProgress: State<Boolean>) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .requiredHeight(3.dp)
-        ) {
+        Box(modifier = Modifier.fillMaxWidth().requiredHeight(3.dp))
+        {
             if (showProgress.value) {
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxSize(),
@@ -205,9 +174,8 @@ object ListSettings {
         val keyboardController = LocalSoftwareKeyboardController.current
         val requester = remember { FocusRequester() }
 
-        Row(
-            modifier = modifier
-        ) {
+        Row (modifier = modifier)
+        {
             Column {
                 val focused = remember { mutableStateOf(false) }
                 val labelColor = when {
@@ -272,22 +240,19 @@ object ListSettings {
                 IconButton(onClick = { selectColor() }) {
                     if (color.value == Color.Unspecified) {
                         Icon(
-                            modifier = Modifier.padding(Constants.KEYLINE_FIRST),
                             imageVector = ImageVector.vectorResource(R.drawable.ic_outline_not_interested_24px),
                             tint = colorResource(R.color.icon_tint_with_alpha),
                             contentDescription = null
                         )
                     } else {
-                        val borderColor =
-                            colorResource(R.color.icon_tint_with_alpha)  // colorResource(R.color.text_tertiary)
+                        val borderColor = colorResource(R.color.icon_tint_with_alpha)  // colorResource(R.color.text_tertiary)
                         Box(
                             modifier = Modifier.size(56.dp),
                             contentAlignment = Alignment.Center
                         ) {
                             Canvas(modifier = Modifier.size(24.dp)) {
                                 drawCircle(color = color.value)
-                                drawCircle(
-                                    color = borderColor, style = Stroke(width = 4.0f)
+                                drawCircle(color = borderColor, style = Stroke(width = 4.0f)
                                 )
                             }
                         }
@@ -297,9 +262,7 @@ object ListSettings {
             center = {
                 Text(
                     text = LocalContext.current.getString(R.string.color),
-                    modifier = Modifier
-                        .weight(0.8f)
-                        .padding(start = Constants.KEYLINE_FIRST)
+                    modifier = Modifier.padding(start = Constants.KEYLINE_FIRST)
                 )
             },
             right = {
@@ -319,7 +282,7 @@ object ListSettings {
         ListSettingRow(
             modifier = Modifier.clickable(onClick =  selectIcon),
             left = {
-                IconButton(onClick = selectIcon, modifier = Modifier.size(56.dp)) {
+                IconButton(onClick = selectIcon) {
                     TasksIcon(
                         label = icon.value,
                         tint = colorResource(R.color.icon_tint_with_alpha)
@@ -329,9 +292,7 @@ object ListSettings {
             center = {
                 Text(
                     text = LocalContext.current.getString(R.string.icon),
-                    modifier = Modifier
-                        .weight(0.8f)
-                        .padding(start = Constants.KEYLINE_FIRST)
+                    modifier = Modifier.padding(start = Constants.KEYLINE_FIRST)
                 )
             }
         )
@@ -339,22 +300,25 @@ object ListSettings {
 
     @Composable
     fun ListSettingRow(
-        left: @Composable RowScope.() -> Unit,
-        center: @Composable RowScope.() -> Unit,
-        right: @Composable (RowScope.() -> Unit)? = null,
+        left: @Composable () -> Unit,
+        center: @Composable () -> Unit,
+        right: @Composable (() -> Unit)? = null,
         modifier: Modifier = Modifier
     ) {
-        Row(
-            modifier = modifier.requiredHeight(56.dp),
-            verticalAlignment = Alignment.CenterVertically
-        )
-        {
-            left()
-            center()
-            right?.invoke(this)
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
+            Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
+                left()
+            }
+            Box (modifier = Modifier.height(56.dp).weight(1f), contentAlignment = Alignment.CenterStart) {
+                center()
+            }
+            right?.let {
+                Box (modifier = Modifier.size(56.dp), contentAlignment = Alignment.Center) {
+                    it.invoke()
+                }
+            }
         }
     }
-
 
     @Composable
     fun ListSettingsSurface(content: @Composable ColumnScope.() -> Unit) {
@@ -363,8 +327,7 @@ object ListSettings {
                 color = colorResource(id = R.color.window_background),
                 contentColor = colorResource(id = R.color.text_primary)
             ) {
-                Column(modifier = Modifier.fillMaxSize())
-                { content() }
+                Column(modifier = Modifier.fillMaxSize()) { content() }
             }
         }
     }
@@ -381,7 +344,6 @@ object ListSettings {
                     shape = RoundedCornerShape(10.dp),
                     containerColor = colorResource(id = R.color.snackbar_background),
                     contentColor = colorResource(id = R.color.snackbar_text_color),
-                    //shadowElevation = 8.dp
                 ) {
                     Text(text = data.visuals.message, fontSize = 18.sp)
                 }

--- a/app/src/main/java/org/tasks/compose/SwipeOut.kt
+++ b/app/src/main/java/org/tasks/compose/SwipeOut.kt
@@ -1,0 +1,92 @@
+package org.tasks.compose
+
+/**
+ * Simple Swipe-to-delete implementation
+ */
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import org.tasks.R
+import kotlin.math.roundToInt
+
+object SwipeOut {
+
+    private enum class Anchors { Left, Center, Right }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun SwipeOut(
+        modifier: Modifier = Modifier,
+        index: Int,
+        onSwipe: (Int) -> Unit,
+        decoration: @Composable BoxScope.() -> Unit = {},
+        content: @Composable BoxScope.() -> Unit
+    ) {
+        val screenWidthPx =
+            with(LocalDensity.current) {
+                LocalConfiguration.current.screenWidthDp.dp.roundToPx().toFloat()
+            }
+
+        val dragState = remember {
+            AnchoredDraggableState(
+                initialValue = Anchors.Center,
+                anchors = DraggableAnchors {
+                    Anchors.Left at -screenWidthPx * 3/4
+                    Anchors.Center at 0f
+                    Anchors.Right at screenWidthPx * 3/4
+                },
+                positionalThreshold = { _ -> screenWidthPx/3 },
+                velocityThreshold = { 100f },
+                animationSpec = tween()
+            )
+        }
+
+        if (dragState.currentValue == Anchors.Left || dragState.currentValue == Anchors.Right) {
+            onSwipe(index)
+        }
+
+        Box(    /* container for swipeable and it's background decoration */
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.CenterStart
+        ) {
+
+            decoration()
+
+            Box(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .offset {
+                        IntOffset(
+                            x = dragState
+                                .requireOffset()
+                                .roundToInt(),
+                            y = 0
+                        )
+                    }
+                    .background(colorResource(id = R.color.content_background)) // MUST BE AFTER .offset modifier (?!?!)
+                    .anchoredDraggable(dragState, Orientation.Horizontal, reverseDirection = false)
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/tasks/compose/SwipeOut.kt
+++ b/app/src/main/java/org/tasks/compose/SwipeOut.kt
@@ -4,6 +4,7 @@ package org.tasks.compose
  * Simple Swipe-to-delete implementation
  */
 
+import androidx.compose.animation.core.exponentialDecay
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -46,7 +47,7 @@ object SwipeOut {
                 LocalConfiguration.current.screenWidthDp.dp.roundToPx().toFloat()
             }
 
-        val dragState = remember {
+        val dragState: AnchoredDraggableState<Anchors> = remember {
             AnchoredDraggableState(
                 initialValue = Anchors.Center,
                 anchors = DraggableAnchors {
@@ -56,7 +57,8 @@ object SwipeOut {
                 },
                 positionalThreshold = { _ -> screenWidthPx/3 },
                 velocityThreshold = { 100f },
-                animationSpec = tween()
+                snapAnimationSpec = tween(),
+                decayAnimationSpec = exponentialDecay()
             )
         }
 
@@ -83,7 +85,7 @@ object SwipeOut {
                         )
                     }
                     .background(colorResource(id = R.color.content_background)) // MUST BE AFTER .offset modifier (?!?!)
-                    .anchoredDraggable(dragState, Orientation.Horizontal, reverseDirection = false)
+                    .anchoredDraggable(state = dragState, orientation = Orientation.Horizontal)
             ) {
                 content()
             }

--- a/app/src/main/java/org/tasks/etebase/EtebaseCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/etebase/EtebaseCalendarSettingsActivity.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
+import org.tasks.themes.TasksTheme
 
 @AndroidEntryPoint
 class EtebaseCalendarSettingsActivity : BaseCaldavCalendarSettingsActivity() {
@@ -22,7 +23,9 @@ class EtebaseCalendarSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         updateCalendarViewModel.observe(this, { updateCalendar() }, this::requestFailed)
 
         setContent {
-            baseCaldavSettingsContent()
+            TasksTheme {
+                baseCaldavSettingsContent()
+            }
         }
     }
 

--- a/app/src/main/java/org/tasks/etebase/EtebaseCalendarSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/etebase/EtebaseCalendarSettingsActivity.kt
@@ -1,6 +1,7 @@
 package org.tasks.etebase
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
@@ -19,6 +20,10 @@ class EtebaseCalendarSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         createCalendarViewModel.observe(this, this::createSuccessful, this::requestFailed)
         deleteCalendarViewModel.observe(this, this::onDeleted, this::requestFailed)
         updateCalendarViewModel.observe(this, { updateCalendar() }, this::requestFailed)
+
+        setContent {
+            baseCaldavSettingsContent()
+        }
     }
 
     override suspend fun createCalendar(caldavAccount: CaldavAccount, name: String, color: Int) =

--- a/app/src/main/java/org/tasks/location/MapFragment.kt
+++ b/app/src/main/java/org/tasks/location/MapFragment.kt
@@ -1,14 +1,11 @@
 package org.tasks.location
 
-import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import org.tasks.data.entity.Place
 
 interface MapFragment {
     fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean, parent: ViewGroup? = null)
-
-    fun getView(): View
 
     val mapPosition: MapPosition?
 

--- a/app/src/main/java/org/tasks/location/MapFragment.kt
+++ b/app/src/main/java/org/tasks/location/MapFragment.kt
@@ -1,10 +1,14 @@
 package org.tasks.location
 
+import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import org.tasks.data.entity.Place
 
 interface MapFragment {
-    fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean)
+    fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean, parent: ViewGroup? = null)
+
+    fun getView(): View
 
     val mapPosition: MapPosition?
 

--- a/app/src/main/java/org/tasks/location/OsmMapFragment.kt
+++ b/app/src/main/java/org/tasks/location/OsmMapFragment.kt
@@ -2,7 +2,6 @@ package org.tasks.location
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -47,13 +46,11 @@ class OsmMapFragment @Inject constructor(
             val copyright = CopyrightOverlay(activity)
             copyright.setTextColor(ContextCompat.getColor(activity, R.color.text_primary))
             overlays.add(copyright)
-            //val parent = parent ?: activity.findViewById<ViewGroup>(R.id.map)
-            (parent ?: activity.findViewById<ViewGroup>(R.id.map)).addView(this)
+            if (parent != null) parent.addView(this)
+            else activity.findViewById<ViewGroup>(R.id.map).addView(this)
         }
         callback.onMapReady(this)
     }
-
-    override fun getView(): View = map
 
     override val mapPosition: MapPosition
         get() {

--- a/app/src/main/java/org/tasks/location/OsmMapFragment.kt
+++ b/app/src/main/java/org/tasks/location/OsmMapFragment.kt
@@ -2,6 +2,7 @@ package org.tasks.location
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -31,7 +32,7 @@ class OsmMapFragment @Inject constructor(
     private var locationOverlay: MyLocationNewOverlay? = null
     private var circle: Polygon? = null
 
-    override fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean) {
+    override fun init(activity: AppCompatActivity, callback: MapFragmentCallback, dark: Boolean, parent: ViewGroup?) {
         this.callback = callback
         Configuration.getInstance()
                 .load(activity, PreferenceManager.getDefaultSharedPreferences(activity))
@@ -46,10 +47,13 @@ class OsmMapFragment @Inject constructor(
             val copyright = CopyrightOverlay(activity)
             copyright.setTextColor(ContextCompat.getColor(activity, R.color.text_primary))
             overlays.add(copyright)
-            activity.findViewById<ViewGroup>(R.id.map).addView(this)
+            //val parent = parent ?: activity.findViewById<ViewGroup>(R.id.map)
+            (parent ?: activity.findViewById<ViewGroup>(R.id.map)).addView(this)
         }
         callback.onMapReady(this)
     }
+
+    override fun getView(): View = map
 
     override val mapPosition: MapPosition
         get() {

--- a/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
@@ -3,21 +3,17 @@ package org.tasks.opentasks
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
-import org.tasks.compose.Constants
-import org.tasks.compose.DeleteButton
-import org.tasks.data.entity.CaldavAccount
-import org.tasks.data.entity.CaldavCalendar
 import org.tasks.compose.ListSettings.ListSettingsProgressBar
 import org.tasks.compose.ListSettings.ListSettingsSnackBar
 import org.tasks.compose.ListSettings.ListSettingsSurface
 import org.tasks.compose.ListSettings.ListSettingsToolbar
 import org.tasks.compose.ListSettings.SelectIconRow
-import org.tasks.data.CaldavAccount
-import org.tasks.data.CaldavCalendar
+import org.tasks.data.entity.CaldavAccount
+import org.tasks.data.entity.CaldavCalendar
+import org.tasks.themes.TasksTheme
 
 @AndroidEntryPoint
 class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
@@ -26,7 +22,7 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MdcTheme {
+            TasksTheme {
                 ListSettingsSurface {
                     ListSettingsToolbar(
                         title = toolbarTitle,
@@ -34,7 +30,7 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                         optionButton = { },
                     )
                     ListSettingsProgressBar(showProgress)
-                    SelectIconRow(icon = iconState) {
+                    SelectIconRow(icon = selectedIcon) {
                         showIconPicker()
                     }
                 }

--- a/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
@@ -1,12 +1,23 @@
 package org.tasks.opentasks
 
 import android.os.Bundle
-import android.view.View
+import androidx.activity.compose.setContent
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
-import org.tasks.R
+import kotlinx.coroutines.launch
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
+import org.tasks.compose.Constants
+import org.tasks.compose.DeleteButton
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
+import org.tasks.compose.ListSettings.ListSettingsProgressBar
+import org.tasks.compose.ListSettings.ListSettingsSnackBar
+import org.tasks.compose.ListSettings.ListSettingsSurface
+import org.tasks.compose.ListSettings.ListSettingsToolbar
+import org.tasks.compose.ListSettings.SelectIconRow
+import org.tasks.data.CaldavAccount
+import org.tasks.data.CaldavCalendar
 
 @AndroidEntryPoint
 class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
@@ -14,15 +25,28 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        toolbar.menu.findItem(R.id.delete).isVisible = false
-        nameLayout.visibility = View.GONE
-        colorRow.visibility = View.GONE
+        setContent {
+            MdcTheme {
+                ListSettingsSurface {
+                    ListSettingsToolbar(
+                        title = toolbarTitle,
+                        save = { lifecycleScope.launch { save() } },
+                        optionButton = { },
+                    )
+                    ListSettingsProgressBar(showProgress)
+                    SelectIconRow(icon = iconState) {
+                        showIconPicker()
+                    }
+                }
+                ListSettingsSnackBar(state = snackbar)
+            }
+        } /* setContent */
     }
 
     override suspend fun createCalendar(caldavAccount: CaldavAccount, name: String, color: Int) {}
 
     override suspend fun updateNameAndColor(
-        account: CaldavAccount, calendar: CaldavCalendar, name: String, color: Int) =
+            account: CaldavAccount, calendar: CaldavCalendar, name: String, color: Int) =
             updateCalendar()
 
     override suspend fun deleteCalendar(caldavAccount: CaldavAccount, caldavCalendar: CaldavCalendar) {}

--- a/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
@@ -7,8 +7,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
 import org.tasks.compose.ListSettings.ProgressBar
-import org.tasks.compose.ListSettings.SettingsSnackBar
-import org.tasks.compose.ListSettings.ListSettingsSurface
+import org.tasks.compose.ListSettings.Toaster
+import org.tasks.compose.ListSettings.SettingsSurface
 import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.SelectIconRow
 import org.tasks.data.entity.CaldavAccount
@@ -23,18 +23,16 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
 
         setContent {
             TasksTheme {
-                ListSettingsSurface {
+                SettingsSurface {
                     Toolbar(
                         title = toolbarTitle,
                         save = { lifecycleScope.launch { save() } },
                         optionButton = { },
                     )
                     ProgressBar(showProgress)
-                    SelectIconRow(icon = selectedIcon) {
-                        showIconPicker()
-                    }
+                    SelectIconRow(icon = selectedIcon) { showIconPicker() }
                 }
-                SettingsSnackBar(state = snackbar)
+                Toaster(state = snackbar)
             }
         } /* setContent */
     }

--- a/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
@@ -30,7 +30,7 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                         optionButton = { },
                     )
                     ProgressBar(showProgress)
-                    SelectIconRow(icon = selectedIcon) { showIconPicker() }
+                    SelectIconRow(icon = selectedIcon.value?: defaultIcon) { showIconPicker() }
                 }
                 Toaster(state = snackbar)
             }

--- a/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/opentasks/OpenTasksListSettingsActivity.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
-import org.tasks.compose.ListSettings.ListSettingsProgressBar
-import org.tasks.compose.ListSettings.ListSettingsSnackBar
+import org.tasks.compose.ListSettings.ProgressBar
+import org.tasks.compose.ListSettings.SettingsSnackBar
 import org.tasks.compose.ListSettings.ListSettingsSurface
-import org.tasks.compose.ListSettings.ListSettingsToolbar
+import org.tasks.compose.ListSettings.Toolbar
 import org.tasks.compose.ListSettings.SelectIconRow
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
@@ -24,17 +24,17 @@ class OpenTasksListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         setContent {
             TasksTheme {
                 ListSettingsSurface {
-                    ListSettingsToolbar(
+                    Toolbar(
                         title = toolbarTitle,
                         save = { lifecycleScope.launch { save() } },
                         optionButton = { },
                     )
-                    ListSettingsProgressBar(showProgress)
+                    ProgressBar(showProgress)
                     SelectIconRow(icon = selectedIcon) {
                         showIconPicker()
                     }
                 }
-                ListSettingsSnackBar(state = snackbar)
+                SettingsSnackBar(state = snackbar)
             }
         } /* setContent */
     }

--- a/app/src/main/java/org/tasks/sync/microsoft/MicrosoftListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/sync/microsoft/MicrosoftListSettingsActivity.kt
@@ -3,6 +3,7 @@ package org.tasks.sync.microsoft
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.todoroo.astrid.activity.MainActivity
@@ -43,6 +44,10 @@ class MicrosoftListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
                         finish()
                     }
                 }
+        }
+
+        setContent {
+            baseCaldavSettingsContent()
         }
     }
 

--- a/app/src/main/java/org/tasks/sync/microsoft/MicrosoftListSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/sync/microsoft/MicrosoftListSettingsActivity.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.tasks.caldav.BaseCaldavCalendarSettingsActivity
 import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
+import org.tasks.themes.TasksTheme
 
 @AndroidEntryPoint
 class MicrosoftListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
@@ -47,7 +48,9 @@ class MicrosoftListSettingsActivity : BaseCaldavCalendarSettingsActivity() {
         }
 
         setContent {
-            baseCaldavSettingsContent()
+            TasksTheme {
+                baseCaldavSettingsContent()
+            }
         }
     }
 

--- a/app/src/main/res/layout/filter_settings_activity.xml
+++ b/app/src/main/res/layout/filter_settings_activity.xml
@@ -57,6 +57,11 @@
         android:clipToPadding="false"
         android:nestedScrollingEnabled="false"/>
 
+      <androidx.compose.ui.platform.ComposeView
+          android:id="@+id/filter_criteria_list"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content" />
+
     </LinearLayout>
 
   </androidx.core.widget.NestedScrollView>

--- a/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
@@ -60,6 +60,7 @@ fun TasksTheme(
         colorScheme = colorScheme.copy(
             primary = Color(primary),
             onPrimary = colorOnPrimary,
+            secondary = Color.Red,      // Hady: Sorry for this hack, I believe the regular solution is planned
         ),
     ) {
         content()


### PR DESCRIPTION
Hi!

This is a second version of new pull request for the same branch with Compose versions of BaseListSettingsActivity and its descendants like TagSettingsActivity, PlaceSettingsActivity etc.

Differences with my October pull request are:

- Branch was rebased to "main" state of December 9, 2024, morning (GMT), inconsistency with updated Compose library fixed
- Fixed the bug with wrong counters in FilterSettingActivity
- Hopefully fixed the bug with unexpected change confirmations when no changes were made. I was not able to reproduce it stably, but found my bug that may cause such confirmation requests in case of editing settings of the objects with default (not edited) icons
- Fixed crash in Google. Now GoogleMapFragment compiles and the corresponding view in PlaceSettingsActivity is displayed correctly and is operable

Hope it helps.

Regards,
Andrei
