### PR TITLE
Add "2 weeks" and "3 months" filter date options

### DIFF
--- a/app/src/main/java/org/tasks/filters/FilterCriteriaProvider.kt
+++ b/app/src/main/java/org/tasks/filters/FilterCriteriaProvider.kt
@@ -237,7 +237,9 @@ class FilterCriteriaProvider @Inject constructor(
                     PermaSql.VALUE_EOD_TOMORROW,
                     PermaSql.VALUE_EOD_DAY_AFTER,
                     PermaSql.VALUE_EOD_NEXT_WEEK,
+                    PermaSql.VALUE_EOD_NEXT_2_WEEKS,
                     PermaSql.VALUE_EOD_NEXT_MONTH,
+                    PermaSql.VALUE_EOD_NEXT_3_MONTHS,
                     PermaSql.VALUE_NOW)
             val values: MutableMap<String?, Any> = HashMap()
             values[Task.DUE_DATE.name] = "?"
@@ -274,7 +276,9 @@ class FilterCriteriaProvider @Inject constructor(
                     PermaSql.VALUE_EOD_TOMORROW,
                     PermaSql.VALUE_EOD_DAY_AFTER,
                     PermaSql.VALUE_EOD_NEXT_WEEK,
+                    PermaSql.VALUE_EOD_NEXT_2_WEEKS,
                     PermaSql.VALUE_EOD_NEXT_MONTH,
+                    PermaSql.VALUE_EOD_NEXT_3_MONTHS,
                     PermaSql.VALUE_NOW)
             val values: MutableMap<String?, Any> = HashMap()
             values[Task.HIDE_UNTIL.name] = "?"

--- a/app/src/main/java/org/tasks/filters/FilterCriteriaProvider.kt
+++ b/app/src/main/java/org/tasks/filters/FilterCriteriaProvider.kt
@@ -241,7 +241,9 @@ class FilterCriteriaProvider @Inject constructor(
                     PermaSql.VALUE_EOD_TOMORROW,
                     PermaSql.VALUE_EOD_DAY_AFTER,
                     PermaSql.VALUE_EOD_NEXT_WEEK,
+                    PermaSql.VALUE_EOD_NEXT_2_WEEKS,
                     PermaSql.VALUE_EOD_NEXT_MONTH,
+                    PermaSql.VALUE_EOD_NEXT_3_MONTHS,
                     PermaSql.VALUE_NOW)
             val values: MutableMap<String?, Any> = HashMap()
             values[Task.DUE_DATE.name] = "?"
@@ -278,7 +280,9 @@ class FilterCriteriaProvider @Inject constructor(
                     PermaSql.VALUE_EOD_TOMORROW,
                     PermaSql.VALUE_EOD_DAY_AFTER,
                     PermaSql.VALUE_EOD_NEXT_WEEK,
+                    PermaSql.VALUE_EOD_NEXT_2_WEEKS,
                     PermaSql.VALUE_EOD_NEXT_MONTH,
+                    PermaSql.VALUE_EOD_NEXT_3_MONTHS,
                     PermaSql.VALUE_NOW)
             val values: MutableMap<String?, Any> = HashMap()
             values[Task.HIDE_UNTIL.name] = "?"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -53,7 +53,9 @@
     <item>@string/tomorrow</item>
     <item>@string/day_after_tomorrow</item>
     <item>@string/next_week</item>
+    <item>@string/next_2_weeks</item>
     <item>@string/next_month</item>
+    <item>@string/next_3_months</item>
     <item>@string/now</item>
   </string-array>
 
@@ -64,7 +66,9 @@
     <item>@string/tomorrow</item>
     <item>@string/day_after_tomorrow</item>
     <item>@string/next_week</item>
+    <item>@string/next_2_weeks</item>
     <item>@string/next_month</item>
+    <item>@string/next_3_months</item>
     <item>@string/now</item>
   </string-array>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -16,7 +16,9 @@
     <item>@string/tomorrow</item>
     <item>@string/day_after_tomorrow</item>
     <item>@string/next_week</item>
+    <item>@string/next_2_weeks</item>
     <item>@string/next_month</item>
+    <item>@string/next_3_months</item>
     <item>@string/now</item>
   </string-array>
 
@@ -27,7 +29,9 @@
     <item>@string/tomorrow</item>
     <item>@string/day_after_tomorrow</item>
     <item>@string/next_week</item>
+    <item>@string/next_2_weeks</item>
     <item>@string/next_month</item>
+    <item>@string/next_3_months</item>
     <item>@string/now</item>
   </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@ File %1$s contained %2$s.\n\n
   <string name="priority_low">Low</string>
   <string name="day_after_tomorrow">Day after tomorrow</string>
   <string name="next_week">Next week</string>
+  <string name="next_2_weeks">Next 2 weeks</string>
   <string name="no_reminders">No reminders</string>
   <string name="default_location_reminder_on_arrival">On arrival</string>
   <string name="default_location_reminder_on_departure">On departure</string>
@@ -123,6 +124,7 @@ File %1$s contained %2$s.\n\n
   <string name="no_start_date">No start date</string>
   <string name="filter_any_start_date">Any start date</string>
   <string name="next_month">Next Month</string>
+  <string name="next_3_months">Next 3 Months</string>
   <string name="CFC_importance_text">Priority at least ?</string>
   <string name="CFC_importance_name">Priority…</string>
   <string name="CFC_tag_text">Tag: ?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@ File %1$s contained %2$s.\n\n
   <string name="EPr_manage_delete_all_gcal_message">Do you really want to delete all your events for tasks?</string>
   <string name="day_after_tomorrow">Day after tomorrow</string>
   <string name="next_week">Next week</string>
+  <string name="next_2_weeks">Next 2 weeks</string>
   <string name="location_update_interval_summary">Periodic location updates improve geofence reliability</string>
   <string name="BFE_Active">My Tasks</string>
   <string name="BFE_Recent">Recently modified</string>
@@ -99,6 +100,7 @@ File %1$s contained %2$s.\n\n
   <string name="no_start_date">No start date</string>
   <string name="filter_any_start_date">Any start date</string>
   <string name="next_month">Next Month</string>
+  <string name="next_3_months">Next 3 Months</string>
   <string name="CFC_importance_text">Priority at least ?</string>
   <string name="CFC_importance_name">Priority…</string>
   <string name="CFC_tag_text">Tag: ?</string>

--- a/compose-metrics/kmp_release-classes.txt
+++ b/compose-metrics/kmp_release-classes.txt
@@ -23,13 +23,17 @@ stable class PermaSql {
   stable val VALUE_EOD_TOMORROW: String
   stable val VALUE_EOD_DAY_AFTER: String
   stable val VALUE_EOD_NEXT_WEEK: String
+  stable val VALUE_EOD_NEXT_2_WEEKS: String
   stable val VALUE_EOD_NEXT_MONTH: String
+  stable val VALUE_EOD_NEXT_3_MONTHS: String
   stable val VALUE_NOW: String
   stable val VALUE_NOON_YESTERDAY: String
   stable val VALUE_NOON_TOMORROW: String
   stable val VALUE_NOON_DAY_AFTER: String
   stable val VALUE_NOON_NEXT_WEEK: String
+  stable val VALUE_NOON_NEXT_2_WEEKS: String
   stable val VALUE_NOON_NEXT_MONTH: String
+  stable val VALUE_NOON_NEXT_3_MONTHS: String
   <runtime stability> = Stable
 }
 unstable class SortHelper {

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/api/PermaSql.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/api/PermaSql.kt
@@ -36,8 +36,14 @@ object PermaSql {
     /** value to be replaced by end of day next week as long  */
     const val VALUE_EOD_NEXT_WEEK: String = "EODW()" // $NON-NLS-1$
 
+    /** value to be replaced by end of day next 2 weeks as long  */
+    const val VALUE_EOD_NEXT_2_WEEKS: String = "EOD2W()" // $NON-NLS-1$
+
     /** value to be replaced by approximate end of day next month as long  */
     const val VALUE_EOD_NEXT_MONTH: String = "EODM()" // $NON-NLS-1$
+
+    /** value to be replaced by approximate end of day next 3 months as long  */
+    const val VALUE_EOD_NEXT_3_MONTHS: String = "EOD3M()" // $NON-NLS-1$
 
     /** value to be replaced with the current time as long  */
     const val VALUE_NOW: String = "NOW()" // $NON-NLS-1$
@@ -54,8 +60,14 @@ object PermaSql {
     /** value to be replaced by noon next week as long  */
     private const val VALUE_NOON_NEXT_WEEK = "NOONW()" // $NON-NLS-1$
 
+    /** value to be replaced by noon next 2 weeks as long  */
+    private const val VALUE_NOON_NEXT_2_WEEKS = "NOON2W()" // $NON-NLS-1$
+
     /** value to be replaced by approximate noon next month as long  */
     private const val VALUE_NOON_NEXT_MONTH = "NOONM()" // $NON-NLS-1$
+
+    /** value to be replaced by approximate noon next 3 months as long  */
+    private const val VALUE_NOON_NEXT_3_MONTHS = "NOON3M()" // $NON-NLS-1$
 
     /** Replace placeholder strings with actual  */
     fun replacePlaceholdersForQuery(value: String): String {
@@ -66,18 +78,22 @@ object PermaSql {
         if (value.contains(VALUE_EOD)
             || value.contains(VALUE_EOD_DAY_AFTER)
             || value.contains(VALUE_EOD_NEXT_WEEK)
+            || value.contains(VALUE_EOD_NEXT_2_WEEKS)
             || value.contains(VALUE_EOD_TOMORROW)
             || value.contains(VALUE_EOD_YESTERDAY)
             || value.contains(VALUE_EOD_NEXT_MONTH)
+            || value.contains(VALUE_EOD_NEXT_3_MONTHS)
         ) {
             value = replaceEodValues(value)
         }
         if (value.contains(VALUE_NOON)
             || value.contains(VALUE_NOON_DAY_AFTER)
             || value.contains(VALUE_NOON_NEXT_WEEK)
+            || value.contains(VALUE_NOON_NEXT_2_WEEKS)
             || value.contains(VALUE_NOON_TOMORROW)
             || value.contains(VALUE_NOON_YESTERDAY)
             || value.contains(VALUE_NOON_NEXT_MONTH)
+            || value.contains(VALUE_NOON_NEXT_3_MONTHS)
         ) {
             value = replaceNoonValues(value)
         }
@@ -92,18 +108,22 @@ object PermaSql {
         if (value.contains(VALUE_EOD)
             || value.contains(VALUE_EOD_DAY_AFTER)
             || value.contains(VALUE_EOD_NEXT_WEEK)
+            || value.contains(VALUE_EOD_NEXT_2_WEEKS)
             || value.contains(VALUE_EOD_TOMORROW)
             || value.contains(VALUE_EOD_YESTERDAY)
             || value.contains(VALUE_EOD_NEXT_MONTH)
+            || value.contains(VALUE_EOD_NEXT_3_MONTHS)
         ) {
             value = replaceEodValues(value, currentTimeMillis().noon())
         }
         if (value.contains(VALUE_NOON)
             || value.contains(VALUE_NOON_DAY_AFTER)
             || value.contains(VALUE_NOON_NEXT_WEEK)
+            || value.contains(VALUE_NOON_NEXT_2_WEEKS)
             || value.contains(VALUE_NOON_TOMORROW)
             || value.contains(VALUE_NOON_YESTERDAY)
             || value.contains(VALUE_NOON_NEXT_MONTH)
+            || value.contains(VALUE_NOON_NEXT_3_MONTHS)
         ) {
             value = replaceNoonValues(value)
         }
@@ -120,7 +140,9 @@ object PermaSql {
         value = value.replace(VALUE_EOD_TOMORROW, (dateTime + ONE_DAY).toString())
         value = value.replace(VALUE_EOD_DAY_AFTER, (dateTime + 2 * ONE_DAY).toString())
         value = value.replace(VALUE_EOD_NEXT_WEEK, (dateTime + 7 * ONE_DAY).toString())
+        value = value.replace(VALUE_EOD_NEXT_2_WEEKS, (dateTime + 14 * ONE_DAY).toString())
         value = value.replace(VALUE_EOD_NEXT_MONTH, (dateTime + 30 * ONE_DAY).toString())
+        value = value.replace(VALUE_EOD_NEXT_3_MONTHS, (dateTime + 90 * ONE_DAY).toString())
         return value
     }
 
@@ -132,7 +154,9 @@ object PermaSql {
         value = value.replace(VALUE_NOON_TOMORROW, (time + ONE_DAY).toString())
         value = value.replace(VALUE_NOON_DAY_AFTER, (time + 2 * ONE_DAY).toString())
         value = value.replace(VALUE_NOON_NEXT_WEEK, (time + 7 * ONE_DAY).toString())
+        value = value.replace(VALUE_NOON_NEXT_2_WEEKS, (time + 14 * ONE_DAY).toString())
         value = value.replace(VALUE_NOON_NEXT_MONTH, (time + 30 * ONE_DAY).toString())
+        value = value.replace(VALUE_NOON_NEXT_3_MONTHS, (time + 90 * ONE_DAY).toString())
         return value
     }
 }


### PR DESCRIPTION
I would like to see tasks that are further than one month away but not all of them to still see tasks without specified date below. This PR adds "2 weeks" and "3 months" filter date options for more filtering control.
Also fixes #3126