### PR TITLE
Fixed: "Clear completed" option now uses sentence case

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,7 +135,7 @@ File %1$s contained %2$s.\n\n
   <string name="gcal_completed_title">%s (completed)</string>
   <string name="CFC_gtasks_list_text">In List: ?</string>
   <string name="CFC_list_name">In list…</string>
-  <string name="gtasks_GTA_clear_completed">Clear Completed</string>
+  <string name="gtasks_GTA_clear_completed">Clear completed</string>
   <string name="gtasks_GLA_authenticating">Authenticating…</string>
   <string name="gtasks_GLA_errorIOAuth">Sorry, we had trouble communicating with Google servers. Please try again later.</string>
   <string name="gtasks_GPr_header">Google Tasks</string>


### PR DESCRIPTION
Full disclosure: I'm not an engineer. I'm just savvy enough with version control and a text editor to be dangerous.

But I think this is a pretty simple fix. I've noticed that "Completed" was capitalized in "Clear Completed" when the other options in this menu weren't. Figured I'd fix this myself. 🙂 