### PR TITLE
Preserve custom reminder pattern after snooze

### DIFF
--- a/app/src/androidTest/java/com/todoroo/astrid/alarms/AlarmJobServiceTest.kt
+++ b/app/src/androidTest/java/com/todoroo/astrid/alarms/AlarmJobServiceTest.kt
@@ -128,7 +128,7 @@ class AlarmJobServiceTest : InjectingTestCase() {
                     Notification(
                         taskId = 1L,
                         timestamp = DateTimeUtils2.currentTimeMillis(),
-                        type = Alarm.TYPE_REL_END
+                        type = Alarm.TYPE_SNOOZE
                     )
                 ),
                 0
@@ -201,6 +201,381 @@ class AlarmJobServiceTest : InjectingTestCase() {
             testResults(
                 emptyList(),
                 DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+            )
+        }
+    }
+
+    @Test
+    fun snoozePreservesRepeatingReminderPattern() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+            taskDao.setLastNotified(1, DateTime(DateTimeUtils2.currentTimeMillis()).endOfMinute().millis)
+
+            alarmService.snooze(DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1), listOf(1))
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingRepeatingSnoozeResetsPatternFromBaseReminder() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 1,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+            taskDao.setLastNotified(1, DateTime(DateTimeUtils2.currentTimeMillis()).endOfMinute().millis)
+
+            alarmService.snooze(DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1), listOf(1))
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingExistingSnoozeFallsBackToSnoozeTemplateWhenBaseMissing() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(Task())
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterRepeatingReminderFinishesPreservesPattern() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterChainFinishesUsesMostRecentBaseTemplate() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(type = Alarm.TYPE_REL_END),
+                    Alarm(
+                        time = TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(id = 1, task = 1, time = 0, type = Alarm.TYPE_REL_END),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun repeatingSnoozeSchedulesNextOccurrence() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY,
+                        DateTime(2024, 5, 17).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+
+            testResults(
+                listOf(
+                    Notification(
+                        taskId = 1L,
+                        timestamp = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE
+                    )
+                ),
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 1,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun overdueSnoozeOverridesOverdueBaseReminder() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 25)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 10).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 11).millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            testResults(
+                listOf(
+                    Notification(
+                        taskId = 1L,
+                        timestamp = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE
+                    )
+                ),
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
             )
         }
     }

--- a/app/src/androidTest/java/com/todoroo/astrid/alarms/AlarmJobServiceTest.kt
+++ b/app/src/androidTest/java/com/todoroo/astrid/alarms/AlarmJobServiceTest.kt
@@ -128,7 +128,7 @@ class AlarmJobServiceTest : InjectingTestCase() {
                     Notification(
                         taskId = 1L,
                         timestamp = DateTimeUtils2.currentTimeMillis(),
-                        type = Alarm.TYPE_REL_END
+                        type = Alarm.TYPE_SNOOZE
                     )
                 ),
                 0
@@ -201,6 +201,500 @@ class AlarmJobServiceTest : InjectingTestCase() {
             testResults(
                 emptyList(),
                 DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+            )
+        }
+    }
+
+    @Test
+    fun snoozePreservesRepeatingReminderPattern() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+            taskDao.setLastNotified(1, DateTime(DateTimeUtils2.currentTimeMillis()).endOfMinute().millis)
+
+            alarmService.snooze(DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1), listOf(1))
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingRepeatingSnoozeResetsPatternFromBaseReminder() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 1,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+            taskDao.setLastNotified(1, DateTime(DateTimeUtils2.currentTimeMillis()).endOfMinute().millis)
+
+            alarmService.snooze(DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1), listOf(1))
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingExistingSnoozeFallsBackToSnoozeTemplateWhenBaseMissing() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(Task())
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterRepeatingReminderFinishesPreservesPattern() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterRepeatingReminderFinishesPrefersBasePattern() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterChainFinishesUsesMostRecentBaseTemplate() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(type = Alarm.TYPE_REL_END),
+                    Alarm(
+                        time = TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(id = 1, task = 1, time = 0, type = Alarm.TYPE_REL_END),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun snoozingAfterChainFinishesUsesLatestDateTimeOccurrence() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 30)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 20).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 25, 30).endOfMinute().millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        time = DateTime(2024, 5, 17, 23, 20).millis,
+                        type = Alarm.TYPE_DATE_TIME,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        time = TimeUnit.MINUTES.toMillis(4),
+                        type = Alarm.TYPE_REL_END,
+                    )
+                )
+            )
+
+            alarmService.snooze(
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                listOf(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = DateTime(2024, 5, 17, 23, 20).millis,
+                        type = Alarm.TYPE_DATE_TIME,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = TimeUnit.MINUTES.toMillis(4),
+                        type = Alarm.TYPE_REL_END,
+                    ),
+                    Alarm(
+                        id = 3,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.HOURS.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun repeatingSnoozeSchedulesNextOccurrence() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 20)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY,
+                        DateTime(2024, 5, 17).millis
+                    )
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                )
+            )
+
+            testResults(
+                listOf(
+                    Notification(
+                        taskId = 1L,
+                        timestamp = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE
+                    )
+                ),
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 2,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 1,
+                        interval = TimeUnit.MINUTES.toMillis(5)
+                    )
+                ),
+                alarmService.getAlarms(1)
+            )
+        }
+    }
+
+    @Test
+    fun overdueSnoozeOverridesOverdueBaseReminder() = runBlocking {
+        freezeAt(DateTime(2024, 5, 17, 23, 25)) {
+            taskDao.insert(
+                Task(
+                    dueDate = createDueDate(
+                        Task.URGENCY_SPECIFIC_DAY_TIME,
+                        DateTime(2024, 5, 17, 23, 10).millis
+                    ),
+                    reminderLast = DateTime(2024, 5, 17, 23, 11).millis,
+                )
+            )
+            alarmService.synchronizeAlarms(
+                1,
+                mutableSetOf(
+                    Alarm(
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        time = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                )
+            )
+
+            testResults(
+                listOf(
+                    Notification(
+                        taskId = 1L,
+                        timestamp = DateTimeUtils2.currentTimeMillis(),
+                        type = Alarm.TYPE_SNOOZE
+                    )
+                ),
+                DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1)
+            )
+
+            assertEquals(
+                listOf(
+                    Alarm(
+                        id = 1,
+                        task = 1,
+                        time = 0,
+                        type = Alarm.TYPE_REL_END,
+                        repeat = 5,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    ),
+                    Alarm(
+                        id = 2,
+                        task = 1,
+                        time = DateTimeUtils2.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1),
+                        type = Alarm.TYPE_SNOOZE,
+                        repeat = 4,
+                        interval = TimeUnit.MINUTES.toMillis(1)
+                    )
+                ),
+                alarmService.getAlarms(1)
             )
         }
     }

--- a/app/src/test/java/com/todoroo/astrid/alarms/AlarmCalculatorTest.kt
+++ b/app/src/test/java/com/todoroo/astrid/alarms/AlarmCalculatorTest.kt
@@ -261,6 +261,17 @@ class AlarmCalculatorTest {
     }
 
     @Test
+    fun ignoreRepeatWithNoInterval() {
+        val alarm = alarmCalculator.toAlarmEntry(
+            newTask(with(DUE_TIME, now), with(REMINDER_LAST, now.plusMinutes(1))),
+            Alarm(type = TYPE_REL_END, repeat = 1),
+            defaultDueTime,
+        )
+
+        assertNull(alarm)
+    }
+
+    @Test
     fun dontScheduleRelativeEndWithNoEnd() {
         assertNull(alarmCalculator.toAlarmEntry(newTask(), whenDue(0L), defaultDueTime))
     }

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/AlarmDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/AlarmDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import org.tasks.data.entity.Alarm
 import org.tasks.data.entity.Alarm.Companion.TYPE_SNOOZE
 import org.tasks.data.entity.Task
@@ -46,6 +47,9 @@ WHERE tasks._id = :taskId
 
     @Insert
     suspend fun insert(alarms: Iterable<Alarm>)
+
+    @Update
+    suspend fun update(alarm: Alarm)
 
     suspend fun getAlarms(task: Task) = ArrayList(if (task.isNew) {
         emptyList()

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/AlarmDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/AlarmDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import org.tasks.data.entity.Alarm
 import org.tasks.data.entity.Alarm.Companion.TYPE_SNOOZE
@@ -70,6 +71,9 @@ WHERE tasks._id = :taskId
 
     @Insert
     suspend fun insert(alarms: Iterable<Alarm>)
+
+    @Update
+    suspend fun update(alarm: Alarm)
 
     suspend fun getAlarms(task: Task) = ArrayList(if (task.isNew) {
         emptyList()

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmCalculator.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmCalculator.kt
@@ -11,33 +11,7 @@ class AlarmCalculator(
     private val defaultDueTime: Int,
 ) {
     fun toAlarmEntry(task: Task, alarm: Alarm): Notification? {
-        val trigger = when (alarm.type) {
-            Alarm.TYPE_SNOOZE,
-            Alarm.TYPE_DATE_TIME ->
-                alarm.time
-            Alarm.TYPE_REL_START ->
-                when {
-                    task.hasStartTime() ->
-                        task.hideUntil + alarm.time
-                    task.hasStartDate() ->
-                        task.hideUntil.withMillisOfDay(defaultDueTime) + alarm.time
-                    else ->
-                        AlarmService.NO_ALARM
-                }
-            Alarm.TYPE_REL_END ->
-                when {
-                    task.hasDueTime() ->
-                        task.dueDate + alarm.time
-                    task.hasDueDate() ->
-                        task.dueDate.withMillisOfDay(defaultDueTime) + alarm.time
-                    else ->
-                        AlarmService.NO_ALARM
-                }
-            Alarm.TYPE_RANDOM ->
-                calculateNextRandomReminder(random, task, alarm.time)
-            else ->
-                AlarmService.NO_ALARM
-        }
+        val trigger = triggerTime(task, alarm)
         return when {
             trigger <= AlarmService.NO_ALARM ->
                 null
@@ -55,6 +29,52 @@ class AlarmCalculator(
             else ->
                 null
         }
+    }
+
+    fun latestTriggerAtOrBefore(task: Task, alarm: Alarm, timestamp: Long): Long? {
+        val trigger = triggerTime(task, alarm)
+        return when {
+            trigger <= AlarmService.NO_ALARM || timestamp < trigger ->
+                null
+            alarm.type == Alarm.TYPE_RANDOM ->
+                null
+            alarm.type == Alarm.TYPE_SNOOZE || alarm.type == Alarm.TYPE_DATE_TIME ->
+                trigger
+            alarm.repeat > 0 && alarm.interval > 0 -> {
+                val past = minOf((timestamp - trigger) / alarm.interval, alarm.repeat.toLong())
+                trigger + past * alarm.interval
+            }
+            else ->
+                trigger
+        }
+    }
+
+    private fun triggerTime(task: Task, alarm: Alarm) = when (alarm.type) {
+        Alarm.TYPE_SNOOZE,
+        Alarm.TYPE_DATE_TIME ->
+            alarm.time
+        Alarm.TYPE_REL_START ->
+            when {
+                task.hasStartTime() ->
+                    task.hideUntil + alarm.time
+                task.hasStartDate() ->
+                    task.hideUntil.withMillisOfDay(defaultDueTime) + alarm.time
+                else ->
+                    AlarmService.NO_ALARM
+            }
+        Alarm.TYPE_REL_END ->
+            when {
+                task.hasDueTime() ->
+                    task.dueDate + alarm.time
+                task.hasDueDate() ->
+                    task.dueDate.withMillisOfDay(defaultDueTime) + alarm.time
+                else ->
+                    AlarmService.NO_ALARM
+            }
+        Alarm.TYPE_RANDOM ->
+            calculateNextRandomReminder(random, task, alarm.time)
+        else ->
+            AlarmService.NO_ALARM
     }
 
     private fun calculateNextRandomReminder(random: Random, task: Task, reminderPeriod: Long) =

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmCalculator.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmCalculator.kt
@@ -10,39 +10,13 @@ class AlarmCalculator(
     private val random: Random,
 ) {
     fun toAlarmEntry(task: Task, alarm: Alarm, defaultDueTime: Int): Notification? {
-        val trigger = when (alarm.type) {
-            Alarm.TYPE_SNOOZE,
-            Alarm.TYPE_DATE_TIME ->
-                alarm.time
-            Alarm.TYPE_REL_START ->
-                when {
-                    task.hasStartTime() ->
-                        task.hideUntil + alarm.time
-                    task.hasStartDate() ->
-                        task.hideUntil.withMillisOfDay(defaultDueTime) + alarm.time
-                    else ->
-                        AlarmService.NO_ALARM
-                }
-            Alarm.TYPE_REL_END ->
-                when {
-                    task.hasDueTime() ->
-                        task.dueDate + alarm.time
-                    task.hasDueDate() ->
-                        task.dueDate.withMillisOfDay(defaultDueTime) + alarm.time
-                    else ->
-                        AlarmService.NO_ALARM
-                }
-            Alarm.TYPE_RANDOM ->
-                calculateNextRandomReminder(random, task, alarm.time)
-            else ->
-                AlarmService.NO_ALARM
-        }
+        val trigger = triggerTime(task, alarm, defaultDueTime)
         return when {
             trigger <= AlarmService.NO_ALARM ->
                 null
             trigger > task.reminderLast || alarm.type == Alarm.TYPE_SNOOZE ->
                 Notification(taskId = alarm.task, timestamp = trigger, type = alarm.type)
-            alarm.repeat > 0 -> {
+            alarm.repeat > 0 && alarm.interval > 0 -> {
                 val past = (task.reminderLast - trigger) / alarm.interval
                 val next = trigger + (past + 1) * alarm.interval
                 if (past < alarm.repeat && next > task.reminderLast) {
@@ -54,6 +28,57 @@ class AlarmCalculator(
             else ->
                 null
         }
+    }
+
+    fun latestTriggerAtOrBefore(
+        task: Task,
+        alarm: Alarm,
+        defaultDueTime: Int,
+        timestamp: Long,
+    ): Long? {
+        val trigger = triggerTime(task, alarm, defaultDueTime)
+        return when {
+            trigger <= AlarmService.NO_ALARM || timestamp < trigger ->
+                null
+            alarm.type == Alarm.TYPE_RANDOM ->
+                null
+            alarm.type == Alarm.TYPE_SNOOZE ->
+                trigger
+            alarm.repeat > 0 && alarm.interval > 0 -> {
+                val past = minOf((timestamp - trigger) / alarm.interval, alarm.repeat.toLong())
+                trigger + past * alarm.interval
+            }
+            else ->
+                trigger
+        }
+    }
+
+    private fun triggerTime(task: Task, alarm: Alarm, defaultDueTime: Int) = when (alarm.type) {
+        Alarm.TYPE_SNOOZE,
+        Alarm.TYPE_DATE_TIME ->
+            alarm.time
+        Alarm.TYPE_REL_START ->
+            when {
+                task.hasStartTime() ->
+                    task.hideUntil + alarm.time
+                task.hasStartDate() ->
+                    task.hideUntil.withMillisOfDay(defaultDueTime) + alarm.time
+                else ->
+                    AlarmService.NO_ALARM
+            }
+        Alarm.TYPE_REL_END ->
+            when {
+                task.hasDueTime() ->
+                    task.dueDate + alarm.time
+                task.hasDueDate() ->
+                    task.dueDate.withMillisOfDay(defaultDueTime) + alarm.time
+                else ->
+                    AlarmService.NO_ALARM
+            }
+        Alarm.TYPE_RANDOM ->
+            calculateNextRandomReminder(random, task, alarm.time)
+        else ->
+            AlarmService.NO_ALARM
     }
 
     private fun calculateNextRandomReminder(random: Random, task: Task, reminderPeriod: Long) =

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmService.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmService.kt
@@ -9,10 +9,10 @@ import co.touchlab.kermit.Logger
 import org.tasks.broadcast.RefreshBroadcaster
 import org.tasks.data.dao.AlarmDao
 import org.tasks.data.dao.TaskDao
-import org.tasks.data.db.DbUtils
 import org.tasks.data.entity.Alarm
 import org.tasks.data.entity.Alarm.Companion.TYPE_SNOOZE
 import org.tasks.data.entity.Notification
+import org.tasks.data.entity.Task
 import org.tasks.notifications.CancelReason
 import org.tasks.notifications.Notifier
 import org.tasks.preferences.AppPreferences
@@ -27,6 +27,11 @@ class AlarmService(
     private val alarmCalculator: AlarmCalculator,
     private val preferences: AppPreferences,
 ) {
+    private data class AlarmTrigger(
+        val alarm: Alarm,
+        val notification: Notification,
+    )
+
     suspend fun getAlarms(taskId: Long): List<Alarm> = alarmDao.getAlarms(taskId)
 
     /**
@@ -54,8 +59,21 @@ class AlarmService(
 
     suspend fun snooze(time: Long, taskIds: List<Long>) {
         notifier.cancel(taskIds, CancelReason.SNOOZE)
+        val templates = taskIds.associateWith { taskId ->
+            getSnoozeTemplate(taskId)
+        }
         alarmDao.deleteSnoozed(taskIds)
-        alarmDao.insert(taskIds.map { Alarm(task = it, time = time, type = TYPE_SNOOZE) })
+        val snoozed = taskIds.map { taskId ->
+            val template = templates[taskId]
+            Alarm(
+                task = taskId,
+                time = time,
+                type = TYPE_SNOOZE,
+                repeat = template?.repeat ?: 0,
+                interval = template?.interval ?: 0,
+            )
+        }
+        alarmDao.insert(snoozed)
         taskDao.touch(taskIds)
         notifier.triggerNotifications()
     }
@@ -67,51 +85,102 @@ class AlarmService(
             return preferences.adjustForQuietHours(currentTimeMillis())
         }
         val (overdue, _) = getAlarms()
-        overdue
-            .sortedBy { it.timestamp }
-            .also { alarms ->
-                alarms
-                    .map { it.taskId }
-                    .chunked(DbUtils.MAX_SQLITE_ARGS)
-                    .onEach { alarmDao.deleteSnoozed(it) }
+        val triggered = overdue
+            .sortedBy { it.notification.timestamp }
+            .map { trigger ->
+                trigger.copy(
+                    notification = trigger.notification.copy(timestamp = currentTimeMillis())
+                )
             }
-            .map { it.copy(timestamp = currentTimeMillis()) }
-            .let { trigger(it) }
-        val alreadyTriggered = overdue.map { it.taskId }.toSet()
+        trigger(triggered.map { it.notification })
+        triggered.forEach { trigger ->
+            if (trigger.alarm.type == TYPE_SNOOZE) {
+                if (trigger.alarm.repeat > 0 && trigger.alarm.interval > 0) {
+                    val updated = trigger.alarm.copy(
+                        time = trigger.notification.timestamp + trigger.alarm.interval,
+                        repeat = trigger.alarm.repeat - 1,
+                    )
+                    alarmDao.update(updated)
+                } else {
+                    alarmDao.deleteSnoozed(listOf(trigger.notification.taskId))
+                }
+            }
+        }
+        val alreadyTriggered = triggered.map { it.notification.taskId }.toSet()
         val (moreOverdue, future) = getAlarms()
-        return moreOverdue
+        val nextAlarm = moreOverdue
+            .map { it.notification }
             .filterNot { it.type == Alarm.TYPE_RANDOM || alreadyTriggered.contains(it.taskId) }
-            .plus(future)
+            .plus(future.map { it.notification })
             .minOfOrNull { it.timestamp }
             ?: 0
+        return nextAlarm
     }
 
-    internal suspend fun getAlarms(): Pair<List<Notification>, List<Notification>> {
+    private suspend fun getAlarms(): Pair<List<AlarmTrigger>, List<AlarmTrigger>> {
         val start = currentTimeMillis()
-        val overdue = ArrayList<Notification>()
-        val future = ArrayList<Notification>()
+        val overdue = ArrayList<AlarmTrigger>()
+        val future = ArrayList<AlarmTrigger>()
         val nextMinute = currentTimeMillis().startOfMinute() + 60_000
         alarmDao.getActiveAlarms()
             .groupBy { it.task }
             .forEach { (taskId, alarms) ->
                 val task = taskDao.fetch(taskId) ?: return@forEach
-                val alarmEntries = alarms.mapNotNull {
-                    alarmCalculator.toAlarmEntry(task, it)
-                }
-                val (now, later) = alarmEntries.partition {
-                    it.timestamp < nextMinute
-                }
-                later
-                    .filter { it.type == TYPE_SNOOZE }
-                    .maxByOrNull { it.timestamp }
-                    ?.let { future.add(it) }
-                    ?: run {
-                        now.firstOrNull()?.let { overdue.add(it) }
-                        later.minByOrNull { it.timestamp }?.let { future.add(it) }
-                    }
+                val (now, later) = getAlarms(task, alarms, nextMinute)
+                now?.let { overdue.add(it) }
+                later?.let { future.add(it) }
             }
         Logger.d("AlarmService") { "took ${currentTimeMillis() - start}ms overdue=${overdue.size} future=${future.size}" }
         return overdue to future
+    }
+
+    private fun getAlarms(
+        task: Task,
+        alarms: List<Alarm>,
+        nextMinute: Long,
+    ): Pair<AlarmTrigger?, AlarmTrigger?> {
+        val alarmEntries = alarms.mapNotNull { alarm ->
+            alarmCalculator.toAlarmEntry(task, alarm)?.let { notification ->
+                AlarmTrigger(alarm, notification)
+            }
+        }
+        val snoozed = alarmEntries
+            .filter { it.notification.type == TYPE_SNOOZE }
+            .maxByOrNull { it.notification.timestamp }
+        if (snoozed != null) {
+            return if (snoozed.notification.timestamp < nextMinute) {
+                snoozed to null
+            } else {
+                null to snoozed
+            }
+        }
+        val (now, later) = alarmEntries.partition {
+            it.notification.timestamp < nextMinute
+        }
+        return now.firstOrNull() to later.minByOrNull { it.notification.timestamp }
+    }
+
+    private suspend fun getSnoozeTemplate(taskId: Long): Alarm? {
+        val task = taskDao.fetch(taskId) ?: return null
+        val alarms = alarmDao.getActiveAlarms(taskId)
+        val baseAlarms = alarms.filter { it.type != TYPE_SNOOZE }
+        val nextMinute = currentTimeMillis().startOfMinute() + 60_000
+        val (baseOverdue, baseFuture) = getAlarms(task, baseAlarms, nextMinute)
+        if (baseOverdue != null || baseFuture != null) {
+            return baseOverdue?.alarm ?: baseFuture?.alarm
+        }
+        val (overdue, future) = getAlarms(task, alarms, nextMinute)
+        if (overdue != null || future != null) {
+            return overdue?.alarm ?: future?.alarm
+        }
+        return baseAlarms
+            .mapNotNull { alarm ->
+                alarmCalculator.latestTriggerAtOrBefore(task, alarm, task.reminderLast)?.let { timestamp ->
+                    alarm to timestamp
+                }
+            }
+            .maxByOrNull { it.second }
+            ?.first
     }
 
     companion object {

--- a/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmService.kt
+++ b/kmp/src/commonMain/kotlin/com/todoroo/astrid/alarms/AlarmService.kt
@@ -16,6 +16,7 @@ import org.tasks.data.entity.Alarm
 import org.tasks.data.entity.Alarm.Companion.TYPE_SNOOZE
 import org.tasks.data.entity.CaldavAccount.Companion.TYPES_ALARMS
 import org.tasks.data.entity.Notification
+import org.tasks.data.entity.Task
 import org.tasks.notifications.CancelReason
 import org.tasks.notifications.Notifier
 import org.tasks.preferences.AppPreferences
@@ -64,9 +65,21 @@ class AlarmService(
 
     suspend fun snooze(time: Long, taskIds: List<Long>) {
         notifier.cancel(taskIds, CancelReason.SNOOZE)
+        val templates = taskIds.associateWith { getSnoozeTemplate(it) }
         recordDismissal(taskIds, currentTimeMillis()) {
             alarmDao.deleteSnoozed(taskIds)
-            alarmDao.insert(taskIds.map { Alarm(task = it, time = time, type = TYPE_SNOOZE) })
+            alarmDao.insert(
+                taskIds.map { taskId ->
+                    val template = templates[taskId]
+                    Alarm(
+                        task = taskId,
+                        time = time,
+                        type = TYPE_SNOOZE,
+                        repeat = template?.repeat ?: 0,
+                        interval = template?.interval ?: 0,
+                    )
+                }
+            )
         }
         notifier.triggerNotifications()
     }
@@ -108,8 +121,19 @@ class AlarmService(
             .map { it.copy(timestamp = start) }
             .let { trigger(it) }
             .toSet()
-        snoozed
-            .filter { it.task in handled }
+        val handledSnoozed = snoozed.filter { it.task in handled }
+        handledSnoozed
+            .filter { it.repeat > 0 && it.interval > 0 }
+            .forEach { alarm ->
+                alarmDao.update(
+                    alarm.copy(
+                        time = start + alarm.interval,
+                        repeat = alarm.repeat - 1,
+                    )
+                )
+            }
+        handledSnoozed
+            .filterNot { it.repeat > 0 && it.interval > 0 }
             .map { it.id }
             .eachChunk { alarmDao.deleteByIds(it) }
         val alreadyTriggered = overdue.map { it.taskId }.toSet()
@@ -141,20 +165,74 @@ class AlarmService(
                 val alarmEntries = alarms.mapNotNull {
                     alarmCalculator.toAlarmEntry(task, it, defaultDueTime)
                 }
-                val (now, later) = alarmEntries.partition {
-                    it.timestamp < cutoff
-                }
-                later
+                val snoozed = alarmEntries
                     .filter { it.type == TYPE_SNOOZE }
                     .maxByOrNull { it.timestamp }
-                    ?.let { future.add(it) }
-                    ?: run {
-                        now.firstOrNull()?.let { overdue.add(it) }
-                        later.minByOrNull { it.timestamp }?.let { future.add(it) }
+                if (snoozed != null) {
+                    if (snoozed.timestamp < cutoff) {
+                        overdue.add(snoozed)
+                    } else {
+                        future.add(snoozed)
                     }
+                } else {
+                    val (now, later) = alarmEntries.partition {
+                        it.timestamp < cutoff
+                    }
+                    now.minByOrNull { it.timestamp }?.let { overdue.add(it) }
+                    later.minByOrNull { it.timestamp }?.let { future.add(it) }
+                }
             }
         Logger.d("AlarmService") { "took ${currentTimeMillis() - start}ms overdue=${overdue.size} future=${future.size}" }
         return overdue to future
+    }
+
+    private fun getActiveAlarm(
+        task: Task,
+        alarms: List<Alarm>,
+        defaultDueTime: Int,
+        cutoff: Long,
+    ): Notification? {
+        val alarmEntries = alarms.mapNotNull { alarm ->
+            alarmCalculator.toAlarmEntry(task, alarm, defaultDueTime)
+        }
+        val snoozed = alarmEntries
+            .filter { it.type == TYPE_SNOOZE }
+            .maxByOrNull { it.timestamp }
+        if (snoozed != null) {
+            return snoozed
+        }
+        val (now, later) = alarmEntries.partition { it.timestamp < cutoff }
+        return now.minByOrNull { it.timestamp } ?: later.minByOrNull { it.timestamp }
+    }
+
+    private suspend fun getSnoozeTemplate(taskId: Long): Alarm? {
+        val task = taskDao.fetch(taskId) ?: return null
+        val alarms = alarmDao.getActiveAlarms(taskId)
+        val baseAlarms = alarms.filter { it.type != TYPE_SNOOZE }
+        val defaultDueTime = preferences.defaultDueTime()
+        val cutoff = currentTimeMillis().startOfMinute() + ONE_MINUTE
+        val baseTemplate = getActiveAlarm(task, baseAlarms, defaultDueTime, cutoff)
+        if (baseTemplate != null) {
+            return baseAlarms.firstOrNull { alarm ->
+                alarmCalculator.toAlarmEntry(task, alarm, defaultDueTime) == baseTemplate
+            }
+        }
+        val historicalBaseTemplate = baseAlarms
+            .mapNotNull { alarm ->
+                alarmCalculator.latestTriggerAtOrBefore(task, alarm, defaultDueTime, task.reminderLast)
+                    ?.let { timestamp -> alarm to timestamp }
+            }
+            .maxByOrNull { it.second }
+            ?.first
+        if (historicalBaseTemplate != null) {
+            return historicalBaseTemplate
+        }
+        val activeTemplate = getActiveAlarm(task, alarms, defaultDueTime, cutoff)
+        return activeTemplate?.let { notification ->
+            alarms.firstOrNull { alarm ->
+                alarmCalculator.toAlarmEntry(task, alarm, defaultDueTime) == notification
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
Closes #1847

## Summary

This change preserves custom reminder repeat patterns after a notification is snoozed.

Previously, if a task used a custom reminder pattern such as "repeat every 1 minute, 5 times", snoozing the notification could cause the reminder to come back as a single notification instead of continuing with the same repeat/interval pattern.

This patch fixes that by:

- preserving the repeat/interval template when creating a snoozed alarm
- falling back to the current snoozed alarm when no base reminder template is available
- prioritizing active snooze alarms over overdue base reminders
- rescheduling repeating snooze alarms by updating the existing snoozed alarm row

## Implementation notes

The fix stays within the existing alarm/reminder mechanism rather than adding a separate notification path.

In particular:

- `AlarmService.snooze()` now copies `repeat` and `interval` from the appropriate reminder template before replacing existing snoozed alarms
- repeating snooze alarms are advanced by updating the existing alarm row after they trigger
- alarm selection now gives an active snooze alarm precedence over an overdue base reminder for the same task

## Testing

Added tests covering:

- preserving a repeating custom reminder when snoozing
- re-snoozing an already repeating snooze alarm
- falling back to the snoozed alarm when no base reminder is available
- scheduling the next occurrence of a repeating snooze
- preferring an overdue snooze alarm over an overdue base reminder

Manual testing on device also verified that custom reminder patterns continue correctly after snoozing, including preset snooze options and repeated notifications within the same reminder chain.