### PR TITLE
Clear stale notifications

### DIFF
--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/caldav/iCalendar.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/caldav/iCalendar.kt
@@ -240,7 +240,7 @@ class iCalendar(
         caldavTask.applyRemote(remote, local)
         val remoteModificationDate = task.modificationDate
 
-        if ((remote.lastAck ?: 0) > task.reminderLast) {
+        if ((remote.lastAck ?: 0) > task.reminderLast || task.isCompleted || task.isDeleted) {
             notifier.cancel(task.id)
         }
 


### PR DESCRIPTION
Clears existing notification when the remote source task has been completed or deleted. Fixes #3089.

It should be noted that even with this fix, the sync interval is 60 minutes, so it could take some time for the notification to clear on its own. I plan on opening another PR in the future to add a configurable sync interval, allowing the notification clearing to occur sooner (at the expense of some battery life depending on specific values). However, I feel that is a separate concern which doesn't really belong with the clearing logic update.