### PR TITLE
Notification swipe/clear behavior on recurring events (advance not co…

### DIFF
--- a/app/src/main/java/org/tasks/notifications/NotificationClearedReceiver.kt
+++ b/app/src/main/java/org/tasks/notifications/NotificationClearedReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.todoroo.astrid.alarms.AlarmService
+import com.todoroo.astrid.repeats.RepeatTaskHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -22,6 +23,7 @@ class NotificationClearedReceiver : BroadcastReceiver() {
     @Inject lateinit var preferences: Preferences
     @Inject lateinit var alarmService: AlarmService
     @Inject lateinit var firebase: Firebase
+    @Inject lateinit var repeatTaskHelper: RepeatTaskHelper
 
     override fun onReceive(context: Context, intent: Intent) {
         val notificationId = intent.getLongExtra(NotificationManager.EXTRA_NOTIFICATION_ID, -1L)
@@ -41,6 +43,9 @@ class NotificationClearedReceiver : BroadcastReceiver() {
             } else {
                 firebase.logEvent(R.string.event_notification, R.string.param_type to "clear")
                 notificationManager.cancel(notificationId)
+                // For recurring tasks, advance to next occurrence so the reminder will fire again.
+                // Swipe/clear should only dismiss this instance, not suppress future reminders.
+                repeatTaskHelper.advanceToNextOccurrence(notificationId)
             }
         }
     }

--- a/app/src/test/java/com/todoroo/astrid/repeats/RepeatTaskHelperTests.kt
+++ b/app/src/test/java/com/todoroo/astrid/repeats/RepeatTaskHelperTests.kt
@@ -1,6 +1,7 @@
 package com.todoroo.astrid.repeats
 
 import com.natpryce.makeiteasy.MakeItEasy.with
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -63,5 +64,42 @@ class RepeatTaskHelperTests : RepeatTests() {
         }
 
         assertEquals(newDay(2021, 2, 2), next)
+    }
+
+    @Test
+    fun advanceToNextOccurrenceWithoutCompleting() = runBlocking {
+        val task = newFromDue(
+                "FREQ=DAILY;INTERVAL=1",
+                newDayTime(2017, 10, 4, 13, 30),
+                with(COMPLETION_TIME, null as DateTime?)
+        )
+        task.id = 1L
+        task.completionDate = 0L
+        task.reminderLast = newDayTime(2017, 10, 4, 13, 30).millis
+
+        val result = advanceToNextOccurrence(1L, task)
+
+        assertTrue(result)
+        assertEquals(newDayTime(2017, 10, 5, 13, 30).millis, task.dueDate)
+        assertEquals(0L, task.reminderLast)
+        assertEquals(0L, task.completionDate)
+    }
+
+    @Test
+    fun advanceToNextOccurrenceReturnsFalseForNonRecurringTask() = runBlocking {
+        val task = newFromDue(
+                "FREQ=DAILY;INTERVAL=1",
+                newDayTime(2017, 10, 4, 13, 30),
+                with(COMPLETION_TIME, null as DateTime?)
+        )
+        task.id = 2L
+        task.completionDate = 0L
+        task.recurrence = null
+        task.reminderLast = newDayTime(2017, 10, 4, 13, 30).millis
+
+        val result = advanceToNextOccurrence(2L, task)
+
+        assertFalse(result)
+        assertEquals(newDayTime(2017, 10, 4, 13, 30).millis, task.dueDate)
     }
 }


### PR DESCRIPTION
…mplete

Changes Made

  1. 'RepeatTaskHelper.kt' – Added advanceToNextOccurrence(taskId) that: • Advances the due date to the next recurrence without completing the task • Resets reminderLast so the next reminder can fire • Reuses the same recurrence logic as handleRepeat (count, RRULE, etc.) • Skips read-only tasks and CalDAV accounts with isSuppressRepeatingTasks
  2. 'NotificationClearedReceiver.kt' – When the user dismisses without snoozing: • Cancels the notification (unchanged) • Calls advanceToNextOccurrence(taskId) for recurring tasks

  Behavior notes:
  • Swipe to snooze ON: Swipe still snoozes and shows the reminder again later; no change.
  • Swipe to snooze OFF: Swipe dismisses and, for recurring tasks, advances to the next occurrence so the next reminder is scheduled.
  • Complete: Still completes the current instance and advances to the next (unchanged).