### PR TITLE
composeApp includes task refresh button

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/tasks/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/App.kt
@@ -22,6 +22,9 @@ import androidx.compose.foundation.verticalScroll
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import org.tasks.jobs.BackgroundWork
+import org.tasks.sync.SyncSource
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
@@ -414,9 +417,11 @@ fun App(
                         LaunchedEffect(Unit) {
                             taskListViewModel.setFilter(MyTasksFilter.create())
                         }
+                        val state by taskListViewModel.state.collectAsState()
                         TaskListScreen(
                             viewModel = taskListViewModel,
                             drawerViewModel = drawerViewModel,
+                            syncOngoing = state.syncOngoing,
                             onSettingsClick = { backStack.add(SettingsDestination) },
                             onSubscribe = { backStack.add(DesktopProDestination()) },
                         )
@@ -731,6 +736,7 @@ private fun SignInErrorDialog(
 private fun TaskListScreen(
     viewModel: TaskListViewModel,
     drawerViewModel: DrawerViewModel,
+    syncOngoing: Boolean,
     onSettingsClick: () -> Unit,
     onSubscribe: () -> Unit,
 ) {
@@ -862,6 +868,7 @@ private fun TaskListScreen(
                         reporting = reporting,
                         viewModel = viewModel,
                         themeColor = themeColor,
+                        syncOngoing = syncOngoing,
                         onShowSortSheet = { showSortSheet = true },
                         onTaskClick = onTaskClick,
                         showMenuButton = true,
@@ -923,6 +930,7 @@ private fun TaskListScreen(
                         reporting = reporting,
                         viewModel = viewModel,
                         themeColor = themeColor,
+                        syncOngoing = syncOngoing,
                         onShowSortSheet = { showSortSheet = true },
                         onTaskClick = onTaskClick,
                         showMenuButton = true,
@@ -1023,6 +1031,7 @@ private fun TaskListContent(
     reporting: org.tasks.analytics.Reporting,
     viewModel: TaskListViewModel,
     themeColor: org.tasks.kmp.org.tasks.themes.ThemeColor,
+    syncOngoing: Boolean,
     onShowSortSheet: () -> Unit,
     onTaskClick: (TaskKey) -> Unit,
     showMenuButton: Boolean,
@@ -1047,6 +1056,7 @@ private fun TaskListContent(
                 reporting = reporting,
                 viewModel = viewModel,
                 themeColor = themeColor,
+                syncOngoing = syncOngoing,
                 showMenuButton = showMenuButton,
                 onShowSortSheet = onShowSortSheet,
                 onMenuClick = onMenuClick,
@@ -1109,6 +1119,7 @@ private fun TaskListPane(
     reporting: org.tasks.analytics.Reporting,
     viewModel: TaskListViewModel,
     themeColor: org.tasks.kmp.org.tasks.themes.ThemeColor,
+    syncOngoing: Boolean,
     showMenuButton: Boolean,
     onShowSortSheet: () -> Unit,
     onMenuClick: () -> Unit,
@@ -1226,6 +1237,24 @@ private fun TaskListPane(
                 )
             },
             actions = {
+                val backgroundWork = koinInject<BackgroundWork>()
+                val scope = rememberCoroutineScope()
+                IconButton(onClick = {
+                    scope.launch { backgroundWork.sync(SyncSource.USER_INITIATED) }
+                }) {
+                    if (syncOngoing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        org.tasks.compose.components.TasksIcon(
+                            label = "refresh",
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+                
                 SettingsMenuButton(
                     showListSettings = showListSettings,
                     onSettingsClick = onSettingsClick,

--- a/composeApp/src/commonMain/kotlin/org/tasks/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/tasks/di/CommonModule.kt
@@ -190,6 +190,7 @@ val commonModule = module {
         val scope = get<CoroutineScope>()
         val mutex = kotlinx.coroutines.sync.Mutex()
         val pending = java.util.concurrent.atomic.AtomicBoolean(false)
+        val tasksPreferences = get<TasksPreferences>()
         object : BackgroundWork {
             override fun updateCalendar(task: Task) {}
             override suspend fun scheduleRefresh(timestamp: Long) {}
@@ -206,6 +207,7 @@ val commonModule = module {
                         return@launch
                     }
                     try {
+                        tasksPreferences.set(TasksPreferences.syncSource, source.name)
                         do {
                             pending.set(false)
                             val caldavSynchronizer = get<CaldavSynchronizer>()
@@ -224,6 +226,7 @@ val commonModule = module {
                             get<OpenTasksSyncer>().sync(hasPro = hasPro)
                         } while (pending.getAndSet(false))
                     } finally {
+                        tasksPreferences.set(TasksPreferences.syncSource, SyncSource.NONE.name)
                         mutex.unlock()
                     }
                 }


### PR DESCRIPTION
Adds the refresh button on app task list. Swipe to refresh _could_ (still) be implemented on desktop, but I think it's worth having the button either way. If we'd rather make the button only for the desktop, is there a preferred pattern to follow?