### PR TITLE
Fix text input alignment/direction

### DIFF
--- a/app/src/main/java/org/tasks/compose/FilterCondition.kt
+++ b/app/src/main/java/org/tasks/compose/FilterCondition.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -482,7 +483,9 @@ object FilterCondition {
                                 contentDescription = null
                             )
                         },
-                        textStyle = MaterialTheme.typography.bodyMedium,
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(
+                            textDirection = TextDirection.Content
+                        ),
                         colors = Constants.textFieldColors(),
                     )
                 }

--- a/app/src/main/java/org/tasks/compose/ShareInvite.kt
+++ b/app/src/main/java/org/tasks/compose/ShareInvite.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import org.tasks.R
 import org.tasks.compose.Constants.TextButton
@@ -108,7 +109,9 @@ object ShareInvite {
                         contentDescription = label
                     )
                 },
-                textStyle = MaterialTheme.typography.bodyLarge,
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    textDirection = TextDirection.Content
+                ),
                 colors = textFieldColors(),
             )
         }

--- a/app/src/main/java/org/tasks/compose/edit/EditTextView.kt
+++ b/app/src/main/java/org/tasks/compose/edit/EditTextView.kt
@@ -92,7 +92,6 @@ fun EditTextView(
                 }
 
                 setBackgroundColor(context.getColor(android.R.color.transparent))
-                textAlignment = View.TEXT_ALIGNMENT_VIEW_START
                 importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
                 freezesText = true
                 setHorizontallyScrolling(false)

--- a/app/src/main/java/org/tasks/compose/edit/SubtaskRow.kt
+++ b/app/src/main/java/org/tasks/compose/edit/SubtaskRow.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.tasks.compose.CheckBox
@@ -170,6 +171,7 @@ fun NewSubtaskRow(
                 .padding(top = 12.dp),
             textStyle = MaterialTheme.typography.bodyLarge.copy(
                 textDecoration = if (subtask.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
+                textDirection = TextDirection.Content,
                 color = MaterialTheme.colorScheme.onSurface,
             ),
             keyboardOptions = KeyboardOptions.Default.copy(

--- a/app/src/main/java/org/tasks/compose/settings/TitleInput.kt
+++ b/app/src/main/java/org/tasks/compose/settings/TitleInput.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
@@ -67,6 +68,7 @@ fun TitleInput(
             BasicTextField(
                 value = text,
                 textStyle = TextStyle(
+                    textDirection = TextDirection.Content,
                     fontSize = LocalTextStyle.current.fontSize,
                     color = LocalContentColor.current
                 ),

--- a/app/src/main/java/org/tasks/tags/TagPickerActivity.kt
+++ b/app/src/main/java/org/tasks/tags/TagPickerActivity.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.AndroidEntryPoint
@@ -190,6 +192,9 @@ internal fun SearchBar(
                 focusedContainerColor = Color.Transparent,
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent
+            ),
+            textStyle = TextStyle(
+                textDirection = TextDirection.Content
             ),
             modifier = Modifier.padding(start = 6.dp),
             keyboardOptions = KeyboardOptions(

--- a/app/src/main/res/layout/fragment_comment_bar.xml
+++ b/app/src/main/res/layout/fragment_comment_bar.xml
@@ -40,7 +40,6 @@
     android:inputType="textCapSentences"
     android:nextFocusLeft="@id/commentField"
     android:nextFocusUp="@id/commentField"
-    android:textAlignment="viewStart"
     android:textColor="?attr/colorOnBackground"
     android:textColorHint="?attr/colorOnBackground"
     android:textCursorDrawable="@null"

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/components/SearchBar.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/components/SearchBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 
 val SEARCH_BAR_HEIGHT = 56.dp
@@ -82,7 +83,9 @@ fun SearchBar(
             }
         ),
         singleLine = true,
-        textStyle = MaterialTheme.typography.bodyLarge,
+        textStyle = MaterialTheme.typography.bodyLarge.copy(
+            textDirection = TextDirection.Content
+        ),
         colors = OutlinedTextFieldDefaults.colors(
             focusedBorderColor = MaterialTheme.colorScheme.onSurface,
             unfocusedBorderColor = MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
This should probably fix #3488

I've noticed the `textAlignment` property of a few `EditText` views has been set to `viewStart` (678bf47883be6aea8bd705833113ab07c222680c). Unless there is some kind of problem with the default `gravity` text alignment, please consider reverting back to it.

There are also text input fields which are created as `(Basic/Outlined)TextField` composables, and by default Jetpack Compose sets their `textDirection` to `TextDirection.Unspecified`. The side effect of that is similar to the one specified above.

A possible solution is to set the text direction to `TextDirection.Content` (81c6717ddeeda2088726e3f86495c84fac6a9f9d). Note that some TextFields have not been changed because they only accept numbers as input.

It's my first PR here, hopefully I've done it right. Please let me know in case I've overlooked something. Thank you :)