### PR TITLE
Add syncing for estimated and elpased seconds using CalDAV custom properties

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/service/Upgrader.kt
+++ b/app/src/main/java/com/todoroo/astrid/service/Upgrader.kt
@@ -150,6 +150,12 @@ class Upgrader @Inject constructor(
                     }
                 }
             }
+            run(from, V14_7_5) {
+                upgraderDao.tasksWithVtodos()
+                    .filter { it.task.estimatedSeconds > 0 || it.task.elapsedSeconds > 0 }
+                    .map { it.id }
+                    .let { taskDao.touch(it) }
+            }
             run(from, V14_8) {
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     uniqueWorkName = "upload_icons",
@@ -421,6 +427,7 @@ class Upgrader @Inject constructor(
         const val V12_8 = 120800
         const val V14_5_4 = 140516
         const val V14_6_1 = 140602
+        const val V14_7_5 = 140705
         const val V14_8 = 140800
 
         @JvmStatic

--- a/app/src/main/java/org/tasks/caldav/iCalendarMerge.kt
+++ b/app/src/main/java/org/tasks/caldav/iCalendarMerge.kt
@@ -3,6 +3,8 @@ package org.tasks.caldav
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.property.Status
 import org.tasks.caldav.iCalendar.Companion.collapsed
+import org.tasks.caldav.iCalendar.Companion.elapsedSeconds
+import org.tasks.caldav.iCalendar.Companion.estimatedSeconds
 import org.tasks.caldav.iCalendar.Companion.getLocal
 import org.tasks.caldav.iCalendar.Companion.order
 import org.tasks.caldav.iCalendar.Companion.parent
@@ -32,6 +34,8 @@ fun org.tasks.data.entity.Task.applyRemote(
     applyStart(remote, local)
     applyCollapsed(remote, local)
     applyOrder(remote, local)
+    applyEstimatedSeconds(remote, local)
+    applyElapsedSeconds(remote, local)
     return this
 }
 
@@ -118,6 +122,18 @@ private fun org.tasks.data.entity.Task.applyOrder(remote: Task, local: Task?) {
 private fun CaldavTask.applyParent(remote: Task, local: Task?) {
     if (local == null || local.parent == remoteParent) {
         remoteParent = remote.parent
+    }
+}
+
+private fun org.tasks.data.entity.Task.applyEstimatedSeconds(remote: Task, local: Task?) {
+    if (local == null || local.estimatedSeconds == estimatedSeconds) {
+        estimatedSeconds = remote.estimatedSeconds ?: 0
+    }
+}
+
+private fun org.tasks.data.entity.Task.applyElapsedSeconds(remote: Task, local: Task?) {
+    if (local == null || local.elapsedSeconds == elapsedSeconds) {
+        elapsedSeconds = remote.elapsedSeconds ?: 0
     }
 }
 

--- a/app/src/test/java/org/tasks/caldav/iCalendarMergeTest.kt
+++ b/app/src/test/java/org/tasks/caldav/iCalendarMergeTest.kt
@@ -655,6 +655,94 @@ class iCalendarMergeTest {
                 assertEquals("789", it.remoteParent)
             }
 
+    @Test
+    fun remoteSetsEstimated() =
+        newTask()
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 2*60*60)),
+                local = null
+            )
+            .let {
+                assertEquals(2*60*60, it.estimatedSeconds)
+            }
+
+    @Test
+    fun remoteRemovesEstimated() =
+        newTask(with(TaskMaker.ESTIMATED_SECONDS, 2*60*60))
+            .applyRemote(
+                remote = newIcal(),
+                local = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 2*60*60))
+            )
+            .let {
+                assertEquals(0, it.estimatedSeconds)
+            }
+
+    @Test
+    fun localResetsEstimated() =
+        newTask()
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 2*60*60)),
+                local = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 2*60*60))
+            )
+            .let {
+                assertEquals(0, it.estimatedSeconds)
+            }
+
+    @Test
+    fun localBeatsRemoteEstimated() =
+        newTask(with(TaskMaker.ESTIMATED_SECONDS, 2*60*60))
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 4*60*60)),
+                local = newIcal(with(iCalMaker.ESTIMATED_SECONDS, 3*60*60))
+            )
+            .let {
+                assertEquals(2*60*60, it.estimatedSeconds)
+            }
+
+    @Test
+    fun remoteSetsElapsed() =
+        newTask()
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ELAPSED_SECONDS, 2*60*60)),
+                local = null
+            )
+            .let {
+                assertEquals(2*60*60, it.elapsedSeconds)
+            }
+
+    @Test
+    fun remoteRemovesElapsed() =
+        newTask(with(TaskMaker.ELAPSED_SECONDS, 2*60*60))
+            .applyRemote(
+                remote = newIcal(),
+                local = newIcal(with(iCalMaker.ELAPSED_SECONDS, 2*60*60))
+            )
+            .let {
+                assertEquals(0, it.elapsedSeconds)
+            }
+
+    @Test
+    fun localResetsElapsed() =
+        newTask()
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ELAPSED_SECONDS, 2*60*60)),
+                local = newIcal(with(iCalMaker.ELAPSED_SECONDS, 2*60*60))
+            )
+            .let {
+                assertEquals(0, it.elapsedSeconds)
+            }
+
+    @Test
+    fun localBeatsRemoteElapsed() =
+        newTask(with(TaskMaker.ELAPSED_SECONDS, 2*60*60))
+            .applyRemote(
+                remote = newIcal(with(iCalMaker.ELAPSED_SECONDS, 4*60*60)),
+                local = newIcal(with(iCalMaker.ELAPSED_SECONDS, 3*60*60))
+            )
+            .let {
+                assertEquals(2*60*60, it.elapsedSeconds)
+            }
+
     companion object {
         private fun DateTime.allDay() =
             createDueDate(URGENCY_SPECIFIC_DAY, millis)

--- a/app/src/test/java/org/tasks/makers/TaskMaker.kt
+++ b/app/src/test/java/org/tasks/makers/TaskMaker.kt
@@ -35,6 +35,8 @@ object TaskMaker {
     val COLLAPSED: Property<Task, Boolean> = newProperty()
     val DESCRIPTION: Property<Task, String?> = newProperty()
     val ORDER: Property<Task, Long> = newProperty()
+    val ESTIMATED_SECONDS: Property<Task, Int> = newProperty()
+    val ELAPSED_SECONDS: Property<Task, Int> = newProperty()
 
     private val instantiator = Instantiator { lookup: PropertyLookup<Task> ->
         val creationTime = lookup.valueOf(CREATION_TIME, DateTimeUtils.newDateTime())
@@ -62,6 +64,8 @@ object TaskMaker {
             order = lookup.valueOf(ORDER, null as Long?),
             creationDate = creationTime.millis,
             modificationDate = lookup.valueOf(MODIFICATION_TIME, creationTime).millis,
+            estimatedSeconds = lookup.valueOf(ESTIMATED_SECONDS, 0),
+            elapsedSeconds = lookup.valueOf(ELAPSED_SECONDS, 0)
         )
         lookup.valueOf(START_DATE, null as DateTime?)?.let {
             task.hideUntil = task.createHideUntil(HIDE_UNTIL_SPECIFIC_DAY, it.millis)

--- a/app/src/test/java/org/tasks/makers/iCalMaker.kt
+++ b/app/src/test/java/org/tasks/makers/iCalMaker.kt
@@ -14,6 +14,8 @@ import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.Status
 import org.tasks.caldav.iCalendar
 import org.tasks.caldav.iCalendar.Companion.collapsed
+import org.tasks.caldav.iCalendar.Companion.elapsedSeconds
+import org.tasks.caldav.iCalendar.Companion.estimatedSeconds
 import org.tasks.caldav.iCalendar.Companion.order
 import org.tasks.caldav.iCalendar.Companion.parent
 import org.tasks.time.DateTime
@@ -35,6 +37,8 @@ object iCalMaker {
     val COLLAPSED: Property<Task, Boolean> = newProperty()
     val RRULE: Property<Task, String?> = newProperty()
     val STATUS: Property<Task, Status?> = newProperty()
+    val ESTIMATED_SECONDS: Property<Task, Int> = newProperty()
+    val ELAPSED_SECONDS: Property<Task, Int> = newProperty()
 
     private val instantiator = Instantiator { lookup: PropertyLookup<Task> ->
         val task = Task()
@@ -65,6 +69,8 @@ object iCalMaker {
         task.collapsed = lookup.valueOf(COLLAPSED, false)
         task.rRule = lookup.valueOf(RRULE, null as String?)?.let { RRule(it) }
         task.status = lookup.valueOf(STATUS, null as Status?)
+        task.estimatedSeconds = lookup.valueOf(ESTIMATED_SECONDS, 0)
+        task.elapsedSeconds = lookup.valueOf(ELAPSED_SECONDS, 0)
         task
     }
     fun newIcal(vararg properties: PropertyValue<in Task?, *>): Task {


### PR DESCRIPTION
This pull request addresses #3780 and implements the described behavior.

## New Features
- map `estimatedSeconds` and `elapsedSeconds` to VTODO properties `X-TASKS-ESTIMATED-SECONDS` and `X-TASKS-ELAPSED-SECONDS`
- implemented all operations, so it uploads, updates and removes these properties
- this enables sync using existing CalDAV

## Testing
- added tests for all operations

## Migration
I added a migration to the Upgrader. As these custom properties do currently not exist, we only need to upload existing local tasks that have the properties set. I did this using the `.touch()` function to change the modification time, I think, this should work fine.

\
Thank you again for your quick response for my request and the great instructions where to start. \
Feel free to provide feedback if anything is missing, I am open to add some changes.