### PR TITLE
Fix keyboard not showing when adding a task from the widget

### DIFF
--- a/app/src/main/java/org/tasks/compose/edit/EditTextView.kt
+++ b/app/src/main/java/org/tasks/compose/edit/EditTextView.kt
@@ -22,9 +22,12 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.addTextChangedListener
 import org.tasks.R
 import org.tasks.dialogs.Linkify
+import org.tasks.extensions.Context.findActivity
 import org.tasks.markdown.MarkdownProvider
 
 @Composable
@@ -113,8 +116,14 @@ fun EditTextView(
                 view.post {
                     fun tryFocus(attempts: Int = 3) {
                         if (view.requestFocus()) {
-                            val imm = context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
-                            imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+                            view.context.findActivity()?.window?.let { window ->
+                                WindowCompat
+                                    .getInsetsController(window, view)
+                                    .show(WindowInsetsCompat.Type.ime())
+                            } ?: run {
+                                val imm = context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                                imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+                            }
                         } else if (attempts > 1) {
                             view.postDelayed({ tryFocus(attempts - 1) }, 50)
                         }


### PR DESCRIPTION
## Summary
Fixes the widget add-task flow where the title field gets focus, but the soft keyboard does not appear.

The title editor now asks the window insets controller to show the IME after focus is requested. The existing InputMethodManager call remains as a fallback when an Activity window is not available.

## Scope
- Only changes the edit title keyboard display path.
- No changes to widget intents, task creation, manifest soft input mode, models, or sync behavior.