### PR TITLE
feat: prioritize earlier-made tasks in smart sort

### DIFF
--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/core/SortHelper.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/core/SortHelper.kt
@@ -56,6 +56,24 @@ object SortHelper {
     private val ORDER_LIST = asc(upper(CaldavCalendar.ORDER))
         .addSecondaryExpression(asc(CaldavCalendar.NAME))
 
+    private const val SMART_ORDER = ("(CASE WHEN (dueDate=0) "
+            +  // if no due date
+            "THEN (strftime('%s','now')*1000)*2 "
+            +  // then now * 2
+            "ELSE ("
+            + ADJUSTED_DUE_DATE
+            + ") END) "
+            +  // else due time
+            // add slightly less than 2 days * importance to give due date priority over importance in case of tie
+            "+ 172799999 * importance "
+            + // if all else is equal, prioritize tasks that have been waiting for longer
+            "+ (CASE WHEN hideUntil != 0 then hideUntil ELSE created END) / 1000")
+    private val RECURSIVE_SMART_ORDER = SMART_ORDER
+        .replace("dueDate", "tasks.dueDate")
+        .replace("importance", "tasks.importance")
+        .replace("hideUntil", "tasks.hideUntil")
+        .replace("created", "tasks.created")
+
     /** Takes a SQL query, and if there isn't already an order, creates an order.  */
     fun adjustQueryForFlagsAndSort(
         preferences: QueryPreferences, originalSql: String?, sort: Int
@@ -110,18 +128,7 @@ object SortHelper {
             SORT_MODIFIED -> desc(Task.MODIFICATION_DATE)
             SORT_CREATED -> desc(Task.CREATION_DATE)
             SORT_LIST -> ORDER_LIST
-            else -> asc(
-                "(CASE WHEN (dueDate=0) "
-                        +  // if no due date
-                        "THEN (strftime('%s','now')*1000)*2 "
-                        +  // then now * 2
-                        "ELSE ("
-                        + ADJUSTED_DUE_DATE
-                        + ") END) "
-                        +  // else due time
-                        // add slightly less than 2 days * importance to give due date priority over importance in case of tie
-                        "+ 172799999 * importance"
-            )
+            else -> asc(SMART_ORDER)
         }
         if (sortType != SORT_ALPHA) {
             order.addSecondaryExpression(ORDER_TITLE)
@@ -159,16 +166,7 @@ object SortHelper {
             SORT_CALDAV -> CALDAV_ORDER_COLUMN
             SORT_LIST -> "CASE WHEN cdl_order = -1 THEN cdl_name ELSE cdl_order END"
             SORT_COMPLETED -> "tasks.completed"
-            else -> ("(CASE WHEN (tasks.dueDate=0) "
-                    +  // if no due date
-                    "THEN (strftime('%s','now')*1000)*2 "
-                    +  // then now * 2
-                    "ELSE ("
-                    + ADJUSTED_DUE_DATE.replace("dueDate", "tasks.dueDate")
-                    + ") END) "
-                    +  // else due time
-                    // add slightly less than 2 days * importance to give due date priority over importance in case of tie
-                    "+ 172799999 * tasks.importance")
+            else -> RECURSIVE_SMART_ORDER
         }
     }
 

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/core/SortHelper.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/core/SortHelper.kt
@@ -12,6 +12,7 @@ import org.tasks.db.QueryUtils.showCompleted
 import org.tasks.db.QueryUtils.showHidden
 import org.tasks.preferences.QueryPreferences
 
+@Suppress("StringLiteralDuplication")
 object SortHelper {
     const val GROUP_NONE: Int = -1
     const val SORT_AUTO: Int = 0


### PR DESCRIPTION
Adjusts the smart sort algorithm so that if two tasks have the same priority and due date, the ones that have been waiting for longer will be shown higher. This helps prioritize tasks that you've been putting off.

Closes #4188