### PR TITLE
implement About screen for desktop

### DIFF
--- a/app/src/main/java/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
+++ b/app/src/main/java/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
@@ -39,223 +39,227 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
+data class HelpAndFeedbackCallbacks(
+    val onWhatsNew: () -> Unit = {},
+    val onRateTasks: () -> Unit = {},
+    val onDocumentation: () -> Unit = {},
+    val onIssueTracker: () -> Unit = {},
+    val onContactDeveloper: () -> Unit = {},
+    val onSendLogs: () -> Unit = {},
+    val onReddit: () -> Unit = {},
+    val onTwitter: () -> Unit = {},
+    val onSourceCode: () -> Unit = {},
+    val onThirdPartyLicenses: () -> Unit = {},
+    val onTermsOfService: () -> Unit = {},
+    val onPrivacyPolicy: () -> Unit = {},
+    val onBlogFeedModeClick: () -> Unit = {},
+    val onCollectStatisticsChanged: (Boolean) -> Unit = {},
+)
+
 @Composable
 fun HelpAndFeedbackScreen(
     versionName: String,
     isGooglePlay: Boolean,
     showTermsOfService: Boolean,
     collectStatistics: Boolean,
-    onWhatsNew: () -> Unit,
-    onRateTasks: () -> Unit,
-    onDocumentation: () -> Unit,
-    onIssueTracker: () -> Unit,
-    onContactDeveloper: () -> Unit,
-    onSendLogs: () -> Unit,
-    onReddit: () -> Unit,
-    onTwitter: () -> Unit,
-    onSourceCode: () -> Unit,
-    onThirdPartyLicenses: () -> Unit,
-    onTermsOfService: () -> Unit,
-    onPrivacyPolicy: () -> Unit,
+    callbacks: HelpAndFeedbackCallbacks = HelpAndFeedbackCallbacks(),
     blogFeedMode: BlogFeedMode,
-    onBlogFeedModeClick: () -> Unit,
-    onCollectStatisticsChanged: (Boolean) -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surface)
-            .verticalScroll(rememberScrollState())
     ) {
-        Spacer(modifier = Modifier.height(SettingsContentPadding))
-
-        // Top items
         Column(
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+                .verticalScroll(rememberScrollState())
         ) {
-            SettingsItemCard(position = CardPosition.First) {
-                PreferenceRow(
-                    title = stringResource(R.string.whats_new),
-                    icon = Icons.Outlined.NewReleases,
-                    summary = stringResource(R.string.version_string, versionName),
-                    onClick = onWhatsNew,
-                )
-            }
-            SettingsItemCard(
-                position = if (isGooglePlay) CardPosition.Middle else CardPosition.Last,
+            Spacer(modifier = Modifier.height(SettingsContentPadding))
+
+            // Top items
+            Column(
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+                verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
             ) {
-                PreferenceRow(
-                    title = stringResource(R.string.blog_notifications),
-                    icon = Icons.Outlined.RssFeed,
-                    summary = stringResource(
-                        when (blogFeedMode) {
-                            BlogFeedMode.NONE -> R.string.blog_feed_none
-                            BlogFeedMode.ANNOUNCEMENTS -> R.string.blog_feed_announcements
-                            BlogFeedMode.ALL -> R.string.blog_feed_all
-                        }
-                    ),
-                    onClick = onBlogFeedModeClick,
-                )
-            }
-            if (isGooglePlay) {
-                SettingsItemCard(position = CardPosition.Last) {
-                    PreferenceRow(
-                        title = stringResource(R.string.rate_tasks),
-                        icon = Icons.Outlined.StarBorder,
-                        onClick = onRateTasks,
-                    )
-                }
-            }
-        }
-
-        // Support section
-        SectionHeader(
-            R.string.support,
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
-        ) {
-            SettingsItemCard(position = CardPosition.First) {
-                PreferenceRow(
-                    title = stringResource(R.string.documentation),
-                    icon = Icons.AutoMirrored.Outlined.HelpOutline,
-                    onClick = onDocumentation,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Middle) {
-                PreferenceRow(
-                    title = stringResource(R.string.issue_tracker),
-                    icon = Icons.Outlined.BugReport,
-                    onClick = onIssueTracker,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Middle) {
-                PreferenceRow(
-                    title = stringResource(R.string.contact_developer),
-                    icon = Icons.Outlined.Email,
-                    onClick = onContactDeveloper,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Last) {
-                PreferenceRow(
-                    title = stringResource(R.string.send_application_logs),
-                    icon = Icons.Outlined.Attachment,
-                    onClick = onSendLogs,
-                )
-            }
-        }
-
-        // Social section
-        SectionHeader(
-            R.string.social,
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
-        ) {
-            SettingsItemCard(position = CardPosition.First) {
-                PreferenceRow(
-                    title = stringResource(R.string.follow_reddit),
-                    iconRes = R.drawable.ic_reddit_share_silhouette,
-                    onClick = onReddit,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Last) {
-                PreferenceRow(
-                    title = stringResource(R.string.follow_twitter),
-                    iconRes = R.drawable.ic_twitter_logo_black,
-                    onClick = onTwitter,
-                )
-            }
-        }
-
-        // Open Source section
-        SectionHeader(
-            R.string.open_source,
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
-        ) {
-            SettingsItemCard(
-                position = if (isGooglePlay) CardPosition.First else CardPosition.Only,
-            ) {
-                PreferenceRow(
-                    title = stringResource(R.string.source_code),
-                    iconRes = R.drawable.ic_octocat,
-                    summary = stringResource(R.string.license_summary),
-                    onClick = onSourceCode,
-                )
-            }
-            if (isGooglePlay) {
-                SettingsItemCard(position = CardPosition.Last) {
-                    PreferenceRow(
-                        title = stringResource(R.string.third_party_licenses),
-                        icon = Icons.Outlined.Gavel,
-                        onClick = onThirdPartyLicenses,
-                    )
-                }
-            }
-        }
-
-        // Legal section
-        SectionHeader(
-            R.string.legal,
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = SettingsContentPadding),
-            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
-        ) {
-            if (showTermsOfService) {
                 SettingsItemCard(position = CardPosition.First) {
                     PreferenceRow(
-                        title = stringResource(R.string.terms_of_service),
-                        icon = Icons.Outlined.Gavel,
-                        onClick = onTermsOfService,
+                        title = stringResource(R.string.whats_new),
+                        icon = Icons.Outlined.NewReleases,
+                        summary = stringResource(R.string.version_string, versionName),
+                        onClick = callbacks.onWhatsNew,
+                    )
+                }
+                SettingsItemCard(
+                    position = if (isGooglePlay) CardPosition.Middle else CardPosition.Last,
+                ) {
+                    PreferenceRow(
+                        title = stringResource(R.string.blog_notifications),
+                        icon = Icons.Outlined.RssFeed,
+                        summary = stringResource(
+                            when (blogFeedMode) {
+                                BlogFeedMode.NONE -> R.string.blog_feed_none
+                                BlogFeedMode.ANNOUNCEMENTS -> R.string.blog_feed_announcements
+                                BlogFeedMode.ALL -> R.string.blog_feed_all
+                            }
+                        ),
+                        onClick = callbacks.onBlogFeedModeClick,
+                    )
+                }
+                if (isGooglePlay) {
+                    SettingsItemCard(position = CardPosition.Last) {
+                        PreferenceRow(
+                            title = stringResource(R.string.rate_tasks),
+                            icon = Icons.Outlined.StarBorder,
+                            onClick = callbacks.onRateTasks,
+                        )
+                    }
+                }
+            }
+
+            // Support section
+            SectionHeader(
+                R.string.support,
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+                verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+            ) {
+                SettingsItemCard(position = CardPosition.First) {
+                    PreferenceRow(
+                        title = stringResource(R.string.documentation),
+                        icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                        onClick = callbacks.onDocumentation,
+                    )
+                }
+                SettingsItemCard(position = CardPosition.Middle) {
+                    PreferenceRow(
+                        title = stringResource(R.string.issue_tracker),
+                        icon = Icons.Outlined.BugReport,
+                        onClick = callbacks.onIssueTracker,
+                    )
+                }
+                SettingsItemCard(position = CardPosition.Middle) {
+                    PreferenceRow(
+                        title = stringResource(R.string.contact_developer),
+                        icon = Icons.Outlined.Email,
+                        onClick = callbacks.onContactDeveloper,
                     )
                 }
                 SettingsItemCard(position = CardPosition.Last) {
                     PreferenceRow(
-                        title = stringResource(R.string.privacy_policy),
-                        icon = Icons.Outlined.PermIdentity,
-                        onClick = onPrivacyPolicy,
+                        title = stringResource(R.string.send_application_logs),
+                        icon = Icons.Outlined.Attachment,
+                        onClick = callbacks.onSendLogs,
                     )
                 }
-            } else {
-                SettingsItemCard {
+            }
+
+            // Social section
+            SectionHeader(
+                R.string.social,
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+                verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+            ) {
+                SettingsItemCard(position = CardPosition.First) {
                     PreferenceRow(
-                        title = stringResource(R.string.privacy_policy),
-                        icon = Icons.Outlined.PermIdentity,
-                        onClick = onPrivacyPolicy,
+                        title = stringResource(R.string.follow_reddit),
+                        iconRes = R.drawable.ic_reddit_share_silhouette,
+                        onClick = callbacks.onReddit,
+                    )
+                }
+                SettingsItemCard(position = CardPosition.Last) {
+                    PreferenceRow(
+                        title = stringResource(R.string.follow_twitter),
+                        iconRes = R.drawable.ic_twitter_logo_black,
+                        onClick = callbacks.onTwitter,
                     )
                 }
             }
-        }
 
-        // Statistics toggle
-        if (isGooglePlay) {
-            Spacer(modifier = Modifier.height(SettingsContentPadding))
-            SettingsItemCard(modifier = Modifier.padding(horizontal = SettingsContentPadding)) {
-                SwitchPreferenceRow(
-                    title = stringResource(R.string.send_anonymous_statistics),
-                    icon = Icons.Outlined.BugReport,
-                    summary = stringResource(R.string.send_anonymous_statistics_summary),
-                    checked = collectStatistics,
-                    onCheckedChange = onCollectStatisticsChanged,
-                )
+            // Open Source section
+            SectionHeader(
+                R.string.open_source,
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+                verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+            ) {
+                SettingsItemCard(
+                    position = if (isGooglePlay) CardPosition.First else CardPosition.Only,
+                ) {
+                    PreferenceRow(
+                        title = stringResource(R.string.source_code),
+                        iconRes = R.drawable.ic_octocat,
+                        summary = stringResource(R.string.license_summary),
+                        onClick = callbacks.onSourceCode,
+                    )
+                }
+                if (isGooglePlay) {
+                    SettingsItemCard(position = CardPosition.Last) {
+                        PreferenceRow(
+                            title = stringResource(R.string.third_party_licenses),
+                            icon = Icons.Outlined.Gavel,
+                            onClick = callbacks.onThirdPartyLicenses,
+                        )
+                    }
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(SettingsContentPadding))
-        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+            // Legal section
+            SectionHeader(
+                R.string.legal,
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = SettingsContentPadding),
+                verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+            ) {
+                if (showTermsOfService) {
+                    SettingsItemCard(position = CardPosition.First) {
+                        PreferenceRow(
+                            title = stringResource(R.string.terms_of_service),
+                            icon = Icons.Outlined.Gavel,
+                            onClick = callbacks.onTermsOfService,
+                        )
+                    }
+                    SettingsItemCard(position = CardPosition.Last) {
+                        PreferenceRow(
+                            title = stringResource(R.string.privacy_policy),
+                            icon = Icons.Outlined.PermIdentity,
+                            onClick = callbacks.onPrivacyPolicy,
+                        )
+                    }
+                } else {
+                    SettingsItemCard {
+                        PreferenceRow(
+                            title = stringResource(R.string.privacy_policy),
+                            icon = Icons.Outlined.PermIdentity,
+                            onClick = callbacks.onPrivacyPolicy,
+                        )
+                    }
+                }
+            }
+
+            // Statistics toggle
+            if (isGooglePlay) {
+                Spacer(modifier = Modifier.height(SettingsContentPadding))
+                SettingsItemCard(modifier = Modifier.padding(horizontal = SettingsContentPadding)) {
+                    SwitchPreferenceRow(
+                        title = stringResource(R.string.send_anonymous_statistics),
+                        icon = Icons.Outlined.BugReport,
+                        summary = stringResource(R.string.send_anonymous_statistics_summary),
+                        checked = collectStatistics,
+                        onCheckedChange = callbacks.onCollectStatisticsChanged,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(SettingsContentPadding))
+            Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+        }
     }
-}
 
 @Composable
 fun BlogFeedModeDialog(

--- a/app/src/main/java/org/tasks/preferences/fragments/HelpAndFeedback.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/HelpAndFeedback.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.tasks.R
 import org.tasks.compose.settings.BlogFeedModeDialog
+import org.tasks.compose.settings.HelpAndFeedbackCallbacks
 import org.tasks.compose.settings.HelpAndFeedbackScreen
 import org.tasks.extensions.Context.openUri
 import org.tasks.preferences.BasePreferences
@@ -52,83 +53,85 @@ class HelpAndFeedback : Fragment() {
                 isGooglePlay = viewModel.isGooglePlay,
                 showTermsOfService = viewModel.showTermsOfService,
                 collectStatistics = viewModel.collectStatistics,
-                onWhatsNew = {
-                    viewModel.logEvent("whats_new")
-                    context?.openUri(R.string.url_changelog)
-                },
-                onRateTasks = {
-                    viewModel.logEvent("rate_tasks")
-                    context?.openUri(R.string.market_url)
-                },
-                onDocumentation = {
-                    viewModel.logEvent("documentation")
-                    context?.openUri(R.string.url_documentation)
-                },
-                onIssueTracker = {
-                    viewModel.logEvent("issue_tracker")
-                    context?.openUri(R.string.url_issue_tracker)
-                },
-                onContactDeveloper = {
-                    viewModel.logEvent("contact_developer")
-                    val uri = Uri.fromParts(
-                        "mailto",
-                        "Alex <${getString(R.string.support_email)}>",
-                        null
-                    )
-                    val intent = Intent(Intent.ACTION_SENDTO, uri)
-                        .putExtra(Intent.EXTRA_SUBJECT, "Tasks Feedback")
-                        .putExtra(Intent.EXTRA_TEXT, viewModel.debugInfo)
-                    startActivity(intent)
-                },
-                onSendLogs = {
-                    viewModel.logEvent("send_logs")
-                    lifecycleScope.launch {
-                        val file = FileProvider.getUriForFile(
-                            requireContext(),
-                            Constants.FILE_PROVIDER_AUTHORITY,
-                            viewModel.getLogZipFile()
-                        )
-                        val intent = Intent(Intent.ACTION_SEND)
-                            .setType("message/rfc822")
-                            .putExtra(Intent.EXTRA_EMAIL, arrayOf(getString(R.string.support_email)))
-                            .putExtra(Intent.EXTRA_SUBJECT, "Tasks logs")
-                            .putExtra(Intent.EXTRA_TEXT, viewModel.debugInfo)
-                            .putExtra(Intent.EXTRA_STREAM, file)
-                            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                        startActivity(intent)
-                    }
-                },
-                onReddit = {
-                    viewModel.logEvent("reddit")
-                    context?.openUri(R.string.url_reddit)
-                },
-                onTwitter = {
-                    viewModel.logEvent("twitter")
-                    context?.openUri(R.string.url_twitter)
-                },
-                onSourceCode = {
-                    viewModel.logEvent("source_code")
-                    context?.openUri(R.string.url_source_code)
-                },
-                onThirdPartyLicenses = {
-                    viewModel.logEvent("third_party_licenses")
-                    val intent = Intent()
-                        .setClassName(requireContext(), "com.google.android.gms.oss.licenses.OssLicensesMenuActivity")
-                    startActivity(intent)
-                },
-                onTermsOfService = {
-                    viewModel.logEvent("tos")
-                    context?.openUri(runBlocking { org.jetbrains.compose.resources.getString(Res.string.url_tos) })
-                },
-                onPrivacyPolicy = {
-                    viewModel.logEvent("privacy_policy")
-                    context?.openUri(runBlocking { org.jetbrains.compose.resources.getString(Res.string.url_privacy_policy) })
-                },
                 blogFeedMode = viewModel.blogFeedMode,
-                onBlogFeedModeClick = { viewModel.showBlogFeedModeDialog() },
-                onCollectStatisticsChanged = { enabled ->
-                    viewModel.updateCollectStatistics(enabled)
-                },
+                callbacks = HelpAndFeedbackCallbacks(
+                    onWhatsNew = {
+                        viewModel.logEvent("whats_new")
+                        context?.openUri(R.string.url_changelog)
+                    },
+                    onRateTasks = {
+                        viewModel.logEvent("rate_tasks")
+                        context?.openUri(R.string.market_url)
+                    },
+                    onDocumentation = {
+                        viewModel.logEvent("documentation")
+                        context?.openUri(R.string.url_documentation)
+                    },
+                    onIssueTracker = {
+                        viewModel.logEvent("issue_tracker")
+                        context?.openUri(R.string.url_issue_tracker)
+                    },
+                    onContactDeveloper = {
+                        viewModel.logEvent("contact_developer")
+                        val uri = Uri.fromParts(
+                            "mailto",
+                            "Alex <${getString(R.string.support_email)}>",
+                            null
+                        )
+                        val intent = Intent(Intent.ACTION_SENDTO, uri)
+                            .putExtra(Intent.EXTRA_SUBJECT, "Tasks Feedback")
+                            .putExtra(Intent.EXTRA_TEXT, viewModel.debugInfo)
+                        startActivity(intent)
+                    },
+                    onSendLogs = {
+                        viewModel.logEvent("send_logs")
+                        lifecycleScope.launch {
+                            val file = FileProvider.getUriForFile(
+                                requireContext(),
+                                Constants.FILE_PROVIDER_AUTHORITY,
+                                viewModel.getLogZipFile()
+                            )
+                            val intent = Intent(Intent.ACTION_SEND)
+                                .setType("message/rfc822")
+                                .putExtra(Intent.EXTRA_EMAIL, arrayOf(getString(R.string.support_email)))
+                                .putExtra(Intent.EXTRA_SUBJECT, "Tasks logs")
+                                .putExtra(Intent.EXTRA_TEXT, viewModel.debugInfo)
+                                .putExtra(Intent.EXTRA_STREAM, file)
+                                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            startActivity(intent)
+                        }
+                    },
+                    onReddit = {
+                        viewModel.logEvent("reddit")
+                        context?.openUri(R.string.url_reddit)
+                    },
+                    onTwitter = {
+                        viewModel.logEvent("twitter")
+                        context?.openUri(R.string.url_twitter)
+                    },
+                    onSourceCode = {
+                        viewModel.logEvent("source_code")
+                        context?.openUri(R.string.url_source_code)
+                    },
+                    onThirdPartyLicenses = {
+                        viewModel.logEvent("third_party_licenses")
+                        val intent = Intent()
+                            .setClassName(requireContext(), "com.google.android.gms.oss.licenses.OssLicensesMenuActivity")
+                        startActivity(intent)
+                    },
+                    onTermsOfService = {
+                        viewModel.logEvent("tos")
+                        context?.openUri(runBlocking { org.jetbrains.compose.resources.getString(Res.string.url_tos) })
+                    },
+                    onPrivacyPolicy = {
+                        viewModel.logEvent("privacy_policy")
+                        context?.openUri(runBlocking { org.jetbrains.compose.resources.getString(Res.string.url_privacy_policy) })
+                    },
+                    onBlogFeedModeClick = { viewModel.showBlogFeedModeDialog() },
+                    onCollectStatisticsChanged = { enabled ->
+                        viewModel.updateCollectStatistics(enabled)
+                    },
+                ),
             )
 
             if (viewModel.showRestartDialog) {

--- a/composeApp/src/commonMain/kotlin/org/tasks/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/App.kt
@@ -106,6 +106,7 @@ import org.tasks.compose.settings.CaldavAccountSettingsDetail
 import org.tasks.compose.settings.CaldavAccountSettingsPane
 import org.tasks.compose.settings.EtebaseAccountSettingsDetail
 import org.tasks.compose.settings.EtebaseAccountSettingsPane
+import org.tasks.compose.settings.HelpAndFeedbackScreen
 import org.tasks.compose.settings.LocalAccountSettingsDetail
 import org.tasks.compose.settings.LocalAccountSettingsPane
 import org.tasks.compose.settings.MainSettingsScreen
@@ -1657,32 +1658,45 @@ private fun SettingsScreen(
             ) {
                 when (selectedContent) {
                     is org.tasks.compose.settings.SettingsDestination -> {
-                        Scaffold(
-                            topBar = {
-                                TopAppBar(
-                                    title = {
-                                        Text(stringResource(selectedContent.titleRes))
-                                    },
-                                    navigationIcon = {
-                                        IconButton(
-                                            onClick = {
-                                                scope.launch { navigator.navigateBack() }
-                                            }
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                                contentDescription = stringResource(Res.string.back),
-                                            )
-                                        }
-                                    },
+                        when (selectedContent) {
+                            org.tasks.compose.settings.SettingsDestination.HelpAndFeedback -> {
+                                HelpAndFeedbackScreen(
+                                    onDocumentation = { uriHandler.openUri("https://tasks.org/docs") },
+                                    onIssueTracker = { uriHandler.openUri("https://github.com/tasks/tasks/issues") },
+                                    onContactDeveloper = { uriHandler.openUri("mailto:tasks@tasks.org") },
+                                    onSourceCode = { uriHandler.openUri("https://github.com/tasks/tasks") },
+                                    onPrivacyPolicy = { uriHandler.openUri("https://tasks.org/privacy") },
                                 )
-                            },
-                        ) { padding ->
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(padding),
-                            )
+                            }
+                            else -> {
+                                Scaffold(
+                                    topBar = {
+                                        TopAppBar(
+                                            title = {
+                                                Text(stringResource(selectedContent.titleRes))
+                                            },
+                                            navigationIcon = {
+                                                IconButton(
+                                                    onClick = {
+                                                        scope.launch { navigator.navigateBack() }
+                                                    }
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                                        contentDescription = stringResource(Res.string.back),
+                                                    )
+                                                }
+                                            },
+                                        )
+                                    },
+                                ) { padding ->
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .padding(padding),
+                                    )
+                                }
+                            }
                         }
                     }
                     is LocalAccountSettingsPane -> {

--- a/composeApp/src/commonMain/kotlin/org/tasks/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/App.kt
@@ -106,6 +106,7 @@ import org.tasks.compose.settings.CaldavAccountSettingsDetail
 import org.tasks.compose.settings.CaldavAccountSettingsPane
 import org.tasks.compose.settings.EtebaseAccountSettingsDetail
 import org.tasks.compose.settings.EtebaseAccountSettingsPane
+import org.tasks.compose.settings.HelpAndFeedbackCallbacks
 import org.tasks.compose.settings.HelpAndFeedbackScreen
 import org.tasks.compose.settings.LocalAccountSettingsDetail
 import org.tasks.compose.settings.LocalAccountSettingsPane
@@ -1661,11 +1662,13 @@ private fun SettingsScreen(
                         when (selectedContent) {
                             org.tasks.compose.settings.SettingsDestination.HelpAndFeedback -> {
                                 HelpAndFeedbackScreen(
-                                    onDocumentation = { uriHandler.openUri("https://tasks.org/docs") },
-                                    onIssueTracker = { uriHandler.openUri("https://github.com/tasks/tasks/issues") },
-                                    onContactDeveloper = { uriHandler.openUri("mailto:tasks@tasks.org") },
-                                    onSourceCode = { uriHandler.openUri("https://github.com/tasks/tasks") },
-                                    onPrivacyPolicy = { uriHandler.openUri("https://tasks.org/privacy") },
+                                    callbacks = HelpAndFeedbackCallbacks(
+                                        onDocumentation = { uriHandler.openUri("https://tasks.org/docs") },
+                                        onIssueTracker = { uriHandler.openUri("https://github.com/tasks/tasks/issues") },
+                                        onContactDeveloper = { uriHandler.openUri("mailto:tasks@tasks.org") },
+                                        onSourceCode = { uriHandler.openUri("https://github.com/tasks/tasks") },
+                                        onPrivacyPolicy = { uriHandler.openUri("https://tasks.org/privacy") },
+                                    )
                                 )
                             }
                             else -> {

--- a/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
@@ -21,7 +21,19 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
 import org.tasks.kmp.JvmBuildConfig
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.contact_developer
+import tasks.kmp.generated.resources.documentation
+import tasks.kmp.generated.resources.gplv3_license
+import tasks.kmp.generated.resources.issue_tracker
+import tasks.kmp.generated.resources.legal
+import tasks.kmp.generated.resources.privacy_policy
+import tasks.kmp.generated.resources.source_code
+import tasks.kmp.generated.resources.support
+import tasks.kmp.generated.resources.version_string
+import tasks.kmp.generated.resources.whats_new
 
 @Composable
 fun HelpAndFeedbackScreen(
@@ -47,9 +59,9 @@ fun HelpAndFeedbackScreen(
         ) {
             SettingsItemCard(position = CardPosition.Only) {
                 PreferenceRow(
-                    title = "What's New",
+                    title = stringResource(Res.string.whats_new),
                     icon = Icons.Outlined.NewReleases,
-                    summary = "Version $versionName",
+                    summary = stringResource(Res.string.version_string, versionName),
                     onClick = onDocumentation,
                 )
             }
@@ -57,7 +69,7 @@ fun HelpAndFeedbackScreen(
 
         // Support section
         SectionHeader(
-            "Support",
+            stringResource(Res.string.support),
             modifier = Modifier.padding(horizontal = 16.dp),
         )
         Column(
@@ -66,30 +78,30 @@ fun HelpAndFeedbackScreen(
         ) {
             SettingsItemCard(position = CardPosition.First) {
                 PreferenceRow(
-                    title = "Documentation",
+                    title = stringResource(Res.string.documentation),
                     icon = Icons.Outlined.HelpOutline,
                     onClick = onDocumentation,
                 )
             }
             SettingsItemCard(position = CardPosition.Middle) {
                 PreferenceRow(
-                    title = "Issue Tracker",
+                    title = stringResource(Res.string.issue_tracker),
                     icon = Icons.Outlined.BugReport,
                     onClick = onIssueTracker,
                 )
             }
             SettingsItemCard(position = CardPosition.Middle) {
                 PreferenceRow(
-                    title = "Contact Developer",
+                    title = stringResource(Res.string.contact_developer),
                     icon = Icons.Outlined.Email,
                     onClick = onContactDeveloper,
                 )
             }
             SettingsItemCard(position = CardPosition.Last) {
                 PreferenceRow(
-                    title = "Source Code",
+                    title = stringResource(Res.string.source_code),
                     icon = Icons.Outlined.NewReleases,
-                    summary = "GPLv3 License",
+                    summary = stringResource(Res.string.gplv3_license),
                     onClick = onSourceCode,
                 )
             }
@@ -97,7 +109,7 @@ fun HelpAndFeedbackScreen(
 
         // Legal section
         SectionHeader(
-            "Legal",
+            stringResource(Res.string.legal),
             modifier = Modifier.padding(horizontal = 16.dp),
         )
         Column(
@@ -106,7 +118,7 @@ fun HelpAndFeedbackScreen(
         ) {
             SettingsItemCard(position = CardPosition.Only) {
                 PreferenceRow(
-                    title = "Privacy Policy",
+                    title = stringResource(Res.string.privacy_policy),
                     icon = Icons.Outlined.PermIdentity,
                     onClick = onPrivacyPolicy,
                 )

--- a/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
@@ -35,14 +35,18 @@ import tasks.kmp.generated.resources.support
 import tasks.kmp.generated.resources.version_string
 import tasks.kmp.generated.resources.whats_new
 
+data class HelpAndFeedbackCallbacks(
+    val onDocumentation: () -> Unit = {},
+    val onIssueTracker: () -> Unit = {},
+    val onContactDeveloper: () -> Unit = {},
+    val onSourceCode: () -> Unit = {},
+    val onPrivacyPolicy: () -> Unit = {},
+)
+
 @Composable
 fun HelpAndFeedbackScreen(
     versionName: String = JvmBuildConfig.VERSION_NAME,
-    onDocumentation: () -> Unit = {},
-    onIssueTracker: () -> Unit = {},
-    onContactDeveloper: () -> Unit = {},
-    onSourceCode: () -> Unit = {},
-    onPrivacyPolicy: () -> Unit = {},
+    callbacks: HelpAndFeedbackCallbacks = HelpAndFeedbackCallbacks(),
 ) {
     Column(
         modifier = Modifier
@@ -51,80 +55,93 @@ fun HelpAndFeedbackScreen(
             .verticalScroll(rememberScrollState())
     ) {
         Spacer(modifier = Modifier.height(16.dp))
-
-        // Version info
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            SettingsItemCard(position = CardPosition.Only) {
-                PreferenceRow(
-                    title = stringResource(Res.string.whats_new),
-                    icon = Icons.Outlined.NewReleases,
-                    summary = stringResource(Res.string.version_string, versionName),
-                    onClick = onDocumentation,
-                )
-            }
-        }
-
-        // Support section
-        SectionHeader(
-            stringResource(Res.string.support),
-            modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            SettingsItemCard(position = CardPosition.First) {
-                PreferenceRow(
-                    title = stringResource(Res.string.documentation),
-                    icon = Icons.Outlined.HelpOutline,
-                    onClick = onDocumentation,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Middle) {
-                PreferenceRow(
-                    title = stringResource(Res.string.issue_tracker),
-                    icon = Icons.Outlined.BugReport,
-                    onClick = onIssueTracker,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Middle) {
-                PreferenceRow(
-                    title = stringResource(Res.string.contact_developer),
-                    icon = Icons.Outlined.Email,
-                    onClick = onContactDeveloper,
-                )
-            }
-            SettingsItemCard(position = CardPosition.Last) {
-                PreferenceRow(
-                    title = stringResource(Res.string.source_code),
-                    icon = Icons.Outlined.NewReleases,
-                    summary = stringResource(Res.string.gplv3_license),
-                    onClick = onSourceCode,
-                )
-            }
-        }
-
-        // Legal section
-        SectionHeader(
-            stringResource(Res.string.legal),
-            modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            SettingsItemCard(position = CardPosition.Only) {
-                PreferenceRow(
-                    title = stringResource(Res.string.privacy_policy),
-                    icon = Icons.Outlined.PermIdentity,
-                    onClick = onPrivacyPolicy,
-                )
-            }
-        }
-
+        VersionInfo(versionName, callbacks.onDocumentation)
+        SupportSection(callbacks.onDocumentation, callbacks.onIssueTracker, callbacks.onContactDeveloper, callbacks.onSourceCode)
+        LegalSection(callbacks.onPrivacyPolicy)
         Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun VersionInfo(versionName: String, onDocumentation: () -> Unit) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        SettingsItemCard(position = CardPosition.Only) {
+            PreferenceRow(
+                title = stringResource(Res.string.whats_new),
+                icon = Icons.Outlined.NewReleases,
+                summary = stringResource(Res.string.version_string, versionName),
+                onClick = onDocumentation,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SupportSection(
+    onDocumentation: () -> Unit,
+    onIssueTracker: () -> Unit,
+    onContactDeveloper: () -> Unit,
+    onSourceCode: () -> Unit,
+) {
+    SectionHeader(
+        stringResource(Res.string.support),
+        modifier = Modifier.padding(horizontal = 16.dp),
+    )
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        SettingsItemCard(position = CardPosition.First) {
+            PreferenceRow(
+                title = stringResource(Res.string.documentation),
+                icon = Icons.Outlined.HelpOutline,
+                onClick = onDocumentation,
+            )
+        }
+        SettingsItemCard(position = CardPosition.Middle) {
+            PreferenceRow(
+                title = stringResource(Res.string.issue_tracker),
+                icon = Icons.Outlined.BugReport,
+                onClick = onIssueTracker,
+            )
+        }
+        SettingsItemCard(position = CardPosition.Middle) {
+            PreferenceRow(
+                title = stringResource(Res.string.contact_developer),
+                icon = Icons.Outlined.Email,
+                onClick = onContactDeveloper,
+            )
+        }
+        SettingsItemCard(position = CardPosition.Last) {
+            PreferenceRow(
+                title = stringResource(Res.string.source_code),
+                icon = Icons.Outlined.NewReleases,
+                summary = stringResource(Res.string.gplv3_license),
+                onClick = onSourceCode,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegalSection(onPrivacyPolicy: () -> Unit) {
+    SectionHeader(
+        stringResource(Res.string.legal),
+        modifier = Modifier.padding(horizontal = 16.dp),
+    )
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        SettingsItemCard(position = CardPosition.Only) {
+            PreferenceRow(
+                title = stringResource(Res.string.privacy_policy),
+                icon = Icons.Outlined.PermIdentity,
+                onClick = onPrivacyPolicy,
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
@@ -1,0 +1,118 @@
+package org.tasks.compose.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Attachment
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material.icons.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.NewReleases
+import androidx.compose.material.icons.outlined.PermIdentity
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.tasks.kmp.JvmBuildConfig
+
+@Composable
+fun HelpAndFeedbackScreen(
+    versionName: String = JvmBuildConfig.VERSION_NAME,
+    onDocumentation: () -> Unit = {},
+    onIssueTracker: () -> Unit = {},
+    onContactDeveloper: () -> Unit = {},
+    onSourceCode: () -> Unit = {},
+    onPrivacyPolicy: () -> Unit = {},
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Version info
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            SettingsItemCard(position = CardPosition.Only) {
+                PreferenceRow(
+                    title = "What's New",
+                    icon = Icons.Outlined.NewReleases,
+                    summary = "Version $versionName",
+                    onClick = onDocumentation,
+                )
+            }
+        }
+
+        // Support section
+        SectionHeader(
+            "Support",
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            SettingsItemCard(position = CardPosition.First) {
+                PreferenceRow(
+                    title = "Documentation",
+                    icon = Icons.Outlined.HelpOutline,
+                    onClick = onDocumentation,
+                )
+            }
+            SettingsItemCard(position = CardPosition.Middle) {
+                PreferenceRow(
+                    title = "Issue Tracker",
+                    icon = Icons.Outlined.BugReport,
+                    onClick = onIssueTracker,
+                )
+            }
+            SettingsItemCard(position = CardPosition.Middle) {
+                PreferenceRow(
+                    title = "Contact Developer",
+                    icon = Icons.Outlined.Email,
+                    onClick = onContactDeveloper,
+                )
+            }
+            SettingsItemCard(position = CardPosition.Last) {
+                PreferenceRow(
+                    title = "Source Code",
+                    icon = Icons.Outlined.NewReleases,
+                    summary = "GPLv3 License",
+                    onClick = onSourceCode,
+                )
+            }
+        }
+
+        // Legal section
+        SectionHeader(
+            "Legal",
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            SettingsItemCard(position = CardPosition.Only) {
+                PreferenceRow(
+                    title = "Privacy Policy",
+                    icon = Icons.Outlined.PermIdentity,
+                    onClick = onPrivacyPolicy,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/kmp/src/commonMain/composeResources/values/strings.xml
+++ b/kmp/src/commonMain/composeResources/values/strings.xml
@@ -259,4 +259,13 @@
     <string name="pricing_sponsor">Or sponsor on GitHub for %1$s</string>
     <string name="already_subscribed">Already a subscriber?</string>
     <string name="sign_in_subtitle">Already a subscriber or invited guest?</string>
+    <string name="whats_new">What's New</string>
+    <string name="version_string">Version %s</string>
+    <string name="support">Support</string>
+    <string name="documentation">Documentation</string>
+    <string name="issue_tracker">Issue tracker</string>
+    <string name="contact_developer">Contact developer</string>
+    <string name="source_code">Source code</string>
+    <string name="legal">Legal</string>
+    <string name="privacy_policy">Privacy policy</string>
 </resources>


### PR DESCRIPTION
This was written entirely by AI, but I have tested it locally on Linux; I was directed to the browser when I clicked on a couple of the links/items that are rendered via `HelpAndFeedbackScreen.kt`.

I am planning to push up more of these scoped PRs, most of which are implementing parts of the Settings pages.