### PR TITLE
Automirrored icons fix

### DIFF
--- a/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
+++ b/app/src/main/java/org/tasks/activities/FilterSettingsActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Help
+import androidx.compose.material.icons.automirrored.outlined.Help
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -14,6 +14,8 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -47,6 +49,7 @@ import org.tasks.filters.FilterCriteriaProvider
 import org.tasks.filters.mapToSerializedString
 import org.tasks.themes.TasksIcons
 import org.tasks.themes.TasksTheme
+import java.util.Locale
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -170,7 +173,18 @@ class FilterSettingsActivity : BaseListSettingsActivity() {
                 optionButton = {
                     if (isNew) {
                         IconButton(onClick = { help() }) {
-                            Icon(imageVector = Icons.Outlined.Help, contentDescription = "")
+                            // Cancel the mirroring of the help icon when the locale is Hebrew.
+                            val modifier =
+                                if (Locale.getDefault().language == Locale.forLanguageTag("he").language) {
+                                    Modifier.scale(scaleX = -1f, scaleY = 1f)
+                                } else {
+                                    Modifier
+                                }
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.Help,
+                                contentDescription = "",
+                                modifier = modifier,
+                            )
                         }
                     } else DeleteButton(filter?.title ?: ""){ delete() }
                 },

--- a/app/src/main/java/org/tasks/compose/pickers/CustomRecurrence.kt
+++ b/app/src/main/java/org/tasks/compose/pickers/CustomRecurrence.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -100,7 +100,7 @@ fun CustomRecurrence(
                 navigationIcon = {
                     IconButton(onClick = save) {
                         Icon(
-                            imageVector = Icons.Outlined.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                             contentDescription = stringResource(id = R.string.save),
                             tint = MaterialTheme.colorScheme.onSurface,
                         )

--- a/app/src/main/res/drawable-iw/ic_outline_help_outline_24px.xml
+++ b/app/src/main/res/drawable-iw/ic_outline_help_outline_24px.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z"/>
+</vector>

--- a/app/src/main/res/drawable-ldrtl/ic_outline_help_outline_24px.xml
+++ b/app/src/main/res/drawable-ldrtl/ic_outline_help_outline_24px.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="m 13,18h -2v -2h 2zM 12,2C 17.52,2 22,6.48 22,12 22,17.52 17.52,22 12,22 6.48,22 2,17.52 2,12 2,6.48 6.48,2 12,2Zm 0,18c 4.41,0 8,-3.59 8,-8 0,-4.41 -3.59,-8 -8,-8 -4.41,0 -8,3.59 -8,8 0,4.41 3.59,8 8,8zM 12,6c 2.21,0 4,1.79 4,4h -2c 0,-1.1 -0.9,-2 -2,-2 -1.1,0 -2,0.9 -2,2 0,2 3,1.75 3,5H 11C 11,12.75 8,12.5 8,10 8,7.79 9.79,6 12,6Z"/>
+</vector>

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/drawer/TaskListDrawer.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/drawer/TaskListDrawer.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -67,6 +68,7 @@ import tasks.kmp.generated.resources.Res
 import tasks.kmp.generated.resources.help_and_feedback
 import tasks.kmp.generated.resources.search
 import tasks.kmp.generated.resources.subscribe
+import java.util.Locale
 import kotlin.math.roundToInt
 
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
@@ -314,10 +316,18 @@ fun RowScope.MenuSearchBar(
             }
         }
         IconButton(onClick = { onDrawerAction(DrawerAction.HELP_AND_FEEDBACK) }) {
+            // Cancel the mirroring of the help icon when the locale is Hebrew.
+            val modifier =
+                if (Locale.getDefault().language == Locale.forLanguageTag("he").language) {
+                    Modifier.scale(scaleX = -1f, scaleY = 1f)
+                } else {
+                    Modifier
+                }
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                 contentDescription = stringResource(Res.string.help_and_feedback),
                 tint = MaterialTheme.colorScheme.onSurface,
+                modifier = modifier,
             )
         }
     }


### PR DESCRIPTION
This should fix #3498

I've added a new Drawable resource called `ic_unmirrored_outline_help_outline_24px` as part of the fix, which is identical to `ic_outline_help_outline_24px`, except it does not have the `android:autoMirrored="true"` property.

There is probably a way to do this without adding another Drawable, but I could not find a more elegant solution.