### PR TITLE
Add Look and feel settings screen based on app implementation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/tasks/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/App.kt
@@ -113,11 +113,13 @@ import org.tasks.compose.settings.HelpAndFeedbackDetail
 import org.tasks.compose.settings.EtebaseAccountSettingsPane
 import org.tasks.compose.settings.LocalAccountSettingsDetail
 import org.tasks.compose.settings.LocalAccountSettingsPane
+import org.tasks.compose.settings.LookAndFeelContent
 import org.tasks.compose.settings.MainSettingsScreen
 import org.tasks.compose.settings.OpenTaskAccountSettingsDetail
 import org.tasks.compose.settings.OpenTaskAccountSettingsPane
 import org.tasks.compose.settings.ProCardState
 import org.tasks.compose.settings.SettingsPane
+import org.tasks.extensions.restartApplication
 import org.tasks.compose.settings.TasksAccountSettingsDetail
 import org.tasks.compose.settings.TasksAccountSettingsPane
 import org.tasks.compose.settings.DesktopProScreen
@@ -159,6 +161,7 @@ import org.tasks.viewmodel.SortSettingsViewModel
 import org.tasks.kmp.org.tasks.themes.ColorProvider
 import org.tasks.themes.BLUE
 import org.tasks.themes.TasksTheme
+import org.tasks.preferences.TasksPreferences
 import org.tasks.data.TaskContainer
 import org.tasks.filters.CaldavFilter
 import org.tasks.filters.Filter
@@ -178,6 +181,7 @@ import org.tasks.viewmodel.TaskEditViewModel
 import org.tasks.viewmodel.MainSettingsViewModel
 import org.tasks.viewmodel.ProCardViewModel
 import org.tasks.viewmodel.TaskListViewModel
+import org.tasks.viewmodel.LookAndFeelViewModel
 import tasks.kmp.generated.resources.Res
 import tasks.kmp.generated.resources.back
 import tasks.kmp.generated.resources.not_available_desktop
@@ -239,7 +243,10 @@ fun App(
             }
         }
     }
-    TasksTheme {
+    val tasksPreferences = koinInject<TasksPreferences>()
+    val themeFlow = remember { tasksPreferences.flow<Int>(TasksPreferences.theme, 5) }
+    val theme by themeFlow.collectAsState(initial = 5)
+    TasksTheme(theme = theme) {
         androidx.compose.runtime.CompositionLocalProvider(
             androidx.compose.ui.platform.LocalUriHandler provides uriHandler,
         ) {
@@ -1750,6 +1757,18 @@ private fun SettingsScreen(
                             },
                         )
                     }
+
+                    is org.tasks.compose.settings.SettingsDestination.LookAndFeel -> {
+                        val viewModel = koinViewModel<LookAndFeelViewModel>()
+                        LookAndFeelContent(
+                            viewModel = viewModel,
+                            onColor = { /* TODO */ },
+                            onDefaultFilter = { /* TODO */ },
+                            onTranslations = { /* TODO */ },
+                            onRestartApplication = { restartApplication() },
+                        )
+                    }
+
                     is org.tasks.compose.settings.SettingsDestination -> {
                         Scaffold(
                             topBar = {

--- a/composeApp/src/commonMain/kotlin/org/tasks/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/di/CommonModule.kt
@@ -70,6 +70,7 @@ import org.tasks.viewmodel.SortSettingsViewModel
 import org.tasks.viewmodel.TaskEditViewModel
 import org.tasks.viewmodel.LocalAccountViewModel
 import org.tasks.viewmodel.HelpAndFeedbackViewModel
+import org.tasks.viewmodel.LookAndFeelViewModel
 import org.tasks.viewmodel.MainSettingsViewModel
 import org.tasks.viewmodel.ProCardViewModel
 import org.tasks.viewmodel.TasksAccountViewModel
@@ -335,6 +336,11 @@ val commonModule = module {
     viewModel {
         MainSettingsViewModel(
             platformConfiguration = get(),
+        )
+    }
+    viewModel {
+        LookAndFeelViewModel(
+            tasksPreferences = get(),
         )
     }
     viewModel {

--- a/composeApp/src/desktopMain/kotlin/main.kt
+++ b/composeApp/src/desktopMain/kotlin/main.kt
@@ -43,6 +43,7 @@ import java.awt.Dimension
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
 import java.io.File
+import java.util.Locale
 import org.tasks.extensions.openInBrowser
 
 private val MIN_WIDTH = 400.dp
@@ -68,6 +69,11 @@ fun main() {
     runBlocking {
         koin.get<AppPreferences>()
             .recordInstallIfNeeded(koin.get<PlatformConfiguration>().versionCode)
+        val languageTag = koin.get<TasksPreferences>()
+            .get(TasksPreferences.languageTag, "")
+        if (languageTag.isNotBlank()) {
+            Locale.setDefault(Locale.forLanguageTag(languageTag))
+        }
     }
     Runtime.getRuntime().addShutdownHook(Thread {
         (koin.get<Reporting>() as? PostHogReporting)?.close()

--- a/kmp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ar/strings.xml
@@ -194,4 +194,22 @@
     <string name="restart_later">لاحقاً</string>
     <string name="blog_feed_none">لا شيء</string>
     <string name="cannot_access_account">لا يمكن الوصول الى الحساب</string>
+    <string name="language">اللغة</string>
+    <string name="theme">المظهر</string>
+    <string name="theme_light">فاتح</string>
+    <string name="theme_black">أسود</string>
+    <string name="theme_dark">داكن</string>
+    <string name="theme_wallpaper">خلفية</string>
+    <string name="theme_day_night">صباحي/مسائي</string>
+    <string name="theme_system_default">افتراضيات النظام</string>
+    <string name="theme_dynamic">ديناميكى</string>
+    <string name="launcher_icon">أيقونة المشغّل</string>
+    <string name="color">اللون</string>
+    <string name="on_launch">عند فتح التطبيق</string>
+    <string name="markdown">ماركداون</string>
+    <string name="markdown_description">تشغيل الماركداون في العنوان والوصف</string>
+    <string name="settings_localization">تخصيص اللغة و الجهة</string>
+    <string name="translations">ساهم في الترجمة</string>
+    <string name="open_last_viewed_list">فتح آخر قائمة تم عرضها</string>
+    <string name="widget_open_list">فتح قائمة</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ast/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ast/strings.xml
@@ -108,4 +108,18 @@
     <string name="restart_later">Dempués</string>
     <string name="blog_feed_none">Denguna</string>
     <string name="cannot_access_account">Nun se puee acceder a la cuenta</string>
+        <string name="language">Llingua</string>
+        <string name="theme">Tema</string>
+        <string name="theme_light">Claru</string>
+        <string name="theme_black">Prietu</string>
+        <string name="theme_dark">Escuru</string>
+        <string name="theme_wallpaper">Fondu de pantalla</string>
+        <string name="theme_day_night">Día/Nueche</string>
+        <string name="theme_system_default">Predetermináu pol sistema</string>
+        <string name="theme_dynamic">Dinámicu</string>
+        <string name="launcher_icon">Iconu del llanzador</string>
+        <string name="color">Color</string>
+        <string name="settings_localization">Llocalización</string>
+        <string name="translations">Contribuyi cola torna</string>
+        <string name="widget_open_list">Abrir llista</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ca/strings.xml
@@ -188,4 +188,22 @@
     <string name="restart_later">Després</string>
     <string name="blog_feed_none">Cap</string>
     <string name="cannot_access_account">No es pot accedir al compte</string>
-</resources>
+    <string name="language">Idioma</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Clar</string>
+    <string name="theme_black">Negre</string>
+    <string name="theme_dark">Fosc</string>
+    <string name="theme_wallpaper">Fons de pantalla</string>
+    <string name="theme_day_night">Dia/Nit</string>
+    <string name="theme_system_default">Predeterminat del sistema</string>
+    <string name="theme_dynamic">Dinàmic</string>
+    <string name="launcher_icon">Icona del llançador</string>
+    <string name="color">Color</string>
+    <string name="on_launch">En iniciar</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Habiliteu el Markdown en el títol i la descripció</string>
+    <string name="settings_localization">Localització</string>
+    <string name="translations">Contribuir traduccions</string>
+    <string name="open_last_viewed_list">Obriu la darrera llista vista</string>
+    <string name="widget_open_list">Llista oberta</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-cs/strings.xml
@@ -294,4 +294,22 @@
     <string name="cannot_access_account">Nepodařilo se připojit k účtu</string>
     <string name="upgrade_subscription_banner">Děkujeme za vaší podporu! Zvyšte své předplatné pro zapnutí cloudové synchronizace Tasks.org</string>
     <string name="subscription_not_found">Vaše cloudové předplatné Tasks.org nebylo nalezeno. Pokud si myslíte, že se jedná o chybu, kontaktujte %1$s</string>
+    <string name="language">Jazyk</string>
+    <string name="theme">Vzhled</string>
+    <string name="theme_light">Světlý</string>
+    <string name="theme_black">Černý</string>
+    <string name="theme_dark">Tmavý</string>
+    <string name="theme_wallpaper">Tapeta</string>
+    <string name="theme_day_night">Den/Noc</string>
+    <string name="theme_system_default">Podle systému</string>
+    <string name="theme_dynamic">Dynamické</string>
+    <string name="launcher_icon">Ikona na domovské obrazovce</string>
+    <string name="color">Barva</string>
+    <string name="on_launch">Při spuštění</string>
+    <string name="markdown">Značkovací jazyk</string>
+    <string name="markdown_description">Zapnout Markdown v nadpisu a popisu</string>
+    <string name="settings_localization">Překlad</string>
+    <string name="translations">Přispějte k překladu</string>
+    <string name="open_last_viewed_list">Otevřít poslední prohlížený seznam</string>
+    <string name="widget_open_list">Otevřít seznam</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-da/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-da/strings.xml
@@ -210,4 +210,22 @@
     <string name="blog_feed_none">Ingen</string>
     <string name="cannot_access_account">Kunne ikke tilgå konto</string>
     <string name="upgrade_subscription_banner">Tak for din støtte! Opgrader dit abonnement for at aktivere Tasks.org Cloud Sync</string>
+    <string name="language">Sprog</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Lys</string>
+    <string name="theme_black">Sort</string>
+    <string name="theme_dark">Mørk</string>
+    <string name="theme_wallpaper">Baggrund</string>
+    <string name="theme_day_night">Dag/nat</string>
+    <string name="theme_system_default">Systemstandard</string>
+    <string name="theme_dynamic">Dynamisk</string>
+    <string name="launcher_icon">App-ikon</string>
+    <string name="color">Farve</string>
+    <string name="on_launch">Ved opstart</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Aktivér Markdown i titel og beskrivelse</string>
+    <string name="settings_localization">Oversættelse</string>
+    <string name="translations">Bidrag med oversættelser</string>
+    <string name="open_last_viewed_list">Åbn sidst viste liste</string>
+    <string name="widget_open_list">Åbn liste</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-de/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-de/strings.xml
@@ -234,4 +234,22 @@
     <string name="restart_later">Später</string>
     <string name="cannot_access_account">Zugriff auf Konto fehlgeschlagen</string>
     <string name="upgrade_subscription_banner">Vielen Dank für deine Unterstützung! Aktualisiere dein Abo, um Tasks.org Cloud Sync zu aktivieren</string>
+    <string name="language">Sprache</string>
+    <string name="theme">Design</string>
+    <string name="theme_light">Hell</string>
+    <string name="theme_black">Schwarz</string>
+    <string name="theme_dark">Dunkel</string>
+    <string name="theme_wallpaper">Hintergrundbild</string>
+    <string name="theme_day_night">Tag/Nacht</string>
+    <string name="theme_system_default">Systemstandard</string>
+    <string name="theme_dynamic">Dynamisch</string>
+    <string name="launcher_icon">Launcher-Symbol</string>
+    <string name="color">Farbe</string>
+    <string name="on_launch">Beim Start</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Markdown in Titel und Beschreibung aktivieren</string>
+    <string name="settings_localization">Übersetzung</string>
+    <string name="translations">Zur Übersetzung beitragen</string>
+    <string name="open_last_viewed_list">Zuletzt betrachtete Liste öffnen</string>
+    <string name="widget_open_list">Liste öffnen</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-el/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-el/strings.xml
@@ -186,4 +186,22 @@
     <string name="restart_later">Αργότερα</string>
     <string name="blog_feed_none">Κανένα</string>
     <string name="cannot_access_account">Δεν υπάρχει πρόσβαση στο λογαριασμό</string>
+        <string name="language">Γλώσσα</string>
+        <string name="theme">Θέμα</string>
+        <string name="theme_light">Λευκό</string>
+        <string name="theme_black">Μαύρο</string>
+        <string name="theme_dark">Σκοτεινό</string>
+        <string name="theme_wallpaper">Ταπετσαρία</string>
+        <string name="theme_day_night">Μέρα/Νύχτα</string>
+        <string name="theme_system_default">Προεπιλογή Συστήματος</string>
+        <string name="theme_dynamic">Δυναμικό</string>
+        <string name="launcher_icon">Εικονίδιο Launcher (προωθητή)</string>
+        <string name="color">Χρώμα</string>
+        <string name="on_launch">Κατά την εκκίνηση</string>
+        <string name="markdown">Αποτίμηση (Markdown)</string>
+        <string name="markdown_description">Ενεργοποίηση αποτίμησης (Markdown) στον τίτλο και την περιγραφή</string>
+        <string name="settings_localization">Εντοπισμός</string>
+        <string name="translations">Συνεισφέρετε μεταφράσεις</string>
+        <string name="open_last_viewed_list">Άνοιγμα λίστας όσων προβλήθηκαν τελευταία</string>
+        <string name="widget_open_list">Άνοιγμα λίστας</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-eo/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-eo/strings.xml
@@ -221,4 +221,22 @@
     <string name="restart_later">Poste</string>
     <string name="cannot_access_account">Ne povas atingi konton</string>
     <string name="upgrade_subscription_banner">Dankon pro via subteno! Altgradigu vian abonon por ŝalti sinkronigon de Tasks.org Cloud</string>
-</resources>
+    <string name="language">Lingvo</string>
+    <string name="theme">Etoso</string>
+    <string name="theme_light">Hela</string>
+    <string name="theme_black">Nigra</string>
+    <string name="theme_dark">Malhela</string>
+    <string name="theme_wallpaper">Ekranfono</string>
+    <string name="theme_day_night">Tago/Nokto</string>
+    <string name="theme_system_default">Laŭ operaciumo</string>
+    <string name="theme_dynamic">Dinamika</string>
+    <string name="launcher_icon">Lanĉila piktogramo</string>
+    <string name="color">Koloro</string>
+    <string name="on_launch">Je lanĉi</string>
+    <string name="markdown">Simpla Marklingo</string>
+    <string name="markdown_description">Ebligi simplan markadon en titolo kaj priskribo</string>
+    <string name="settings_localization">Traduko</string>
+    <string name="translations">Helpi traduki</string>
+    <string name="open_last_viewed_list">Malfermi liston de laste rigardita</string>
+    <string name="widget_open_list">Malfermi liston</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-es/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-es/strings.xml
@@ -188,4 +188,22 @@
     <string name="restart_later">Más tarde</string>
     <string name="blog_feed_none">Ninguna</string>
     <string name="cannot_access_account">No se puede acceder a la cuenta</string>
+    <string name="language">Idioma</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_black">Negro</string>
+    <string name="theme_dark">Oscuro</string>
+    <string name="theme_wallpaper">Fondo de pantalla</string>
+    <string name="theme_day_night">Día/noche</string>
+    <string name="theme_system_default">Valor predeterminado del sistema</string>
+    <string name="theme_dynamic">Dinámico</string>
+    <string name="launcher_icon">Icono del iniciador</string>
+    <string name="color">Color</string>
+    <string name="on_launch">En lanzador</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Activar Markdown en el título y la descripción</string>
+    <string name="settings_localization">Configuración regional</string>
+    <string name="translations">Contribuir con la traducción</string>
+    <string name="open_last_viewed_list">Última lista vista abierta</string>
+    <string name="widget_open_list">Lista abierta</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-et/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-et/strings.xml
@@ -229,4 +229,22 @@
     <string name="restart_later">Hiljem</string>
     <string name="cannot_access_account">Ei pääse kontole ligi</string>
     <string name="upgrade_subscription_banner">Tänud sinu toetuse eest! Kasutamaks Tasks.org-i pilvesünkroonimise võimalus palun uuenda oma tellimust</string>
-</resources>
+    <string name="language">Keel</string>
+    <string name="theme">Teema</string>
+    <string name="theme_light">Hele</string>
+    <string name="theme_black">Must</string>
+    <string name="theme_dark">Tume</string>
+    <string name="theme_wallpaper">Taustapilt</string>
+    <string name="theme_day_night">Päev/Öö</string>
+    <string name="theme_system_default">Süsteemi vaikeseade</string>
+    <string name="theme_dynamic">Dünaamiline</string>
+    <string name="launcher_icon">Rakenduse ikoon</string>
+    <string name="color">Värv</string>
+    <string name="on_launch">Käivitamisel</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Luba Markdown pealkirjas ja kirjelduses</string>
+    <string name="settings_localization">Kohalikustamine</string>
+    <string name="translations">Aita tõlkida</string>
+    <string name="open_last_viewed_list">Ava viimati vaadatud loend</string>
+    <string name="widget_open_list">Ava loend</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-eu/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-eu/strings.xml
@@ -165,4 +165,21 @@
     <string name="restart_later">Geroago</string>
     <string name="blog_feed_none">Bat ere ez</string>
     <string name="cannot_access_account">Ezin izan da kontua atzitu</string>
+        <string name="language">Hizkuntza</string>
+        <string name="theme">Azala</string>
+        <string name="theme_light">Argia</string>
+        <string name="theme_black">Beltza</string>
+        <string name="theme_dark">Iluna</string>
+        <string name="theme_wallpaper">Horma-papera</string>
+        <string name="theme_day_night">Eguna/Gaua</string>
+        <string name="theme_system_default">Sisteman lehenetsia</string>
+        <string name="launcher_icon">Abiarazlearen ikonoa</string>
+        <string name="color">Kolorea</string>
+        <string name="on_launch">Abioan</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Markdown gaitu izenburuan eta deskribapenean</string>
+        <string name="settings_localization">Lokalizazioa</string>
+        <string name="translations">Lagundu itzulpenekin</string>
+        <string name="open_last_viewed_list">Ireki ikusitako azkenen zerrenda</string>
+        <string name="widget_open_list">Ireki zerrenda</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-fa/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-fa/strings.xml
@@ -66,4 +66,11 @@
     <string name="restart_now">اکنون ریست کن</string>
     <string name="restart_later">بعدا</string>
     <string name="blog_feed_none">هیچکدام</string>
+        <string name="language">زبان</string>
+        <string name="theme">تم</string>
+        <string name="theme_light">روشن</string>
+        <string name="theme_dark">تیره</string>
+        <string name="color">رنگ</string>
+        <string name="settings_localization">محلی‌سازی</string>
+        <string name="translations">مشارکت در ترجمه</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-fi/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-fi/strings.xml
@@ -199,4 +199,22 @@
     <string name="restart_later">Myöhemmin</string>
     <string name="blog_feed_none">Ei mitään</string>
     <string name="cannot_access_account">Tiliin ei päästä käsiksi</string>
+    <string name="language">Kieli</string>
+    <string name="theme">Teema</string>
+    <string name="theme_light">Vaalea</string>
+    <string name="theme_black">Musta</string>
+    <string name="theme_dark">Tumma</string>
+    <string name="theme_wallpaper">Taustakuva</string>
+    <string name="theme_day_night">Päivä/Yö</string>
+    <string name="theme_system_default">Järjestelmän oletus</string>
+    <string name="theme_dynamic">Dynaaminen</string>
+    <string name="launcher_icon">Käynnistyskuvake</string>
+    <string name="color">Väri</string>
+    <string name="on_launch">Käynnistettäessä</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Ota Markdown käyttöön otsikossa ja kuvauksessa</string>
+    <string name="settings_localization">Paikallistaminen</string>
+    <string name="translations">Osallistu kääntämiseen</string>
+    <string name="open_last_viewed_list">Avaa viimeksi katsottu lista</string>
+    <string name="widget_open_list">Avaa lista</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-fr/strings.xml
@@ -294,3 +294,22 @@
     <string name="upgrade_subscription_banner">Merci pour votre soutien ! Mettez à niveau votre abonnement pour activer la synchronisation cloud Tasks.org</string>
     <string name="subscription_not_found">Votre abonnement au cloud Tasks.org est introuvable. Si vous pensez qu\'il s\'agit d\'une erreur, veuillez contacter %1$s</string>
 </resources>
+    <string name="language">Langue</string>
+    <string name="theme">Thème</string>
+    <string name="theme_light">Clair</string>
+    <string name="theme_black">Noir</string>
+    <string name="theme_dark">Sombre</string>
+    <string name="theme_wallpaper">Fond d'écran</string>
+    <string name="theme_day_night">Jour/Nuit</string>
+    <string name="theme_system_default">Valeur par défaut du système</string>
+    <string name="theme_dynamic">Dynamique</string>
+    <string name="launcher_icon">Icône du lanceur</string>
+    <string name="color">Couleur</string>
+    <string name="on_launch">Au lancement</string>
+    <string name="markdown">« Markdown »</string>
+    <string name="markdown_description">Activer « Markdown » dans le titre et la description</string>
+    <string name="settings_localization">Localisation</string>
+    <string name="translations">Contribuer aux traductions</string>
+    <string name="open_last_viewed_list">Ouvrir la dernière liste consultée</string>
+    <string name="widget_open_list">Ouvrir la liste</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-gl/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-gl/strings.xml
@@ -186,4 +186,22 @@
     <string name="restart_later">Máis tarde</string>
     <string name="blog_feed_none">Ningunha</string>
     <string name="cannot_access_account">Non se pode acceder á conta</string>
+        <string name="language">Lingua</string>
+        <string name="theme">Tema</string>
+        <string name="theme_light">Claro</string>
+        <string name="theme_black">Negro</string>
+        <string name="theme_dark">Escuro</string>
+        <string name="theme_wallpaper">Fondo de pantalla</string>
+        <string name="theme_day_night">Día/Noite</string>
+        <string name="theme_system_default">Predefinido do sistema</string>
+        <string name="theme_dynamic">Dinámico</string>
+        <string name="launcher_icon">Icona de escritorio</string>
+        <string name="color">Cor</string>
+        <string name="on_launch">Ao iniciar</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Activa Markdown no título e na descrición</string>
+        <string name="settings_localization">Localización</string>
+        <string name="translations">Contribúe coa tradución</string>
+        <string name="open_last_viewed_list">Abrir a última lista vista</string>
+        <string name="widget_open_list">Abrir lista</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-he/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-he/strings.xml
@@ -228,4 +228,22 @@
     <string name="blog_feed_none">ללא</string>
     <string name="cannot_access_account">לא ניתן לגשת לחשבון</string>
     <string name="upgrade_subscription_banner">תודה על תמיכתך! יש לשדרג את המינוי שלך כדי להפעיל גיבוי בענן Tasks.org</string>
-</resources>
+    <string name="language">שפה</string>
+    <string name="theme">ערכת נושא</string>
+    <string name="theme_light">בהיר</string>
+    <string name="theme_black">שחור</string>
+    <string name="theme_dark">כהה</string>
+    <string name="theme_wallpaper">תמונת רקע</string>
+    <string name="theme_day_night">יום/לילה</string>
+    <string name="theme_system_default">ברירת מחדל של המערכת</string>
+    <string name="theme_dynamic">דינמי</string>
+    <string name="launcher_icon">סמל משגר</string>
+    <string name="color">צבע</string>
+    <string name="on_launch">בעת שיגור</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">אפשור Markdown בכותרת ובתיאור</string>
+    <string name="settings_localization">לוקליזציה</string>
+    <string name="translations">לתרום תרגומים</string>
+    <string name="open_last_viewed_list">פתיחת הרשימה האחרונה שנצפתה</string>
+    <string name="widget_open_list">פתיחת רשימה</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-hr/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-hr/strings.xml
@@ -292,4 +292,22 @@
     <string name="pricing_nyp_feature_2">Sinkronizacija s CalDAV-om i EteSync-om za samostalni hosting</string>
     <string name="cannot_access_account">Nije moguće pristupiti računu</string>
     <string name="upgrade_subscription_banner">Hvala ti na podršci! Nadogradi svoju pretplatu i na taj način omogući Tasks.org Cloud sinkronizaciju</string>
-</resources>
+    <string name="language">Jezik</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Svjetla</string>
+    <string name="theme_black">Crna</string>
+    <string name="theme_dark">Tamna</string>
+    <string name="theme_wallpaper">Pozadinska slika</string>
+    <string name="theme_day_night">Dan/Noć</string>
+    <string name="theme_system_default">Standardne postavke sustava</string>
+    <string name="theme_dynamic">Dinamično</string>
+    <string name="launcher_icon">Ikona pokretača</string>
+    <string name="color">Boja</string>
+    <string name="on_launch">Pri pokretanju</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Omogući Markdown u naslovu i opisu</string>
+    <string name="settings_localization">Lokalizacija</string>
+    <string name="translations">Doprinesi prijevodima</string>
+    <string name="open_last_viewed_list">Otvori zadnji pogledani popis</string>
+    <string name="widget_open_list">Otvori popis</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-hu/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-hu/strings.xml
@@ -231,4 +231,22 @@
     <string name="restart_later">Később</string>
     <string name="cannot_access_account">Fiók nem elérhető</string>
     <string name="upgrade_subscription_banner">Köszönjük a támogatást. Frissítse az előfizetését a Tasks.org felhős szinkronizáció engedélyezéséhez</string>
-</resources>
+    <string name="language">Nyelv</string>
+    <string name="theme">Téma</string>
+    <string name="theme_light">Világos</string>
+    <string name="theme_black">Fekete</string>
+    <string name="theme_dark">Sötét</string>
+    <string name="theme_wallpaper">Háttérkép</string>
+    <string name="theme_day_night">Nappal/Éjszaka</string>
+    <string name="theme_system_default">Alapértelmezett</string>
+    <string name="theme_dynamic">Dinamikus</string>
+    <string name="launcher_icon">Launcher ikon</string>
+    <string name="color">Szín</string>
+    <string name="on_launch">Indításkor</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Markdown engedélyezése címben és leírásban</string>
+    <string name="settings_localization">Lokalizáció</string>
+    <string name="translations">Részvétel a fordításban</string>
+    <string name="open_last_viewed_list">Utoljára használt lista megnyitása</string>
+    <string name="widget_open_list">Lista megnyitása</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-id/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-id/strings.xml
@@ -229,4 +229,22 @@
     <string name="restart_later">Nanti</string>
     <string name="cannot_access_account">Tidak bisa mengakses akun</string>
     <string name="upgrade_subscription_banner">Terima kasih atas dukungan Anda! Tingkatkan langganan Anda untuk mengaktifkan Sinkronisasi Cloud Tasks.org</string>
-</resources>
+    <string name="language">Bahasa</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Cerah</string>
+    <string name="theme_black">Hitam</string>
+    <string name="theme_dark">Gelap</string>
+    <string name="theme_wallpaper">Latar</string>
+    <string name="theme_day_night">Siang/Malam</string>
+    <string name="theme_system_default">Bawaan sistem</string>
+    <string name="theme_dynamic">Dinamis</string>
+    <string name="launcher_icon">Ikon peluncur</string>
+    <string name="color">Warna</string>
+    <string name="on_launch">Pada awal peluncuran</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Aktifkan Markdown di judul dan keterangan</string>
+    <string name="settings_localization">Pelokalan bahasa</string>
+    <string name="translations">Kontribusi terjemahan</string>
+    <string name="open_last_viewed_list">Buka daftar yang terakhir dilihat</string>
+    <string name="widget_open_list">Buka daftar</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-it/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-it/strings.xml
@@ -234,4 +234,22 @@
     <string name="restart_later">Dopo</string>
     <string name="cannot_access_account">Impossibile accedere all'account</string>
     <string name="upgrade_subscription_banner">Grazie per il tuo sostegno! Aggiorna il tuo abbonamento per abilitare Tasks.org Cloud Sync</string>
-</resources>
+    <string name="language">Lingua</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Chiaro</string>
+    <string name="theme_black">Nero</string>
+    <string name="theme_dark">Scuro</string>
+    <string name="theme_wallpaper">Sfondo</string>
+    <string name="theme_day_night">Giorno/Notte</string>
+    <string name="theme_system_default">Predefinito del sistema</string>
+    <string name="theme_dynamic">Dinamico</string>
+    <string name="launcher_icon">Icona del launcher</string>
+    <string name="color">Colore</string>
+    <string name="on_launch">All'avvio</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Abilita la formattazione Markdown nel titolo e nella descrizione</string>
+    <string name="settings_localization">Localizzazione</string>
+    <string name="translations">Contribuisci alla traduzione</string>
+    <string name="open_last_viewed_list">Apri l'ultima lista visualizzata</string>
+    <string name="widget_open_list">Apri lista</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ja/strings.xml
@@ -244,4 +244,22 @@
     <string name="restart_later">あとで</string>
     <string name="cannot_access_account">アカウントにアクセスできません</string>
     <string name="upgrade_subscription_banner">ご支援ありがとうございます！ Tasks.org Cloudと同期するために、定期購入をアップグレードしましょう</string>
-</resources>
+    <string name="language">言語</string>
+    <string name="theme">テーマ</string>
+    <string name="theme_light">ライト</string>
+    <string name="theme_black">黒</string>
+    <string name="theme_dark">ダーク</string>
+    <string name="theme_wallpaper">壁紙</string>
+    <string name="theme_day_night">デイナイト</string>
+    <string name="theme_system_default">システムデフォルト</string>
+    <string name="theme_dynamic">ダイナミック</string>
+    <string name="launcher_icon">ランチャーアイコン</string>
+    <string name="color">色</string>
+    <string name="on_launch">起動時</string>
+    <string name="markdown">マークダウン</string>
+    <string name="markdown_description">タイトル欄と説明欄でマークダウン記法を有効にします</string>
+    <string name="settings_localization">ローカライズ</string>
+    <string name="translations">翻訳に貢献する</string>
+    <string name="open_last_viewed_list">最後に表示したリストを開く</string>
+    <string name="widget_open_list">リストをひらく</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-kmr/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-kmr/strings.xml
@@ -31,4 +31,13 @@
     <string name="social">Civakî</string>
     <string name="restart_later">Paşê</string>
     <string name="blog_feed_none">Ne yek</string>
+        <string name="language">Ziman</string>
+        <string name="theme">Rûkar</string>
+        <string name="theme_light">Ron</string>
+        <string name="theme_black">Reş</string>
+        <string name="theme_dark">Tarî</string>
+        <string name="theme_wallpaper">Wêneya dîwêr</string>
+        <string name="theme_day_night">Roj/Êvar</string>
+        <string name="color">Reng</string>
+        <string name="settings_localization">Herêmîkirin</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ko/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ko/strings.xml
@@ -185,4 +185,22 @@
     <string name="restart_later">나중에</string>
     <string name="blog_feed_none">없음</string>
     <string name="cannot_access_account">계정에 접근할 수 없습니다</string>
+        <string name="language">언어</string>
+        <string name="theme">테마</string>
+        <string name="theme_light">밝게</string>
+        <string name="theme_black">검정</string>
+        <string name="theme_dark">어둡게</string>
+        <string name="theme_wallpaper">바탕화면</string>
+        <string name="theme_day_night">주간/야간</string>
+        <string name="theme_system_default">시스템 기본설정</string>
+        <string name="theme_dynamic">동적</string>
+        <string name="launcher_icon">런처 아이콘</string>
+        <string name="color">색상</string>
+        <string name="on_launch">앱 구동 시</string>
+        <string name="markdown">마크 다운</string>
+        <string name="markdown_description">제목과 설명에 마크다운 방식 가능</string>
+        <string name="settings_localization">현지화</string>
+        <string name="translations">번역 참여하기</string>
+        <string name="open_last_viewed_list">마지막으로 보던 목록 열기</string>
+        <string name="widget_open_list">목록 열기</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-lt/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-lt/strings.xml
@@ -167,4 +167,21 @@
     <string name="restart_later">Vėliau</string>
     <string name="blog_feed_none">Nėra</string>
     <string name="cannot_access_account">Paskyra nepasiekiama</string>
+        <string name="language">Kalba</string>
+        <string name="theme">Tema</string>
+        <string name="theme_light">Šviesi</string>
+        <string name="theme_black">Juoda</string>
+        <string name="theme_dark">Tamsi</string>
+        <string name="theme_wallpaper">Fono vaizdas</string>
+        <string name="theme_day_night">Diena/Naktis</string>
+        <string name="theme_system_default">Sistemos numatyta</string>
+        <string name="launcher_icon">Paleidimo piktograma</string>
+        <string name="color">Spalva</string>
+        <string name="on_launch">Paleidžiant</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Įgalinti Markdown pavadinime ir aprašyme</string>
+        <string name="settings_localization">Lokalizacija</string>
+        <string name="translations">Padėti išversti</string>
+        <string name="open_last_viewed_list">Atidaryti paskutinį peržiūrėtą sąrašą</string>
+        <string name="widget_open_list">Atidaryti sąrašą</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ne/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ne/strings.xml
@@ -19,4 +19,5 @@
     <string name="task_list_options">कार्य सूचीका विकल्पहरू</string>
     <string name="contact_developer">विकासकर्तालाई सम्पर्क गर्नुहोस्</string>
     <string name="source_code">श्रोत कोड</string>
+        <string name="translations">अनुवादहरू योगदान गर्नुहोस्</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-nl/strings.xml
@@ -205,4 +205,22 @@
     <string name="restart_later">Later</string>
     <string name="blog_feed_none">Geen</string>
     <string name="cannot_access_account">Krijgt geen toegang tot account</string>
+        <string name="language">Taal</string>
+        <string name="theme">Thema</string>
+        <string name="theme_light">Licht</string>
+        <string name="theme_black">Zwart</string>
+        <string name="theme_dark">Donker</string>
+        <string name="theme_wallpaper">Achtergrond</string>
+        <string name="theme_day_night">Dag/Nacht</string>
+        <string name="theme_system_default">Systeemstandaard</string>
+        <string name="theme_dynamic">Dynamisch</string>
+        <string name="launcher_icon">Startpictogram</string>
+        <string name="color">Kleur</string>
+        <string name="on_launch">Bij het starten</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Sta Markdown toe in titel en beschrijving</string>
+        <string name="settings_localization">Localisatie</string>
+        <string name="translations">Vertalingen toevoegen</string>
+        <string name="open_last_viewed_list">Laatst bekeken lijst openen</string>
+        <string name="widget_open_list">Lijst openen</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-or/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-or/strings.xml
@@ -42,4 +42,13 @@
     <string name="social">ସାମାଜିକ</string>
     <string name="open_source">ଖୋଲା ଉତ୍ସ</string>
     <string name="restart_later">ପରେ</string>
+        <string name="language">ଭାଷା</string>
+        <string name="theme">ଥିମ୍</string>
+        <string name="theme_light">ହାଲୁକା</string>
+        <string name="theme_black">କଳା</string>
+        <string name="theme_dark">ଗାଢ଼</string>
+        <string name="theme_day_night">ଦିନ/ରାତି</string>
+        <string name="theme_system_default">ସିଷ୍ଟମ୍ ଡିଫଲ୍ଟ</string>
+        <string name="color">ରଙ୍ଗ</string>
+        <string name="translations">ଅନୁଵାଦରେ ଯୋଗଦାନ କରନ୍ତୁ</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-pl/strings.xml
@@ -179,4 +179,22 @@
     <string name="restart_later">Póżniej</string>
     <string name="blog_feed_none">Brak</string>
     <string name="cannot_access_account">Brak dostępu do konta</string>
+        <string name="language">Język</string>
+        <string name="theme">Motyw</string>
+        <string name="theme_light">Jasny</string>
+        <string name="theme_black">Czarny</string>
+        <string name="theme_dark">Ciemny</string>
+        <string name="theme_wallpaper">Tapeta</string>
+        <string name="theme_day_night">Dzień/noc</string>
+        <string name="theme_system_default">Domyślny systemowy</string>
+        <string name="theme_dynamic">Dynamiczny</string>
+        <string name="launcher_icon">Ikona programu startowego</string>
+        <string name="color">Kolor</string>
+        <string name="on_launch">Przy uruchomieniu</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Włącz Markdown w tytule i opisie</string>
+        <string name="settings_localization">Ustawienia regionalne</string>
+        <string name="translations">Wspomóż tłumaczenie</string>
+        <string name="open_last_viewed_list">Otwórz ostatnio przeglądaną listę</string>
+        <string name="widget_open_list">Otwórz listę</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -248,4 +248,22 @@
     <string name="restart_later">Depois</string>
     <string name="cannot_access_account">Não é possível acessar a conta</string>
     <string name="upgrade_subscription_banner">Obrigado pelo apoio! Atualize sua inscrição para ativar sincronização em nuvem Tasks.org</string>
-</resources>
+    <string name="language">Idioma</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_black">Preto</string>
+    <string name="theme_dark">Escuro</string>
+    <string name="theme_wallpaper">Plano de fundo</string>
+    <string name="theme_day_night">Dia/Noite</string>
+    <string name="theme_system_default">Padrão do Sistema</string>
+    <string name="theme_dynamic">Dinâmico</string>
+    <string name="launcher_icon">Ícone do lançador</string>
+    <string name="color">Cor</string>
+    <string name="on_launch">Ao iniciar</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Habilitar Markdown no título e descrição</string>
+    <string name="settings_localization">Localização</string>
+    <string name="translations">Ajude com as traduções</string>
+    <string name="open_last_viewed_list">Abrir a última lista visualizada</string>
+    <string name="widget_open_list">Abrir lista</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-pt/strings.xml
@@ -186,4 +186,22 @@
     <string name="restart_later">Mais tarde</string>
     <string name="blog_feed_none">Nenhum</string>
     <string name="cannot_access_account">Não é possível aceder à conta</string>
+        <string name="language">Idioma</string>
+        <string name="theme">Tema</string>
+        <string name="theme_light">Claro</string>
+        <string name="theme_black">Preto</string>
+        <string name="theme_dark">Escuro</string>
+        <string name="theme_wallpaper">Fundo</string>
+        <string name="theme_day_night">Dia/noite</string>
+        <string name="theme_system_default">Predefinição do sistema</string>
+        <string name="theme_dynamic">Dinâmico</string>
+        <string name="launcher_icon">Ícone do lançador</string>
+        <string name="color">Cor</string>
+        <string name="on_launch">Ao abrir a aplicação</string>
+        <string name="markdown">Código Markdown</string>
+        <string name="markdown_description">Ativar código Markdown no título e descrição</string>
+        <string name="settings_localization">Tradução</string>
+        <string name="translations">Contribuir nas traduções</string>
+        <string name="open_last_viewed_list">Abrir a última lista vista</string>
+        <string name="widget_open_list">Abrir lista</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ro/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ro/strings.xml
@@ -194,4 +194,22 @@
     <string name="accept">Acceptă</string>
     <string name="email_to_task">E-mail către sarcină</string>
     <string name="upgrade_subscription_banner">Îți mulțumim pentru suport! Actualizează-ți abonamentul pentru a activa Tasks.org Cloud Sync</string>
-</resources>
+    <string name="language">Limbă</string>
+    <string name="theme">Temă</string>
+    <string name="theme_light">Luminoasă</string>
+    <string name="theme_black">Neagră</string>
+    <string name="theme_dark">Întunecată</string>
+    <string name="theme_wallpaper">Imagine de fundal</string>
+    <string name="theme_day_night">Zi/Noapte</string>
+    <string name="theme_system_default">Implicit</string>
+    <string name="theme_dynamic">Dinamic</string>
+    <string name="launcher_icon">Pictograma lansatorului</string>
+    <string name="color">Culoare</string>
+    <string name="on_launch">La lansare</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Activează Markdown în titlu și descriere</string>
+    <string name="settings_localization">Localizare</string>
+    <string name="translations">Contribuie la traduceri</string>
+    <string name="open_last_viewed_list">Deschide ultima listă vizualizată</string>
+    <string name="widget_open_list">Listă deschisă</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ru/strings.xml
@@ -200,4 +200,22 @@
     <string name="restart_later">Позже</string>
     <string name="blog_feed_none">Нет</string>
     <string name="cannot_access_account">Учётная запись недоступна</string>
+        <string name="language">Язык</string>
+        <string name="theme">Цветовая тема</string>
+        <string name="theme_light">Светлая</string>
+        <string name="theme_black">Чёрная</string>
+        <string name="theme_dark">Тёмная</string>
+        <string name="theme_wallpaper">Как обои</string>
+        <string name="theme_day_night">День / ночь</string>
+        <string name="theme_system_default">Как в системе</string>
+        <string name="theme_dynamic">Динамическая</string>
+        <string name="launcher_icon">Иконка запуска</string>
+        <string name="color">Цвет</string>
+        <string name="on_launch">При запуске</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Включить Markdown в названии и описании</string>
+        <string name="settings_localization">Локализация</string>
+        <string name="translations">Участвовать в переводе программы</string>
+        <string name="open_last_viewed_list">Открыть последний просмотренный список</string>
+        <string name="widget_open_list">Открыть список</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-si/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-si/strings.xml
@@ -158,4 +158,21 @@
     <string name="restart_later">පසුව</string>
     <string name="blog_feed_none">කිසිවක් නැත</string>
     <string name="cannot_access_account">ගිණුමට ප්‍රවේශ විය නොහැක</string>
+    <string name="language">භාෂාව</string>
+    <string name="theme">තේමාව</string>
+    <string name="theme_light">ලා පැහැති</string>
+    <string name="theme_black">කලු පැහැය</string>
+    <string name="theme_dark">අඳුරු පැහැති</string>
+    <string name="theme_wallpaper">බිතුපත (Wallpaper)</string>
+    <string name="theme_day_night">දිවා / රාත්‍රි</string>
+    <string name="theme_system_default">පද්ධති පෙරනිමිය</string>
+    <string name="launcher_icon">දියත් කිරීමේ අයිකනය</string>
+    <string name="color">වර්ණය</string>
+    <string name="on_launch">ආරම්භ කිරීමේදී</string>
+    <string name="markdown">ලකුණු කිරීම</string>
+    <string name="markdown_description">මාතෘකාව සහ විස්තරය තුළ ලකුණු කිරීම සක්‍රිය කරන්න</string>
+    <string name="settings_localization">ප්‍රාදේශීයකරණය</string>
+    <string name="translations">පරිවර්තන සඳහා දායක වන්න</string>
+    <string name="open_last_viewed_list">අවසන් වරට බැලූ ලැයිස්තුව විවෘත කරන්න</string>
+    <string name="widget_open_list">ලැයිස්තුව විවෘත කරන්න</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-sk/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-sk/strings.xml
@@ -186,4 +186,22 @@
     <string name="restart_later">Neskôr</string>
     <string name="blog_feed_none">Žiadna</string>
     <string name="cannot_access_account">Chyba v prístupe k účtu</string>
+        <string name="language">Jazyk</string>
+        <string name="theme">Téma</string>
+        <string name="theme_light">Svetlá</string>
+        <string name="theme_black">Čierna</string>
+        <string name="theme_dark">Tmavá</string>
+        <string name="theme_wallpaper">Tapeta</string>
+        <string name="theme_day_night">Deň/Noc</string>
+        <string name="theme_system_default">Podľa systému</string>
+        <string name="theme_dynamic">Dynamické</string>
+        <string name="launcher_icon">Ikona</string>
+        <string name="color">Farba</string>
+        <string name="on_launch">Pri spustení</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Zapnúť Markdown v nadpise a popise</string>
+        <string name="settings_localization">Preklad</string>
+        <string name="translations">Prispieť prekladom</string>
+        <string name="open_last_viewed_list">Otvoriť posledný zobr. zoznam</string>
+        <string name="widget_open_list">Otvoriť zoznam</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-sr/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-sr/strings.xml
@@ -212,4 +212,22 @@
     <string name="blog_feed_none">Празно</string>
     <string name="cannot_access_account">Не може се приступити налогу</string>
     <string name="upgrade_subscription_banner">Хвала на подршци! Унапреди претплату за омогућену Tasks.org Cloud синхронизацију</string>
+        <string name="language">Језик</string>
+        <string name="theme">Тема</string>
+        <string name="theme_light">Светло</string>
+        <string name="theme_black">Црно</string>
+        <string name="theme_dark">Тамно</string>
+        <string name="theme_wallpaper">Позадина</string>
+        <string name="theme_day_night">Дан/Ноћ</string>
+        <string name="theme_system_default">Системски подразумевано</string>
+        <string name="theme_dynamic">Динамично</string>
+        <string name="launcher_icon">Иконица за покретање</string>
+        <string name="color">Боја</string>
+        <string name="on_launch">При покретању</string>
+        <string name="markdown">Редукција</string>
+        <string name="markdown_description">Омогући Редукцију у називу и опису</string>
+        <string name="settings_localization">Локализација</string>
+        <string name="translations">Допринеси преводима</string>
+        <string name="open_last_viewed_list">Отвори последње прегледану листу</string>
+        <string name="widget_open_list">Отвори листу</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-sv/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-sv/strings.xml
@@ -288,4 +288,22 @@
     <string name="blog_feed_announcements">Endast tillkännagivanden</string>
     <string name="blog_feed_all">Alla inlägg</string>
     <string name="cannot_access_account">Kan inte komma åt kontot</string>
+        <string name="language">Språk</string>
+        <string name="theme">Tema</string>
+        <string name="theme_light">Ljust</string>
+        <string name="theme_black">Svart</string>
+        <string name="theme_dark">Mörkt</string>
+        <string name="theme_wallpaper">Bakgrundsbild</string>
+        <string name="theme_day_night">Dag/Natt</string>
+        <string name="theme_system_default">Systemets standardinställning</string>
+        <string name="theme_dynamic">Dynamisk</string>
+        <string name="launcher_icon">Hemskärmsikon</string>
+        <string name="color">Färg</string>
+        <string name="on_launch">Vid start</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Aktivera Markdown i titel och beskrivning</string>
+        <string name="settings_localization">Språk</string>
+        <string name="translations">Hjälp till med översättning</string>
+        <string name="open_last_viewed_list">Öppna senast visade lista</string>
+        <string name="widget_open_list">Öppna lista</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ta/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ta/strings.xml
@@ -186,4 +186,22 @@
     <string name="restart_later">பின்னர்</string>
     <string name="blog_feed_none">எதுவுமில்லை</string>
     <string name="cannot_access_account">கணக்கை அணுக முடியாது</string>
+        <string name="language">மொழி</string>
+        <string name="theme">பேசும்</string>
+        <string name="theme_light">ஒளி</string>
+        <string name="theme_black">கருப்பு</string>
+        <string name="theme_dark">இருள்</string>
+        <string name="theme_wallpaper">சுவர்</string>
+        <string name="theme_day_night">பகல் / இரவு</string>
+        <string name="theme_system_default">கணினி இயல்புநிலை</string>
+        <string name="theme_dynamic">மாறும்</string>
+        <string name="launcher_icon">துவக்கி படவுரு</string>
+        <string name="color">நிறம்</string>
+        <string name="on_launch">தொடங்கும்போது</string>
+        <string name="markdown">மார்க் பேரூர்</string>
+        <string name="markdown_description">தலைப்பு மற்றும் விளக்கத்தில் மார்க் டவுனை இயக்கவும்</string>
+        <string name="settings_localization">உள்ளூர்மயமாக்கல்</string>
+        <string name="translations">மொழிபெயர்ப்புகளை பங்களிக்கவும்</string>
+        <string name="open_last_viewed_list">கடைசியாகப் பார்த்த பட்டியலைத் திறக்கவும்</string>
+        <string name="widget_open_list">திறந்த பட்டியல்</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-th/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-th/strings.xml
@@ -155,4 +155,21 @@
     <string name="restart_later">หลัง</string>
     <string name="blog_feed_none">ไม่มีใคร</string>
     <string name="cannot_access_account">ไม่สามารถเข้าถึงบัญชี</string>
+        <string name="language">ภาษา</string>
+        <string name="theme">หัวข้อ</string>
+        <string name="theme_light">แสง</string>
+        <string name="theme_black">ดำ</string>
+        <string name="theme_dark">รูปแบบสีดำ</string>
+        <string name="theme_wallpaper">วอลเปเปอร์</string>
+        <string name="theme_day_night">กลางวัน/กลางคืน</string>
+        <string name="theme_system_default">ค่าเริ่มต้นของระบบ</string>
+        <string name="launcher_icon">ไอคอนตัวเปิดใช้</string>
+        <string name="color">สี</string>
+        <string name="on_launch">เปิดตัว</string>
+        <string name="markdown">มาร์กดาวน์</string>
+        <string name="markdown_description">เปิดใช้งานการทําเครื่องหมายในชื่อและคําอธิบาย</string>
+        <string name="settings_localization">แปล</string>
+        <string name="translations">สนับสนุนการแปล</string>
+        <string name="open_last_viewed_list">เปิดรายการที่ดูล่าสุด</string>
+        <string name="widget_open_list">เปิดรายการ</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-tl/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-tl/strings.xml
@@ -16,4 +16,5 @@
     <string name="rate_tasks">Halagahan ang Tasks</string>
     <string name="contact_developer">Kontakin ang developer</string>
     <string name="source_code">Pinagmulang code</string>
+        <string name="translations">Umambag ng pagsasalin</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-tr/strings.xml
@@ -291,4 +291,22 @@
     <string name="cannot_access_account">Hesaba erişilemedi</string>
     <string name="upgrade_subscription_banner">Desteğiniz için sağ olun! Tasks.org Bulut Eşzamanlamasını etkinleştirmek için aboneliğinizi yükseltin</string>
     <string name="subscription_not_found">Tasks.org bulut aboneliğiniz bulunamadı. Bunun hata olduğuna inanıyorsanız, iletişime geçin: %1$s</string>
-</resources>
+    <string name="language">Dil</string>
+    <string name="theme">Gövde</string>
+    <string name="theme_light">Açık</string>
+    <string name="theme_black">Siyah</string>
+    <string name="theme_dark">Koyu</string>
+    <string name="theme_wallpaper">Duvar kağıdı</string>
+    <string name="theme_day_night">Gündüz/Gece</string>
+    <string name="theme_system_default">Sistem öntanımlısı</string>
+    <string name="theme_dynamic">Dinamik</string>
+    <string name="launcher_icon">Başlatıcı simgesi</string>
+    <string name="color">Renk</string>
+    <string name="on_launch">Başlangıçta</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Başlık ve açıklamada Markdown'ı etkinleştir</string>
+    <string name="settings_localization">Yerelleştirme</string>
+    <string name="translations">Çeviri katkıları</string>
+    <string name="open_last_viewed_list">Son görülen listeyi aç</string>
+    <string name="widget_open_list">Listeyi aç</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-uk/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-uk/strings.xml
@@ -189,4 +189,22 @@
     <string name="restart_later">Пізніше</string>
     <string name="blog_feed_none">Немає</string>
     <string name="cannot_access_account">Немає доступу до облікового запису</string>
+        <string name="language">Мова</string>
+        <string name="theme">Тема</string>
+        <string name="theme_light">Світла</string>
+        <string name="theme_black">Чорна</string>
+        <string name="theme_dark">Темна</string>
+        <string name="theme_wallpaper">Шпалери</string>
+        <string name="theme_day_night">День/Ніч</string>
+        <string name="theme_system_default">За системними налаштуваннями</string>
+        <string name="theme_dynamic">Динамічна</string>
+        <string name="launcher_icon">Піктограма запуску</string>
+        <string name="color">Колір</string>
+        <string name="on_launch">Під час запуску</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Увімкнути Markdown у заголовку та описі</string>
+        <string name="settings_localization">Локалізація</string>
+        <string name="translations">Допомогти перекласти</string>
+        <string name="open_last_viewed_list">Відкрити останній переглянутий список</string>
+        <string name="widget_open_list">Відкрити список</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-ur/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-ur/strings.xml
@@ -109,4 +109,17 @@
     <string name="restart_later">بعد میں</string>
     <string name="blog_feed_none">کوئی نہیں</string>
     <string name="cannot_access_account">اکاونٹ تک رسائی نہیں ہو سکتی</string>
+    <string name="language">زبان</string>
+    <string name="theme">تھیم</string>
+    <string name="theme_light">سفید</string>
+    <string name="theme_black">سیاہ</string>
+    <string name="theme_dark">ڈارک</string>
+    <string name="theme_wallpaper">وال پیپر</string>
+    <string name="theme_day_night">دن/رات</string>
+    <string name="theme_system_default">سسٹم ڈیفالٹ</string>
+    <string name="launcher_icon">لانچر آئیکن</string>
+    <string name="color">رنگ</string>
+    <string name="settings_localization">لوکلائزیشن</string>
+    <string name="translations">ترجمہ کریں</string>
+    <string name="widget_open_list">فہرست کھولیں</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-vi/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-vi/strings.xml
@@ -174,4 +174,21 @@
     <string name="restart_later">Để sau</string>
     <string name="blog_feed_none">Không có</string>
     <string name="cannot_access_account">Không thể truy cập tài khoản</string>
+        <string name="language">Ngôn ngữ</string>
+        <string name="theme">Chủ đề</string>
+        <string name="theme_light">Sáng</string>
+        <string name="theme_black">Đen</string>
+        <string name="theme_dark">Tối</string>
+        <string name="theme_wallpaper">Hình nền</string>
+        <string name="theme_day_night">Ngày/Đêm</string>
+        <string name="theme_system_default">Mặc định hệ thống</string>
+        <string name="launcher_icon">Biểu tượng trên launcher</string>
+        <string name="color">Màu</string>
+        <string name="on_launch">Khi khởi động</string>
+        <string name="markdown">Markdown</string>
+        <string name="markdown_description">Bật Markdown trong tiêu đề và mô tả</string>
+        <string name="settings_localization">Ngôn ngữ</string>
+        <string name="translations">Đóng góp bản dịch</string>
+        <string name="open_last_viewed_list">Mở danh sách đã xem lần cuối</string>
+        <string name="widget_open_list">Mở danh sách</string>
 </resources>

--- a/kmp/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -289,4 +289,22 @@
     <string name="cannot_access_account">无法访问账号</string>
     <string name="upgrade_subscription_banner">感谢您的支持！升级您的订阅即可启用 Tasks.org 云同步</string>
     <string name="subscription_not_found">未找到您的 Tasks.org 云订阅。如果您认为这是一个错误，请联系 %1$s</string>
-</resources>
+    <string name="language">语言</string>
+    <string name="theme">主题</string>
+    <string name="theme_light">亮色</string>
+    <string name="theme_black">黑色</string>
+    <string name="theme_dark">暗色</string>
+    <string name="theme_wallpaper">壁纸</string>
+    <string name="theme_day_night">日/夜</string>
+    <string name="theme_system_default">系统默认</string>
+    <string name="theme_dynamic">动态</string>
+    <string name="launcher_icon">启动器图标</string>
+    <string name="color">颜色</string>
+    <string name="on_launch">启动时</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">在任务标题和描述中启用 Markdown</string>
+    <string name="settings_localization">本地化</string>
+    <string name="translations">贡献翻译</string>
+    <string name="open_last_viewed_list">打开上次查看的清单</string>
+    <string name="widget_open_list">打开清单</string>
+  </resources>

--- a/kmp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/kmp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -224,4 +224,22 @@
     <string name="blog_feed_none">無</string>
     <string name="cannot_access_account">無法存取帳號</string>
     <string name="upgrade_subscription_banner">感謝您的支持！升級您的訂閱以啟用 Tasks.org 雲端同步</string>
-</resources>
+    <string name="language">語言</string>
+    <string name="theme">主題</string>
+    <string name="theme_light">亮色</string>
+    <string name="theme_black">黑色</string>
+    <string name="theme_dark">深色</string>
+    <string name="theme_wallpaper">桌布</string>
+    <string name="theme_day_night">日/夜</string>
+    <string name="theme_system_default">系統預設</string>
+    <string name="theme_dynamic">動態</string>
+    <string name="launcher_icon">啟動器圖示</string>
+    <string name="color">色彩</string>
+    <string name="on_launch">啟動時</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">在標題和描述中啟用 Markdown</string>
+    <string name="settings_localization">在地化</string>
+    <string name="translations">貢獻翻譯</string>
+    <string name="open_last_viewed_list">開器最後觀看的清單</string>
+    <string name="widget_open_list">開啟清單</string>
+    </resources>

--- a/kmp/src/commonMain/composeResources/values/keys.xml
+++ b/kmp/src/commonMain/composeResources/values/keys.xml
@@ -24,4 +24,12 @@
     <string name="event_pebble" translatable="false">pebble</string>
     <string name="param_device_model" translatable="false">device_model</string>
     <string name="not_available_desktop" translatable="false">🚧🚧🚧</string>
+    <string-array name="base_theme_names">
+        <item>@string/theme_light</item>
+        <item>@string/theme_black</item>
+        <item>@string/theme_dark</item>
+        <item>@string/theme_wallpaper</item>
+        <item>@string/theme_day_night</item>
+        <item>@string/theme_system_default</item>
+    </string-array>
 </resources>

--- a/kmp/src/commonMain/composeResources/values/strings.xml
+++ b/kmp/src/commonMain/composeResources/values/strings.xml
@@ -291,4 +291,24 @@
     <string name="restart_now">Restart now</string>
     <string name="restart_later">Later</string>
     <string name="cannot_access_account">Cannot access account</string>
+    <!-- Look and feel settings -->
+    <string name="theme">Theme</string>
+    <string name="theme_dynamic">Dynamic color</string>
+    <string name="color">Color</string>
+    <string name="launcher_icon">Launcher icon</string>
+    <string name="markdown">Markdown</string>
+    <string name="markdown_description">Enable Markdown formatting for task descriptions</string>
+    <string name="on_launch">On launch</string>
+    <string name="open_last_viewed_list">Open last viewed list</string>
+    <string name="widget_open_list">Default list</string>
+    <string name="settings_localization">Localization</string>
+    <string name="language">Language</string>
+    <string name="translations">Translations</string>
+    <string name="theme_light">Light</string>
+    <string name="theme_black">Black</string>
+    <string name="theme_dark">Dark</string>
+    <string name="theme_wallpaper">Wallpaper</string>
+    <string name="theme_day_night">Day/Night</string>
+    <string name="theme_system">System default</string>
+    <string name="theme_system_default">System default</string>
 </resources>

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/settings/HelpAndFeedbackScreen.kt
@@ -332,3 +332,4 @@ fun BlogFeedModeDialog(
         confirmButton = {},
     )
 }
+

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/settings/LookAndFeelScreen.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/settings/LookAndFeelScreen.kt
@@ -23,10 +23,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import org.tasks.R
+import org.jetbrains.compose.resources.stringResource
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.color
+import tasks.kmp.generated.resources.language
+import tasks.kmp.generated.resources.launcher_icon
+import tasks.kmp.generated.resources.markdown
+import tasks.kmp.generated.resources.markdown_description
+import tasks.kmp.generated.resources.on_launch
+import tasks.kmp.generated.resources.open_last_viewed_list
+import tasks.kmp.generated.resources.requires_pro_subscription
+import tasks.kmp.generated.resources.settings_localization
+import tasks.kmp.generated.resources.theme
+import tasks.kmp.generated.resources.theme_dynamic
+import tasks.kmp.generated.resources.translations
+import tasks.kmp.generated.resources.widget_open_list
 
 @Composable
 fun LookAndFeelScreen(
@@ -58,7 +70,6 @@ fun LookAndFeelScreen(
     ) {
         Spacer(modifier = Modifier.height(SettingsContentPadding))
 
-        // Appearance island
         Column(
             modifier = Modifier.padding(horizontal = SettingsContentPadding),
             verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
@@ -70,7 +81,7 @@ fun LookAndFeelScreen(
 
             SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
                 PreferenceRow(
-                    title = stringResource(R.string.theme),
+                    title = stringResource(Res.string.theme),
                     summary = themeName,
                     onClick = onTheme,
                 )
@@ -78,12 +89,12 @@ fun LookAndFeelScreen(
             if (dynamicColorAvailable) {
                 SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
                     SwitchPreferenceRow(
-                        title = stringResource(R.string.theme_dynamic),
+                        title = stringResource(Res.string.theme_dynamic),
                         checked = dynamicColorEnabled,
                         enabled = !dynamicColorProOnly,
                         onCheckedChange = onDynamicColor,
                         summary = if (dynamicColorProOnly)
-                            stringResource(R.string.requires_pro_subscription)
+                            stringResource(Res.string.requires_pro_subscription)
                         else
                             null,
                     )
@@ -92,7 +103,7 @@ fun LookAndFeelScreen(
             if (showColor) {
                 SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
                     PreferenceRow(
-                        title = stringResource(R.string.color),
+                        title = stringResource(Res.string.color),
                         leading = { ColorIcon(Color(themeColor)) },
                         onClick = onColor,
                     )
@@ -100,7 +111,7 @@ fun LookAndFeelScreen(
             }
             SettingsItemCard(position = CardPosition.forIndex(i, total)) {
                 PreferenceRow(
-                    title = stringResource(R.string.launcher_icon),
+                    title = stringResource(Res.string.launcher_icon),
                     leading = { ColorIcon(Color(launcherColor)) },
                     onClick = onLauncher,
                 )
@@ -109,19 +120,17 @@ fun LookAndFeelScreen(
 
         Spacer(modifier = Modifier.height(SettingsContentPadding))
 
-        // Markdown island
         SettingsItemCard(modifier = Modifier.padding(horizontal = SettingsContentPadding)) {
             SwitchPreferenceRow(
-                title = stringResource(R.string.markdown),
-                summary = stringResource(R.string.markdown_description),
+                title = stringResource(Res.string.markdown),
+                summary = stringResource(Res.string.markdown_description),
                 checked = markdownEnabled,
                 onCheckedChange = onMarkdown,
             )
         }
 
-        // On launch section
         SectionHeader(
-            R.string.on_launch,
+            stringResource(Res.string.on_launch),
             modifier = Modifier.padding(horizontal = SettingsContentPadding),
         )
         Column(
@@ -130,14 +139,14 @@ fun LookAndFeelScreen(
         ) {
             SettingsItemCard(position = CardPosition.First) {
                 SwitchPreferenceRow(
-                    title = stringResource(R.string.open_last_viewed_list),
+                    title = stringResource(Res.string.open_last_viewed_list),
                     checked = openLastViewedList,
                     onCheckedChange = onOpenLastViewedList,
                 )
             }
             SettingsItemCard(position = CardPosition.Last) {
                 PreferenceRow(
-                    title = stringResource(R.string.widget_open_list),
+                    title = stringResource(Res.string.widget_open_list),
                     summary = defaultFilterName,
                     enabled = !openLastViewedList,
                     onClick = onDefaultFilter,
@@ -145,9 +154,8 @@ fun LookAndFeelScreen(
             }
         }
 
-        // Localization section
         SectionHeader(
-            R.string.settings_localization,
+            stringResource(Res.string.settings_localization),
             modifier = Modifier.padding(horizontal = SettingsContentPadding),
         )
         Column(
@@ -156,14 +164,14 @@ fun LookAndFeelScreen(
         ) {
             SettingsItemCard(position = CardPosition.First) {
                 PreferenceRow(
-                    title = stringResource(R.string.language),
+                    title = stringResource(Res.string.language),
                     summary = localeName,
                     onClick = onLanguage,
                 )
             }
             SettingsItemCard(position = CardPosition.Last) {
                 PreferenceRow(
-                    title = stringResource(R.string.translations),
+                    title = stringResource(Res.string.translations),
                     icon = Icons.AutoMirrored.Outlined.OpenInNew,
                     onClick = onTranslations,
                 )

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/compose/settings/LookAndFeelContent.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/compose/settings/LookAndFeelContent.kt
@@ -1,0 +1,231 @@
+package org.tasks.compose.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.tasks.viewmodel.LookAndFeelViewModel
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.cancel
+import tasks.kmp.generated.resources.language
+import tasks.kmp.generated.resources.restart_later
+import tasks.kmp.generated.resources.restart_now
+import tasks.kmp.generated.resources.restart_required
+import tasks.kmp.generated.resources.theme
+import tasks.kmp.generated.resources.theme_black
+import tasks.kmp.generated.resources.theme_dark
+import tasks.kmp.generated.resources.theme_day_night
+import tasks.kmp.generated.resources.theme_light
+import tasks.kmp.generated.resources.theme_system_default
+import tasks.kmp.generated.resources.theme_wallpaper
+import java.util.Locale
+
+@Composable
+fun LookAndFeelContent(
+    viewModel: LookAndFeelViewModel,
+    onColor: () -> Unit,
+    onDefaultFilter: () -> Unit,
+    onTranslations: () -> Unit,
+    onRestartApplication: () -> Unit = {},
+) {
+    var showThemeDialog by remember { mutableStateOf(false) }
+    var showLanguageDialog by remember { mutableStateOf(false) }
+    val themeLight = stringResource(Res.string.theme_light)
+    val themeBlack = stringResource(Res.string.theme_black)
+    val themeDark = stringResource(Res.string.theme_dark)
+    val themeWallpaper = stringResource(Res.string.theme_wallpaper)
+    val themeDayNight = stringResource(Res.string.theme_day_night)
+    val themeSystemDefault = stringResource(Res.string.theme_system_default)
+
+    LookAndFeelScreen(
+        themeName = when (viewModel.themeIndex) {
+            0 -> themeLight
+            1 -> themeBlack
+            2 -> themeDark
+            3 -> themeWallpaper
+            4 -> themeDayNight
+            else -> themeSystemDefault
+        },
+        dynamicColorAvailable = false,
+        dynamicColorEnabled = false,
+        dynamicColorProOnly = false,
+        themeColor = viewModel.themeColor,
+        launcherColor = viewModel.themeColor,
+        markdownEnabled = viewModel.markdownEnabled,
+        openLastViewedList = viewModel.openLastViewedList,
+        defaultFilterName = "",
+        localeName = viewModel.localeName,
+        onTheme = { showThemeDialog = true },
+        onDynamicColor = {},
+        onColor = onColor,
+        onLauncher = {},
+        onMarkdown = { viewModel.updateMarkdownEnabled(it) },
+        onOpenLastViewedList = { viewModel.updateOpenLastViewedList(it) },
+        onDefaultFilter = onDefaultFilter,
+        onLanguage = { showLanguageDialog = true },
+        onTranslations = onTranslations,
+    )
+
+    if (showThemeDialog) {
+        ThemeDialog(
+            selectedIndex = viewModel.themeIndex,
+            onSelect = { index ->
+                viewModel.setTheme(index)
+                showThemeDialog = false
+            },
+            onDismiss = { showThemeDialog = false },
+        )
+    }
+
+    if (showLanguageDialog) {
+        LanguageDialog(
+            currentTag = viewModel.languageTag,
+            onSelect = { tag ->
+                viewModel.updateLanguageTag(tag)
+                showLanguageDialog = false
+            },
+            onDismiss = { showLanguageDialog = false },
+        )
+    }
+
+    if (viewModel.showRestartDialog) {
+        ConfirmDialog(
+            text = stringResource(Res.string.restart_required),
+            confirmText = stringResource(Res.string.restart_now),
+            dismissText = stringResource(Res.string.restart_later),
+            onConfirm = onRestartApplication,
+            onDismiss = { viewModel.dismissRestartDialog() },
+        )
+    }
+}
+
+@Composable
+private fun ThemeDialog(
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val names = listOf(
+        stringResource(Res.string.theme_light),
+        stringResource(Res.string.theme_black),
+        stringResource(Res.string.theme_dark),
+        stringResource(Res.string.theme_wallpaper),
+        stringResource(Res.string.theme_day_night),
+        stringResource(Res.string.theme_system_default),
+    )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.theme)) },
+        text = {
+            Column {
+                names.forEachIndexed { index, name ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(
+                                role = Role.RadioButton,
+                                onClick = { onSelect(index) },
+                            )
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = selectedIndex == index,
+                            onClick = { onSelect(index) },
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun LanguageDialog(
+    currentTag: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val locales = remember {
+        LookAndFeelViewModel.LOCALE_TAGS.mapNotNull { tag ->
+            try {
+                val locale = Locale.forLanguageTag(tag)
+                val displayName = locale.getDisplayName(locale)
+                if (displayName.isNotBlank()) LocaleItem(tag, displayName) else null
+            } catch (_: Exception) {
+                null
+            }
+        }.sortedBy { it.displayName }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.language)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                locales.forEach { item ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(
+                                role = Role.RadioButton,
+                                onClick = { onSelect(item.tag) },
+                            )
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = currentTag == item.tag,
+                            onClick = { onSelect(item.tag) },
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = item.displayName,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}
+
+private data class LocaleItem(
+    val tag: String,
+    val displayName: String,
+)

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/viewmodel/LookAndFeelViewModel.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/viewmodel/LookAndFeelViewModel.kt
@@ -1,0 +1,107 @@
+package org.tasks.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.tasks.preferences.TasksPreferences
+import org.tasks.themes.BLUE
+import java.util.Locale
+
+open class LookAndFeelViewModel(
+    private val tasksPreferences: TasksPreferences,
+) : ViewModel() {
+
+    var themeIndex by mutableIntStateOf(5)
+        private set
+    var themeColor by mutableIntStateOf(BLUE)
+        private set
+    var markdownEnabled by mutableStateOf(false)
+        private set
+    var openLastViewedList by mutableStateOf(true)
+        private set
+    var languageTag by mutableStateOf("")
+        private set
+    var showRestartDialog by mutableStateOf(false)
+        private set
+
+    val localeName: String
+        get() {
+            val tag = languageTag
+            if (tag.isBlank()) return ""
+            return try {
+                val locale = Locale.forLanguageTag(tag)
+                locale.getDisplayName(locale)
+            } catch (_: Exception) {
+                tag
+            }
+        }
+
+    init {
+        viewModelScope.launch {
+            themeIndex = tasksPreferences.get(TasksPreferences.theme, 5)
+            themeColor = tasksPreferences.get(TasksPreferences.themeColor, BLUE)
+            markdownEnabled = tasksPreferences.get(TasksPreferences.markdownEnabled, false)
+            openLastViewedList = tasksPreferences.get(TasksPreferences.openLastViewedList, true)
+            languageTag = tasksPreferences.get(TasksPreferences.languageTag, "")
+        }
+    }
+
+    fun setTheme(index: Int) {
+        themeIndex = index
+        viewModelScope.launch {
+            tasksPreferences.set(TasksPreferences.theme, index)
+        }
+    }
+
+    fun updateThemeColor(color: Int) {
+        themeColor = color
+        viewModelScope.launch {
+            tasksPreferences.set(TasksPreferences.themeColor, color)
+        }
+    }
+
+    fun updateMarkdownEnabled(enabled: Boolean) {
+        markdownEnabled = enabled
+        viewModelScope.launch {
+            tasksPreferences.set(TasksPreferences.markdownEnabled, enabled)
+        }
+    }
+
+    fun updateOpenLastViewedList(enabled: Boolean) {
+        openLastViewedList = enabled
+        viewModelScope.launch {
+            tasksPreferences.set(TasksPreferences.openLastViewedList, enabled)
+        }
+    }
+
+    fun updateLanguageTag(tag: String) {
+        languageTag = tag
+        if (tag.isNotBlank()) {
+            Locale.setDefault(Locale.forLanguageTag(tag))
+        }
+        showRestartDialog = true
+        viewModelScope.launch {
+            tasksPreferences.set(TasksPreferences.languageTag, tag)
+        }
+    }
+
+    fun dismissRestartDialog() {
+        showRestartDialog = false
+    }
+
+    companion object {
+        val LOCALE_TAGS = listOf(
+            "en", "af", "ar", "ast", "be", "bg", "bn", "bs", "ca", "ckb",
+            "cs", "cv", "da", "de", "el", "eo", "es", "et", "eu", "fa",
+            "fi", "fr", "gl", "hr", "hu", "hy", "ia", "id", "it", "iw",
+            "he", "ja", "kmr", "kn", "ko", "krl", "lt", "ml", "mr", "my",
+            "nah", "nb", "ne", "nl", "or", "pl", "pt", "pt-BR", "ro", "ru",
+            "si", "sk", "sl", "sr", "sv", "szl", "ta", "th", "tl", "tr",
+            "uk", "ur", "vi", "zh-CN", "zh-TW",
+        )
+    }
+}


### PR DESCRIPTION
Mostly written with AI with additional testing and prompting by me to get more of the features of the screen working.

The instructions you wrote on my first PR were very helpful for the LLM to get _most_ of the initial work done. It may be a good idea to include that as part of an agent skills markdown file to its more readily available for this kind of work. Honestly I didn't need to spend much time on this at all because of the instructions you wrote.

Now, I'm not sure about some of the "not implemented" function parameters because they _are_ working for the desktop, but it feels strange to keep them like that.