### PR TITLE
fix of two minor misbehaviors in date-time handling

### DIFF
--- a/app/src/main/java/org/tasks/compose/pickers/DatePickerDialog.kt
+++ b/app/src/main/java/org/tasks/compose/pickers/DatePickerDialog.kt
@@ -25,7 +25,11 @@ fun DatePickerDialog(
 ) {
     val initialDateUTC by remember(initialDate) {
         derivedStateOf {
-            DateTime(initialDate).toUTC().millis
+            // DateTime(initialDate).toUTC().millis
+            // DateTime.toUTC() does not change DateTime.millis value, but DatePicker expects it
+            // is in local timezone and decrements it by TimeZone.offset. This shifts the date to
+            // the previous date in timezones to East of GMT, which is unexpected
+            DateTime(initialDate).let { it.millis + it.offset }
         }
     }
     val datePickerState = rememberDatePickerState(

--- a/app/src/main/java/org/tasks/repeats/CustomRecurrenceViewModel.kt
+++ b/app/src/main/java/org/tasks/repeats/CustomRecurrenceViewModel.kt
@@ -172,7 +172,11 @@ class CustomRecurrenceViewModel @Inject constructor(
             builder.interval(state.interval)
         }
         when (state.endSelection) {
-            1 -> builder.until(Date(state.endDate))
+            // 1 -> builder.until(Date(state.endDate))
+            // builder.until expects that Date() is in local timezone and strips it, which effectively
+            // equivalent to decrementing the "endDate" value by TimeZone.offset. This changes the date
+            // to the previous day in timezones to the East of GMT, so this value shall be pre-shifted
+            1 -> builder.until(Date(DateTime(state.endDate).let { it.millis + it.offset }))
             2 -> builder.count(state.endCount.coerceAtLeast(1))
         }
         return builder.build().toString()


### PR DESCRIPTION
I've found two misbehaviors with Date-Time handlng in UI, which apear in timezones to the East of GMT.
This pool request is a fix.

### Description

I am in GMT+2. Today is January 12 2025.
I create new task, then click to recurrence row and select "Custom...".
CustomRecurence dialog opens. On "Ends" selectors I see "On Feb 12" in the second row, which is expected.
I click to this row and DatePickerDialog opens.
The selected date in this dialog is February 11, which is not expected.
_The fix is in DatePickerDialog.kt_

I tap OK and in return back to CustomRecurrence dialog. I see "On Feb 11" in the second row.
Then I save changes and return to the TaskEdit activity.
In the recurrence row I see this text:
        **Repeats weekly, ends on February 10.**
This is also unexpected.
_The fix is in CustomRecurrenceViewModel.kt_

Good luck!