### PR TITLE
Add persistence layer and synchronize task notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,12 @@ android {
             resValue("string", "posthog_key", tasks_posthog_key ?: "")
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard.pro")
-            signingConfig = signingConfigs.getByName("release")
+            val tasksStoreFile: String? by project
+            if (tasksStoreFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            } else {
+                signingConfig = signingConfigs.getByName("debug")
+            }
         }
     }
 

--- a/app/src/googleplay/AndroidManifest.xml
+++ b/app/src/googleplay/AndroidManifest.xml
@@ -5,6 +5,10 @@
   <application tools:ignore="GoogleAppIndexingWarning">
 
     <meta-data
+        android:name="firebase_crashlytics_collection_enabled"
+        android:value="false"/>
+
+    <meta-data
       android:name="com.google.android.geo.API_KEY"
       android:value="@string/google_key" />
 
@@ -12,12 +16,15 @@
       android:name="com.google.android.gms.version"
       android:value="@integer/google_play_services_version"/>
 
+    <service
+        android:name=".fcm.TasksFirebaseMessagingService"
+        android:exported="false">
+      <intent-filter>
+        <action android:name="com.google.firebase.MESSAGING_EVENT" />
+      </intent-filter>
+    </service>
 
     <receiver android:name=".location.GoogleGeofenceTransitionIntentService$Broadcast"/>
-    <service
-      android:exported="false"
-      android:name=".location.GoogleGeofenceTransitionIntentService"
-      android:permission="android.permission.BIND_JOB_SERVICE"/>
 
     <service
         android:name=".wear.WearDataService"

--- a/app/src/googleplay/AndroidManifest.xml
+++ b/app/src/googleplay/AndroidManifest.xml
@@ -5,10 +5,6 @@
   <application tools:ignore="GoogleAppIndexingWarning">
 
     <meta-data
-        android:name="firebase_crashlytics_collection_enabled"
-        android:value="false"/>
-
-    <meta-data
       android:name="com.google.android.geo.API_KEY"
       android:value="@string/google_key" />
 
@@ -16,15 +12,12 @@
       android:name="com.google.android.gms.version"
       android:value="@integer/google_play_services_version"/>
 
-    <service
-        android:name=".fcm.TasksFirebaseMessagingService"
-        android:exported="false">
-      <intent-filter>
-        <action android:name="com.google.firebase.MESSAGING_EVENT" />
-      </intent-filter>
-    </service>
 
     <receiver android:name=".location.GoogleGeofenceTransitionIntentService$Broadcast"/>
+    <service
+      android:exported="false"
+      android:name=".location.GoogleGeofenceTransitionIntentService"
+      android:permission="android.permission.BIND_JOB_SERVICE"/>
 
     <service
         android:name=".wear.WearDataService"
@@ -35,6 +28,28 @@
         <data
             android:host="*"
             android:pathPrefix="/grpc/"
+            android:scheme="wear" />
+      </intent-filter>
+    </service>
+
+    <!-- Listener service for sync data from Wear -->
+    <service
+        android:name=".wear.WearSyncListenerService"
+        android:exported="true"
+        tools:ignore="ExportedService">
+      <intent-filter>
+        <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+        <data
+            android:host="*"
+            android:pathPrefix="/outbox/watch/"
+            android:scheme="wear" />
+        <data
+            android:host="*"
+            android:pathPrefix="/sync/request"
+            android:scheme="wear" />
+        <data
+            android:host="*"
+            android:pathPrefix="/ack/phone/"
             android:scheme="wear" />
       </intent-filter>
     </service>

--- a/app/src/googleplay/java/org/tasks/injection/FlavorModule.kt
+++ b/app/src/googleplay/java/org/tasks/injection/FlavorModule.kt
@@ -21,6 +21,7 @@ import org.tasks.billing.GooglePlayQrScanner
 import org.tasks.billing.QrScanner
 import org.tasks.billing.SubscriptionProvider
 import org.tasks.extensions.wearDataLayerRegistry
+import org.tasks.wear.PhoneSyncManager
 import org.tasks.http.HttpClientFactory
 import org.tasks.location.Geocoder
 import org.tasks.location.GeocoderMapbox
@@ -93,13 +94,15 @@ class FlavorModule {
     @Provides
     @Singleton
     fun getWearRefresher(
-        @ApplicationContext applicationContext: Context,
         phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
+        wearDataLayerRegistry: WearDataLayerRegistry,
+        phoneSyncManager: PhoneSyncManager,
         @ApplicationScope scope: CoroutineScope,
     ): WearRefresher = WearRefresherImpl(
-        phoneDataLayerAppHelper,
-        Wearable.getMessageClient(applicationContext),
-        scope,
+        phoneDataLayerAppHelper = phoneDataLayerAppHelper,
+        registry = wearDataLayerRegistry,
+        scope = scope,
+        phoneSyncManager = phoneSyncManager,
     )
 
     @Provides

--- a/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
+++ b/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
@@ -74,6 +74,7 @@ object DataMapKeys {
  * Receives task operations from the watch and applies them to the phone database.
  */
 @Singleton
+@Suppress("TooManyFunctions", "LongParameterList", "LongMethod", "TooGenericExceptionCaught")
 class PhoneSyncManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val taskDao: TaskDao,
@@ -143,9 +144,6 @@ class PhoneSyncManager @Inject constructor(
         }
     }
 
-    /**
-     * Handle operation from watch (create, update, delete).
-     */
     private suspend fun handleWatchOperation(event: DataEvent) {
         val path = event.dataItem.uri.path ?: return
         val opIdStr = path.removePrefix(SyncPaths.WATCH_OUTBOX_PREFIX)
@@ -365,9 +363,6 @@ class PhoneSyncManager @Inject constructor(
         Timber.d("PhoneSyncManager: Set task ${task.id} completed=$completed from watch operation")
     }
 
-    /**
-     * Send acknowledgment to watch.
-     */
     private suspend fun sendWatchAck(opId: Long, success: Boolean, error: String? = null) {
         val path = SyncPaths.watchAckPath(opId)
         val request = PutDataMapRequest.create(path).apply {
@@ -388,9 +383,6 @@ class PhoneSyncManager @Inject constructor(
         }
     }
 
-    /**
-     * Handle sync request from watch - send all tasks as snapshot.
-     */
     private suspend fun handleSyncRequest(@Suppress("UNUSED_PARAMETER") event: DataEvent) {
         Timber.d("PhoneSyncManager: Watch requested sync")
 
@@ -409,9 +401,6 @@ class PhoneSyncManager @Inject constructor(
         sendTaskSnapshotInternal(tasks)
     }
 
-    /**
-     * Send a snapshot of all tasks to watch.
-     */
     private suspend fun sendTaskSnapshotInternal(tasks: List<Task>) {
         val path = SyncPaths.TASKS_SNAPSHOT
         val request = PutDataMapRequest.create(path).apply {

--- a/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
+++ b/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
@@ -214,7 +214,7 @@ class PhoneSyncManager @Inject constructor(
         }
 
         // Create new task using TaskCreator
-        val task = taskCreator.basicQuickAddTask(title)
+        val task = taskCreator.basicQuickAddTask(title, remoteId = taskId)
 
         // Update task with remoteId, notes, and other fields
         taskDao.fetch(task.id)?.let { fetchedTask ->
@@ -249,30 +249,83 @@ class PhoneSyncManager @Inject constructor(
             return
         }
 
+        val phoneModTime = task.modificationDate
+
+        // Extract incoming field values and their timestamps
         val title = dataMap.getString(DataMapKeys.KEY_TITLE)
+        val titleUpdatedAt = if (dataMap.containsKey(DataMapKeys.KEY_TITLE_UPDATED_AT))
+            dataMap.getLong(DataMapKeys.KEY_TITLE_UPDATED_AT) else null
         val notes = dataMap.getString(DataMapKeys.KEY_NOTES)
+        val notesUpdatedAt = if (dataMap.containsKey(DataMapKeys.KEY_NOTES_UPDATED_AT))
+            dataMap.getLong(DataMapKeys.KEY_NOTES_UPDATED_AT) else null
         val completed = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED))
             dataMap.getBoolean(DataMapKeys.KEY_COMPLETED) else null
+        val completedUpdatedAt = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED_UPDATED_AT))
+            dataMap.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT) else null
         val dueDate = dataMap.getLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }
 
-        val oldDueDate = task.dueDate
+        // Per-field last-write-wins: only apply fields where watch timestamp is newer
+        var newTitle = task.title
+        var newNotes = task.notes
+        var newCompletionDate = task.completionDate
+        var newDueDate = task.dueDate
+        var modified = false
 
-        val updatedTask = task.copy(
-            title = title ?: task.title,
-            notes = notes ?: task.notes,
-            dueDate = dueDate ?: task.dueDate,
-            completionDate = when {
-                completed == null -> task.completionDate
+        // Title: apply if watch timestamp is newer than phone modification date
+        if (title != null && titleUpdatedAt != null && titleUpdatedAt > phoneModTime) {
+            newTitle = title
+            modified = true
+            Timber.d("PhoneSyncManager: Accepting newer title for task ${task.id}")
+        } else if (title != null) {
+            Timber.d("PhoneSyncManager: Keeping phone title for task ${task.id} (phone newer)")
+        }
+
+        // Notes: apply if watch timestamp is newer
+        if (notes != null && notesUpdatedAt != null && notesUpdatedAt > phoneModTime) {
+            newNotes = notes
+            modified = true
+            Timber.d("PhoneSyncManager: Accepting newer notes for task ${task.id}")
+        } else if (notes != null) {
+            Timber.d("PhoneSyncManager: Keeping phone notes for task ${task.id} (phone newer)")
+        }
+
+        // Completed: apply if watch timestamp is newer
+        if (completed != null && completedUpdatedAt != null && completedUpdatedAt > phoneModTime) {
+            newCompletionDate = when {
                 completed && !task.isCompleted -> System.currentTimeMillis()
                 !completed -> 0
                 else -> task.completionDate
             }
+            modified = true
+            Timber.d("PhoneSyncManager: Accepting newer completed=$completed for task ${task.id}")
+        } else if (completed != null) {
+            Timber.d("PhoneSyncManager: Keeping phone completed for task ${task.id} (phone newer)")
+        }
+
+        // DueDate: apply if different (no per-field timestamp available for due date)
+        val oldDueDate = task.dueDate
+        if (dueDate != null && dueDate != oldDueDate) {
+            newDueDate = dueDate
+            modified = true
+        }
+
+        if (!modified) {
+            Timber.d("PhoneSyncManager: No fields updated for task ${task.id} (all phone fields newer)")
+            return
+        }
+
+        val updatedTask = task.copy(
+            title = newTitle,
+            notes = newNotes,
+            dueDate = newDueDate,
+            completionDate = newCompletionDate,
+            modificationDate = System.currentTimeMillis(),
         )
 
         taskDao.update(updatedTask)
 
         // If due date was added or changed, create alarm and trigger notifications
-        if (dueDate != null && dueDate > 0 && dueDate != oldDueDate) {
+        if (newDueDate != oldDueDate && newDueDate > 0) {
             val existingAlarms = alarmDao.getAlarms(task.id)
             val hasWhenDueAlarm = existingAlarms.any { it.type == org.tasks.data.entity.Alarm.TYPE_REL_END }
             if (!hasWhenDueAlarm) {
@@ -281,7 +334,7 @@ class PhoneSyncManager @Inject constructor(
             workManager.triggerNotifications()
         }
 
-        Timber.d("PhoneSyncManager: Updated task ${task.id} from watch operation (dueDate: $dueDate)")
+        Timber.d("PhoneSyncManager: Updated task ${task.id} from watch operation with conflict resolution")
     }
 
     private suspend fun handleDelete(taskId: String, @Suppress("UNUSED_PARAMETER") dataMap: com.google.android.gms.wearable.DataMap) {
@@ -434,6 +487,29 @@ class PhoneSyncManager @Inject constructor(
     suspend fun notifyTaskChanged(taskId: Long) {
         val task = taskDao.fetch(taskId) ?: return
         sendTaskUpdate(task)
+    }
+
+    /**
+     * Notify watch about task deletion on phone.
+     */
+    suspend fun notifyTaskDeleted(taskId: Long) {
+        val task = taskDao.fetch(taskId)
+        val taskIdForWatch = task?.remoteId?.takeIf { it.isNotBlank() } ?: taskId.toString()
+        val path = SyncPaths.taskUpdatePath(taskIdForWatch)
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putString(DataMapKeys.KEY_TASK_ID, taskIdForWatch)
+            dataMap.putBoolean(DataMapKeys.KEY_DELETED, true)
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, System.currentTimeMillis())
+            dataMap.putLong("phoneId", taskId)
+            setUrgent()
+        }
+
+        try {
+            dataClient.putDataItem(request.asPutDataRequest()).await()
+            Timber.d("PhoneSyncManager: Sent delete notification for task $taskId")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to send delete notification for task $taskId")
+        }
     }
 }
 

--- a/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
+++ b/app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt
@@ -1,0 +1,439 @@
+package org.tasks.wear
+
+import android.content.Context
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import org.tasks.data.dao.TaskDao
+import org.tasks.service.TaskCompleter
+import com.todoroo.astrid.service.TaskCreator
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.tasks.analytics.Firebase
+import org.tasks.data.entity.Task
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Sync protocol constants shared between phone and watch.
+ */
+object SyncPaths {
+    // Watch -> Phone operations
+    const val WATCH_OUTBOX_PREFIX = "/outbox/watch/"
+    fun watchAckPath(opId: Long) = "/ack/watch/$opId"
+
+    // Phone -> Watch operations
+    const val PHONE_OUTBOX_PREFIX = "/outbox/phone/"
+    fun phoneAckPath(opId: String) = "/ack/phone/$opId"
+
+    // Task updates from phone to watch
+    const val TASK_UPDATE_PREFIX = "/tasks/"
+    fun taskUpdatePath(taskId: String) = "$TASK_UPDATE_PREFIX$taskId"
+
+    // Snapshot
+    const val TASKS_SNAPSHOT = "/snapshot/tasks"
+
+    // Sync request
+    const val SYNC_REQUEST = "/sync/request"
+}
+
+object DataMapKeys {
+    const val KEY_OP_ID = "opId"
+    const val KEY_TASK_ID = "taskId"
+    const val KEY_OP_TYPE = "opType"
+    const val KEY_TIMESTAMP = "timestamp"
+
+    const val KEY_TITLE = "title"
+    const val KEY_TITLE_UPDATED_AT = "titleUpdatedAt"
+    const val KEY_NOTES = "notes"
+    const val KEY_NOTES_UPDATED_AT = "notesUpdatedAt"
+    const val KEY_COMPLETED = "completed"
+    const val KEY_COMPLETED_UPDATED_AT = "completedUpdatedAt"
+    const val KEY_DELETED = "deleted"
+    const val KEY_PRIORITY = "priority"
+    const val KEY_REPEATING = "repeating"
+    const val KEY_DUE_DATE = "dueDate"
+
+    const val KEY_SUCCESS = "success"
+    const val KEY_ERROR = "error"
+
+    const val KEY_TASK_COUNT = "taskCount"
+    const val KEY_SNAPSHOT_TIMESTAMP = "snapshotTimestamp"
+}
+
+/**
+ * Sync manager for handling watch operations on the phone side.
+ * Receives task operations from the watch and applies them to the phone database.
+ */
+@Singleton
+class PhoneSyncManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val taskDao: TaskDao,
+    private val taskCreator: TaskCreator,
+    private val taskCompleter: TaskCompleter,
+    private val firebase: Firebase,
+    private val alarmDao: org.tasks.data.dao.AlarmDao,
+    private val workManager: org.tasks.jobs.WorkManager,
+) : DataClient.OnDataChangedListener {
+
+    private val dataClient: DataClient = Wearable.getDataClient(context)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Start listening for data changes from watch.
+     */
+    fun startListening() {
+        dataClient.addListener(this)
+        Timber.d("PhoneSyncManager: Started listening for data changes")
+    }
+
+    /**
+     * Stop listening for data changes.
+     */
+    fun stopListening() {
+        dataClient.removeListener(this)
+        Timber.d("PhoneSyncManager: Stopped listening for data changes")
+    }
+
+    override fun onDataChanged(events: DataEventBuffer) {
+        Timber.d("PhoneSyncManager: Received ${events.count} data events")
+
+        // IMPORTANT: DataEventBuffer is closed when onDataChanged returns,
+        // so we must extract data BEFORE launching the coroutine
+        val frozenEvents = mutableListOf<Pair<Int, DataEvent>>()
+        for (event in events) {
+            frozenEvents.add(Pair(event.type, event.freeze()))
+        }
+
+        scope.launch {
+            for ((type, event) in frozenEvents) {
+                when (type) {
+                    DataEvent.TYPE_CHANGED -> handleDataChanged(event)
+                    DataEvent.TYPE_DELETED -> { /* Usually no action needed */ }
+                }
+            }
+        }
+    }
+
+    private suspend fun handleDataChanged(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        Timber.d("PhoneSyncManager: Data changed: $path")
+
+        when {
+            // Operation from watch (create, update, delete, complete)
+            path.startsWith(SyncPaths.WATCH_OUTBOX_PREFIX) -> {
+                handleWatchOperation(event)
+            }
+            // Watch is requesting a full sync
+            path == SyncPaths.SYNC_REQUEST -> {
+                handleSyncRequest(event)
+            }
+            // Ack from watch for our operation (phone->watch) - just log it
+            path.startsWith("/ack/phone/") -> {
+                Timber.d("PhoneSyncManager: Received ack from watch: $path")
+            }
+        }
+    }
+
+    /**
+     * Handle operation from watch (create, update, delete).
+     */
+    private suspend fun handleWatchOperation(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        val opIdStr = path.removePrefix(SyncPaths.WATCH_OUTBOX_PREFIX)
+        val opId = opIdStr.toLongOrNull() ?: return
+
+        val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+        val dataMap = dataMapItem.dataMap
+
+        val taskId = dataMap.getString(DataMapKeys.KEY_TASK_ID) ?: return
+        val opType = dataMap.getString(DataMapKeys.KEY_OP_TYPE) ?: return
+
+        Timber.d("PhoneSyncManager: Processing operation $opId of type $opType for task $taskId")
+
+        try {
+            when (opType) {
+                "CREATE" -> handleCreate(taskId, dataMap)
+                "UPDATE" -> handleUpdate(taskId, dataMap)
+                "DELETE" -> handleDelete(taskId, dataMap)
+                "COMPLETE" -> handleComplete(taskId, dataMap)
+            }
+
+            // Send ack to watch
+            sendWatchAck(opId, true)
+
+            // Delete the processed DataItem
+            try {
+                dataClient.deleteDataItems(event.dataItem.uri).await()
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to delete DataItem after processing")
+            }
+
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to process operation $opId")
+            sendWatchAck(opId, false, e.message)
+        }
+    }
+
+    private suspend fun handleCreate(taskId: String, dataMap: com.google.android.gms.wearable.DataMap) {
+        val title = dataMap.getString(DataMapKeys.KEY_TITLE) ?: "Untitled"
+        val notes = dataMap.getString(DataMapKeys.KEY_NOTES)
+        val completed = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED))
+            dataMap.getBoolean(DataMapKeys.KEY_COMPLETED) else false
+        val priority = if (dataMap.containsKey(DataMapKeys.KEY_PRIORITY))
+            dataMap.getInt(DataMapKeys.KEY_PRIORITY) else Task.Priority.NONE
+        val dueDate = dataMap.getLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }
+
+        // Check if a task with this remoteId (watch task ID) already exists to prevent duplicates
+        val existingTask = taskDao.fetch(taskId)
+        if (existingTask != null) {
+            Timber.d("PhoneSyncManager: Task with remoteId $taskId already exists (id=${existingTask.id}), updating instead")
+            val updated = existingTask.copy(
+                title = title,
+                notes = notes ?: existingTask.notes,
+                completionDate = if (completed) System.currentTimeMillis() else existingTask.completionDate,
+                priority = priority,
+                dueDate = dueDate ?: existingTask.dueDate,
+                modificationDate = System.currentTimeMillis(),
+            )
+            taskDao.update(updated)
+            // If due date changed, update alarms
+            if (dueDate != null && dueDate != existingTask.dueDate && dueDate > 0) {
+                alarmDao.insert(org.tasks.data.entity.Alarm.whenDue(existingTask.id))
+                workManager.triggerNotifications()
+            }
+            return
+        }
+
+        // Create new task using TaskCreator
+        val task = taskCreator.basicQuickAddTask(title)
+
+        // Update task with remoteId, notes, and other fields
+        taskDao.fetch(task.id)?.let { fetchedTask ->
+            val updated = fetchedTask.copy(
+                remoteId = taskId, // Store watch task ID so we can find it later
+                notes = notes ?: fetchedTask.notes,
+                completionDate = if (completed) System.currentTimeMillis() else fetchedTask.completionDate,
+                priority = priority,
+                dueDate = dueDate ?: fetchedTask.dueDate,
+            )
+            taskDao.update(updated)
+
+            // If a due date is set, create default "when due" alarm for notifications
+            if (dueDate != null && dueDate > 0) {
+                alarmDao.insert(org.tasks.data.entity.Alarm.whenDue(fetchedTask.id))
+                workManager.triggerNotifications()
+            }
+        }
+
+        firebase.addTask("wearable")
+        Timber.d("PhoneSyncManager: Created task ${task.id} from watch operation (remoteId: $taskId, dueDate: $dueDate)")
+    }
+
+    private suspend fun handleUpdate(taskId: String, dataMap: com.google.android.gms.wearable.DataMap) {
+        // Try to find task by numeric ID first, then by remoteId (for watch-created tasks)
+        val task = taskId.toLongOrNull()?.let { taskDao.fetch(it) }
+            ?: taskDao.fetch(taskId) // Search by remoteId
+
+        if (task == null) {
+            Timber.w("PhoneSyncManager: Task $taskId not found for update, creating instead")
+            handleCreate(taskId, dataMap)
+            return
+        }
+
+        val title = dataMap.getString(DataMapKeys.KEY_TITLE)
+        val notes = dataMap.getString(DataMapKeys.KEY_NOTES)
+        val completed = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED))
+            dataMap.getBoolean(DataMapKeys.KEY_COMPLETED) else null
+        val dueDate = dataMap.getLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }
+
+        val oldDueDate = task.dueDate
+
+        val updatedTask = task.copy(
+            title = title ?: task.title,
+            notes = notes ?: task.notes,
+            dueDate = dueDate ?: task.dueDate,
+            completionDate = when {
+                completed == null -> task.completionDate
+                completed && !task.isCompleted -> System.currentTimeMillis()
+                !completed -> 0
+                else -> task.completionDate
+            }
+        )
+
+        taskDao.update(updatedTask)
+
+        // If due date was added or changed, create alarm and trigger notifications
+        if (dueDate != null && dueDate > 0 && dueDate != oldDueDate) {
+            val existingAlarms = alarmDao.getAlarms(task.id)
+            val hasWhenDueAlarm = existingAlarms.any { it.type == org.tasks.data.entity.Alarm.TYPE_REL_END }
+            if (!hasWhenDueAlarm) {
+                alarmDao.insert(org.tasks.data.entity.Alarm.whenDue(task.id))
+            }
+            workManager.triggerNotifications()
+        }
+
+        Timber.d("PhoneSyncManager: Updated task ${task.id} from watch operation (dueDate: $dueDate)")
+    }
+
+    private suspend fun handleDelete(taskId: String, @Suppress("UNUSED_PARAMETER") dataMap: com.google.android.gms.wearable.DataMap) {
+        val task = taskId.toLongOrNull()?.let { taskDao.fetch(it) }
+            ?: taskDao.fetch(taskId)
+
+        if (task == null) {
+            Timber.w("PhoneSyncManager: Task $taskId not found for delete")
+            return
+        }
+
+        taskDao.update(task.copy(deletionDate = System.currentTimeMillis()))
+        Timber.d("PhoneSyncManager: Deleted task ${task.id} from watch operation")
+    }
+
+    private suspend fun handleComplete(taskId: String, dataMap: com.google.android.gms.wearable.DataMap) {
+        val task = taskId.toLongOrNull()?.let { taskDao.fetch(it) }
+            ?: taskDao.fetch(taskId)
+
+        if (task == null) {
+            Timber.w("PhoneSyncManager: Task $taskId not found for complete")
+            return
+        }
+
+        val completed = dataMap.getBoolean(DataMapKeys.KEY_COMPLETED)
+        taskCompleter.setComplete(task.id, completed)
+        firebase.completeTask("wearable")
+        Timber.d("PhoneSyncManager: Set task ${task.id} completed=$completed from watch operation")
+    }
+
+    /**
+     * Send acknowledgment to watch.
+     */
+    private suspend fun sendWatchAck(opId: Long, success: Boolean, error: String? = null) {
+        val path = SyncPaths.watchAckPath(opId)
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putLong(DataMapKeys.KEY_OP_ID, opId)
+            dataMap.putBoolean(DataMapKeys.KEY_SUCCESS, success)
+            if (error != null) {
+                dataMap.putString(DataMapKeys.KEY_ERROR, error)
+            }
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, System.currentTimeMillis())
+            setUrgent()
+        }
+
+        try {
+            dataClient.putDataItem(request.asPutDataRequest()).await()
+            Timber.d("PhoneSyncManager: Sent ack for operation $opId (success=$success)")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to send ack for operation $opId")
+        }
+    }
+
+    /**
+     * Handle sync request from watch - send all tasks as snapshot.
+     */
+    private suspend fun handleSyncRequest(@Suppress("UNUSED_PARAMETER") event: DataEvent) {
+        Timber.d("PhoneSyncManager: Watch requested sync")
+
+        // Get all non-deleted tasks
+        val tasks = taskDao.getActiveTasks()
+
+        sendTaskSnapshotInternal(tasks)
+    }
+
+    /**
+     * Send a snapshot of all active tasks to watch.
+     * Public method for use by WearRefresherImpl.
+     */
+    suspend fun sendTaskSnapshot() {
+        val tasks = taskDao.getActiveTasks()
+        sendTaskSnapshotInternal(tasks)
+    }
+
+    /**
+     * Send a snapshot of all tasks to watch.
+     */
+    private suspend fun sendTaskSnapshotInternal(tasks: List<Task>) {
+        val path = SyncPaths.TASKS_SNAPSHOT
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putInt(DataMapKeys.KEY_TASK_COUNT, tasks.size)
+            dataMap.putLong(DataMapKeys.KEY_SNAPSHOT_TIMESTAMP, System.currentTimeMillis())
+
+            // Serialize each task
+            tasks.forEachIndexed { index, task ->
+                val prefix = "task_$index"
+                // Use remoteId (watch UUID) if available, otherwise phone ID as string
+                val taskIdForWatch = task.remoteId?.takeIf { it.isNotBlank() } ?: task.id.toString()
+                dataMap.putString("${prefix}_id", taskIdForWatch)
+                dataMap.putString("${prefix}_title", task.title ?: "")
+                dataMap.putLong("${prefix}_titleUpdatedAt", task.modificationDate)
+                dataMap.putString("${prefix}_notes", task.notes ?: "")
+                dataMap.putLong("${prefix}_notesUpdatedAt", task.modificationDate)
+                dataMap.putBoolean("${prefix}_completed", task.isCompleted)
+                dataMap.putLong("${prefix}_completedUpdatedAt",
+                    if (task.isCompleted) task.completionDate else task.modificationDate)
+                dataMap.putBoolean("${prefix}_deleted", task.deletionDate > 0)
+                // Send phoneId so watch can properly link and deduplicate
+                dataMap.putLong("${prefix}_phoneId", task.id)
+                dataMap.putInt("${prefix}_priority", task.priority)
+                dataMap.putLong("${prefix}_dueDate", task.dueDate)
+            }
+        }
+
+        try {
+            dataClient.putDataItem(request.asPutDataRequest()).await()
+            Timber.d("PhoneSyncManager: Sent snapshot with ${tasks.size} tasks")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to send task snapshot")
+        }
+    }
+
+    /**
+     * Send a single task update to watch.
+     */
+    suspend fun sendTaskUpdate(task: Task) {
+        // Use remoteId (watch UUID) if available, otherwise phone ID as string
+        val taskIdForWatch = task.remoteId?.takeIf { it.isNotBlank() } ?: task.id.toString()
+        val path = SyncPaths.taskUpdatePath(taskIdForWatch)
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putString(DataMapKeys.KEY_TASK_ID, taskIdForWatch)
+            dataMap.putString(DataMapKeys.KEY_TITLE, task.title ?: "")
+            dataMap.putLong(DataMapKeys.KEY_TITLE_UPDATED_AT, task.modificationDate)
+            dataMap.putString(DataMapKeys.KEY_NOTES, task.notes ?: "")
+            dataMap.putLong(DataMapKeys.KEY_NOTES_UPDATED_AT, task.modificationDate)
+            dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, task.isCompleted)
+            dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT,
+                if (task.isCompleted) task.completionDate else task.modificationDate)
+            dataMap.putBoolean(DataMapKeys.KEY_DELETED, task.deletionDate > 0)
+            dataMap.putInt(DataMapKeys.KEY_PRIORITY, task.priority)
+            dataMap.putBoolean(DataMapKeys.KEY_REPEATING, !task.recurrence.isNullOrBlank())
+            dataMap.putLong(DataMapKeys.KEY_DUE_DATE, task.dueDate)
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, System.currentTimeMillis())
+            // Send phoneId so watch can properly link and deduplicate
+            dataMap.putLong("phoneId", task.id)
+            setUrgent()
+        }
+
+        try {
+            dataClient.putDataItem(request.asPutDataRequest()).await()
+            Timber.d("PhoneSyncManager: Sent task update for ${task.id} (watchId: $taskIdForWatch)")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to send task update for ${task.id}")
+        }
+    }
+
+    /**
+     * Notify watch about task changes on phone.
+     */
+    suspend fun notifyTaskChanged(taskId: Long) {
+        val task = taskDao.fetch(taskId) ?: return
+        sendTaskUpdate(task)
+    }
+}
+

--- a/app/src/googleplay/java/org/tasks/wear/WearRefresherImpl.kt
+++ b/app/src/googleplay/java/org/tasks/wear/WearRefresherImpl.kt
@@ -58,9 +58,15 @@ class WearRefresherImpl(
      * Notify watch about a specific task change.
      * This is called after task updates to sync changes to watch.
      */
-    suspend fun notifyTaskChanged(taskId: Long) {
+    override suspend fun notifyTaskChanged(taskId: Long) {
         if (watchConnected) {
             phoneSyncManager?.notifyTaskChanged(taskId)
+        }
+    }
+
+    override suspend fun notifyTaskDeleted(taskId: Long) {
+        if (watchConnected) {
+            phoneSyncManager?.notifyTaskDeleted(taskId)
         }
     }
 }

--- a/app/src/googleplay/java/org/tasks/wear/WearRefresherImpl.kt
+++ b/app/src/googleplay/java/org/tasks/wear/WearRefresherImpl.kt
@@ -1,50 +1,70 @@
 package org.tasks.wear
 
-import com.google.android.gms.wearable.MessageClient
+import androidx.datastore.core.DataStore
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.data.ProtoDataStoreHelper.protoDataStore
+import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.tasks.await
+import org.tasks.GrpcProto.LastUpdate
+import org.tasks.copy
 import timber.log.Timber
 
 @OptIn(ExperimentalHorologistApi::class)
 class WearRefresherImpl(
     phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
-    private val messageClient: MessageClient,
+    private val registry: WearDataLayerRegistry,
     private val scope: CoroutineScope,
+    private val phoneSyncManager: PhoneSyncManager? = null,
 ) : WearRefresher {
 
-    private var connectedNodeIds: List<String> = emptyList()
+    private var watchConnected = false
 
     init {
         phoneDataLayerAppHelper
             .connectedAndInstalledNodes
             .catch { Timber.e("${it.message}") }
             .onEach { nodes ->
-                connectedNodeIds = nodes.map { it.id }
-                sendRefreshMessage()
+                Timber.d("Connected nodes: ${nodes.joinToString()}")
+                watchConnected = nodes.isNotEmpty()
+                lastUpdate.update()
             }
             .launchIn(scope)
+
+        // Start listening for sync events from watch
+        phoneSyncManager?.startListening()
+    }
+
+    private val lastUpdate: DataStore<LastUpdate> by lazy {
+        registry.protoDataStore<LastUpdate>(scope)
     }
 
     override suspend fun refresh() {
-        sendRefreshMessage()
-    }
-
-    private suspend fun sendRefreshMessage() {
-        for (nodeId in connectedNodeIds) {
+        if (watchConnected) {
+            lastUpdate.update()
+            // Push all tasks to watch for bidirectional sync
             try {
-                messageClient.sendMessage(nodeId, PATH_REFRESH, byteArrayOf()).await()
+                phoneSyncManager?.sendTaskSnapshot()
             } catch (e: Exception) {
-                Timber.e(e, "Failed to send refresh message to $nodeId")
+                Timber.e(e, "Failed to push tasks to watch on refresh")
             }
         }
     }
 
-    companion object {
-        const val PATH_REFRESH = "/tasks/refresh"
+    /**
+     * Notify watch about a specific task change.
+     * This is called after task updates to sync changes to watch.
+     */
+    suspend fun notifyTaskChanged(taskId: Long) {
+        if (watchConnected) {
+            phoneSyncManager?.notifyTaskChanged(taskId)
+        }
     }
+}
+
+private suspend fun DataStore<LastUpdate>.update() {
+    updateData { it.copy { now = System.currentTimeMillis() } }
 }

--- a/app/src/googleplay/java/org/tasks/wear/WearSyncListenerService.kt
+++ b/app/src/googleplay/java/org/tasks/wear/WearSyncListenerService.kt
@@ -1,0 +1,37 @@
+package org.tasks.wear
+
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.WearableListenerService
+import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * WearableListenerService that receives data changes from watch.
+ * This service runs in the background and receives sync operations
+ * even when the Tasks app is not in the foreground.
+ */
+@AndroidEntryPoint
+class WearSyncListenerService : WearableListenerService() {
+
+    @Inject
+    lateinit var phoneSyncManager: PhoneSyncManager
+
+    override fun onCreate() {
+        super.onCreate()
+        Timber.d("WearSyncListenerService: Created")
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        Timber.d("WearSyncListenerService: Received ${dataEvents.count} data events")
+
+        // Forward to the sync manager
+        phoneSyncManager.onDataChanged(dataEvents)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Timber.d("WearSyncListenerService: Destroyed")
+    }
+}
+

--- a/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
+++ b/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
@@ -58,8 +58,8 @@ class TaskCreator @Inject constructor(
     private val locationDao: LocationDao,
     private val alarmDao: AlarmDao,
 ) {
-    suspend fun basicQuickAddTask(title: String, filter: Filter? = null): Task {
-        val task = createWithValues(filter, title.trim { it <= ' ' })
+    suspend fun basicQuickAddTask(title: String, filter: Filter? = null, remoteId: String? = null): Task {
+        val task = createWithValues(filter, title.trim { it <= ' ' }, remoteId)
         taskDao.createNew(task)
         val gcalCreateEventEnabled = preferences.isDefaultCalendarSet && task.hasDueDate() // $NON-NLS-1$
         if (!isNullOrEmpty(task.title)
@@ -129,19 +129,19 @@ class TaskCreator @Inject constructor(
         return create(null, title)
     }
 
-    suspend fun createWithValues(filter: Filter?, title: String?): Task =
-        create(mapFromSerializedString(filter?.valuesForNewTasks), title)
+    suspend fun createWithValues(filter: Filter?, title: String?, remoteId: String? = null): Task =
+        create(mapFromSerializedString(filter?.valuesForNewTasks), title, remoteId)
 
     /**
      * Create task from the given content values, saving it. This version doesn't need to start with a
      * base task model.
      */
-    internal suspend fun create(values: Map<String, Any>?, title: String?): Task {
+    internal suspend fun create(values: Map<String, Any>?, title: String?, remoteId: String? = null): Task {
         val task = Task(
             title = title?.trim { it <= ' ' },
             creationDate = currentTimeMillis(),
             modificationDate = currentTimeMillis(),
-            remoteId = UUIDHelper.newUUID(),
+            remoteId = remoteId ?: UUIDHelper.newUUID(),
             priority = preferences.defaultPriority(),
         )
         preferences.getStringValue(R.string.p_default_recurrence)

--- a/app/src/main/java/org/tasks/injection/ApplicationModule.kt
+++ b/app/src/main/java/org/tasks/injection/ApplicationModule.kt
@@ -7,6 +7,7 @@ import com.todoroo.astrid.alarms.AlarmCalculator
 import com.todoroo.astrid.alarms.AlarmService
 import com.todoroo.astrid.service.AndroidCleanup
 import com.todoroo.astrid.timers.TimerPlugin
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -48,6 +49,9 @@ import org.tasks.caldav.TasksAccountDataRepository
 import org.tasks.caldav.VtodoCache
 import org.tasks.compose.drawer.DrawerConfiguration
 import org.tasks.R
+import org.tasks.wear.WearSyncNotifier
+import org.tasks.wear.WearSyncNotifierImpl
+import org.tasks.wear.WearRefresher
 import org.tasks.data.OpenTaskDao
 import org.tasks.opentasks.OpenTaskContentObserver
 import org.tasks.opentasks.OpenTasksSynchronizer
@@ -478,6 +482,12 @@ class ApplicationModule {
 
     @Provides
     @Singleton
+    fun providesWearSyncNotifier(
+        wearRefresher: Lazy<WearRefresher>,
+    ): WearSyncNotifier = WearSyncNotifierImpl(wearRefresher)
+
+    @Provides
+    @Singleton
     fun providesTaskSaver(
         taskDao: TaskDao,
         refreshBroadcaster: RefreshBroadcaster,
@@ -486,7 +496,8 @@ class ApplicationModule {
         timerPlugin: TimerPlugin,
         backgroundWork: BackgroundWork,
         caldavDao: CaldavDao,
-    ) = TaskSaver(taskDao, refreshBroadcaster, notifier, locationService, timerPlugin, backgroundWork, caldavDao)
+        wearSyncNotifier: WearSyncNotifier,
+    ) = TaskSaver(taskDao, refreshBroadcaster, notifier, locationService, timerPlugin, backgroundWork, caldavDao, wearSyncNotifier)
 
     @Provides
     fun providesTimerPlugin(
@@ -575,7 +586,8 @@ class ApplicationModule {
         vtodoCache: VtodoCache,
         tasksPreferences: TasksPreferences,
         taskCleanup: TaskCleanup,
-    ) = TaskDeleter(deletionDao, taskDao, caldavDao, refreshBroadcaster, vtodoCache, tasksPreferences, taskCleanup)
+        wearSyncNotifier: WearSyncNotifier,
+    ) = TaskDeleter(deletionDao, taskDao, caldavDao, refreshBroadcaster, vtodoCache, tasksPreferences, taskCleanup, wearSyncNotifier)
 
     @Provides
     fun providesTaskMigrator(

--- a/app/src/main/java/org/tasks/wear/WearRefresher.kt
+++ b/app/src/main/java/org/tasks/wear/WearRefresher.kt
@@ -2,4 +2,6 @@ package org.tasks.wear
 
 interface WearRefresher {
     suspend fun refresh()
+    suspend fun notifyTaskChanged(taskId: Long) {}
+    suspend fun notifyTaskDeleted(taskId: Long) {}
 }

--- a/app/src/main/java/org/tasks/wear/WearSyncNotifierImpl.kt
+++ b/app/src/main/java/org/tasks/wear/WearSyncNotifierImpl.kt
@@ -1,0 +1,18 @@
+package org.tasks.wear
+
+import dagger.Lazy
+
+/**
+ * Bridge between the kmp WearSyncNotifier interface and the app-level WearRefresher.
+ */
+class WearSyncNotifierImpl(
+    private val wearRefresher: Lazy<WearRefresher>,
+) : WearSyncNotifier {
+    override suspend fun notifyTaskChanged(taskId: Long) {
+        wearRefresher.get().notifyTaskChanged(taskId)
+    }
+
+    override suspend fun notifyTaskDeleted(taskId: Long) {
+        wearRefresher.get().notifyTaskDeleted(taskId)
+    }
+}

--- a/kmp/src/commonMain/kotlin/org/tasks/data/TaskSaver.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/data/TaskSaver.kt
@@ -23,6 +23,7 @@ import org.tasks.location.LocationService
 import org.tasks.notifications.CancelReason
 import org.tasks.notifications.Notifier
 import org.tasks.time.DateTimeUtils2.currentTimeMillis
+import org.tasks.wear.WearSyncNotifier
 
 class TaskSaver(
     private val taskDao: TaskDao,
@@ -32,6 +33,7 @@ class TaskSaver(
     private val timerPlugin: TimerPlugin,
     private val backgroundWork: BackgroundWork,
     private val caldavDao: CaldavDao,
+    private val wearSyncNotifier: WearSyncNotifier,
 ) {
     suspend fun save(task: Task, original: Task?, dirty: Boolean = true) {
         val markDirty = dirty && needsSync(task, original)
@@ -83,6 +85,11 @@ class TaskSaver(
         }
         if (!task.isSuppressRefresh()) {
             refreshBroadcaster.broadcastRefresh()
+        }
+        try {
+            wearSyncNotifier.notifyTaskChanged(task.id)
+        } catch (e: Exception) {
+            // Don't fail task save if wear sync notification fails
         }
         notifier.triggerNotifications()
         backgroundWork.scheduleRefresh()

--- a/kmp/src/commonMain/kotlin/org/tasks/data/TaskSaver.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/data/TaskSaver.kt
@@ -65,6 +65,7 @@ class TaskSaver(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun afterSave(task: Task, original: Task?) {
         val completionDateModified = task.completionDate != (original?.completionDate ?: 0)
         val deletionDateModified = task.deletionDate != (original?.deletionDate ?: 0)

--- a/kmp/src/commonMain/kotlin/org/tasks/service/TaskDeleter.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/service/TaskDeleter.kt
@@ -14,6 +14,7 @@ import org.tasks.data.entity.Task
 import org.tasks.filters.filterPreferencesKey
 import org.tasks.preferences.FilterPreferences.Companion.delete
 import org.tasks.preferences.TasksPreferences
+import org.tasks.wear.WearSyncNotifier
 
 class TaskDeleter(
     private val deletionDao: DeletionDao,
@@ -23,6 +24,7 @@ class TaskDeleter(
     private val vtodoCache: VtodoCache,
     private val tasksPreferences: TasksPreferences,
     private val taskCleanup: TaskCleanup,
+    private val wearSyncNotifier: WearSyncNotifier,
 ) {
 
     suspend fun markMoved(taskIds: List<Long>) {
@@ -45,6 +47,11 @@ class TaskDeleter(
             cleanup = { taskCleanup.cleanup(it) }
         )
         refreshBroadcaster.broadcastRefresh()
+        ids.forEach { id ->
+            try {
+                wearSyncNotifier.notifyTaskDeleted(id)
+            } catch (_: Exception) {}
+        }
         taskDao.fetch(ids)
     }
 
@@ -59,6 +66,11 @@ class TaskDeleter(
             cleanup = { taskCleanup.cleanup(it) }
         )
         refreshBroadcaster.broadcastRefresh()
+        tasks.forEach { id ->
+            try {
+                wearSyncNotifier.notifyTaskDeleted(id)
+            } catch (_: Exception) {}
+        }
     }
 
     suspend fun delete(list: CaldavCalendar) {

--- a/kmp/src/commonMain/kotlin/org/tasks/wear/WearSyncNotifier.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/wear/WearSyncNotifier.kt
@@ -1,0 +1,10 @@
+package org.tasks.wear
+
+/**
+ * Interface for notifying the wear sync layer about task changes.
+ * Implemented in the app module to bridge to the actual WearRefresher.
+ */
+interface WearSyncNotifier {
+    suspend fun notifyTaskChanged(taskId: Long)
+    suspend fun notifyTaskDeleted(taskId: Long)
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/service/TaskMigratorTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/service/TaskMigratorTest.kt
@@ -20,6 +20,7 @@ import org.tasks.data.entity.CaldavAccount.Companion.TYPE_TASKS
 import org.tasks.data.entity.CaldavCalendar
 import org.tasks.sync.SyncAdapters
 import org.tasks.sync.SyncSource
+import org.tasks.wear.WearSyncNotifier
 
 class TaskMigratorTest : DatabaseTest() {
     private val caldavDao = db.caldavDao()
@@ -31,6 +32,7 @@ class TaskMigratorTest : DatabaseTest() {
         vtodoCache = mock(),
         tasksPreferences = mock(),
         taskCleanup = object : TaskCleanup {},
+        wearSyncNotifier = mock(),
     )
     private val caldavClient: CaldavClient = mock()
     private val clientProvider: CaldavClientProvider = mock()

--- a/kmp/src/jvmTest/kotlin/org/tasks/sync/SyncAdaptersTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/sync/SyncAdaptersTest.kt
@@ -28,6 +28,7 @@ import org.tasks.data.entity.SYNC_ALARMS
 import org.tasks.data.entity.SYNC_LOCATION
 import org.tasks.data.entity.SYNC_TAGS
 import org.tasks.data.entity.Task
+import org.tasks.wear.WearSyncNotifier
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncAdaptersTest {
@@ -48,6 +49,7 @@ class SyncAdaptersTest {
         timerPlugin = mock(),
         backgroundWork = mock(),
         caldavDao = caldavDao,
+        wearSyncNotifier = mock(),
     )
 
     @After

--- a/wear-datalayer/src/main/java/org/tasks/extensions/ContextExtensions.kt
+++ b/wear-datalayer/src/main/java/org/tasks/extensions/ContextExtensions.kt
@@ -4,10 +4,15 @@ import android.content.Context
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.WearDataLayerRegistry
 import kotlinx.coroutines.CoroutineScope
+import org.tasks.wear.LastUpdateSerializer
+import org.tasks.wear.SettingsSerializer
 
 @OptIn(ExperimentalHorologistApi::class)
 fun Context.wearDataLayerRegistry(scope: CoroutineScope) =
     WearDataLayerRegistry.fromContext(
         application = applicationContext,
         coroutineScope = scope,
-    )
+    ).apply {
+        registerSerializer(SettingsSerializer)
+        registerSerializer(LastUpdateSerializer)
+    }

--- a/wear-datalayer/src/main/java/org/tasks/wear/LastUpdateSerializer.kt
+++ b/wear-datalayer/src/main/java/org/tasks/wear/LastUpdateSerializer.kt
@@ -1,0 +1,24 @@
+package org.tasks.wear
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.google.protobuf.InvalidProtocolBufferException
+import org.tasks.GrpcProto.LastUpdate
+import java.io.InputStream
+import java.io.OutputStream
+
+object LastUpdateSerializer : Serializer<LastUpdate> {
+    override val defaultValue: LastUpdate
+        get() = LastUpdate.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): LastUpdate =
+        try {
+            LastUpdate.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+
+    override suspend fun writeTo(t: LastUpdate, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/wear-datalayer/src/main/java/org/tasks/wear/SettingsSerializer.kt
+++ b/wear-datalayer/src/main/java/org/tasks/wear/SettingsSerializer.kt
@@ -1,0 +1,24 @@
+package org.tasks.wear
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.google.protobuf.InvalidProtocolBufferException
+import org.tasks.GrpcProto.Settings
+import java.io.InputStream
+import java.io.OutputStream
+
+object SettingsSerializer : Serializer<Settings> {
+    override val defaultValue: Settings
+        get() = Settings.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): Settings =
+        try {
+            Settings.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+
+    override suspend fun writeTo(t: Settings, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/wear-datalayer/src/main/proto/grpc.proto
+++ b/wear-datalayer/src/main/proto/grpc.proto
@@ -113,3 +113,14 @@ service WearService {
   rpc getTaskCount(GetTaskCountRequest) returns (GetTaskCountResponse);
   rpc getVersion(GetVersionRequest) returns (GetVersionResponse);
 }
+
+message LastUpdate {
+  uint64 now = 1;
+}
+
+message Settings {
+  repeated uint64 collapsed = 1;
+  optional string filter = 2;
+  bool showHidden = 3;
+  bool showCompleted = 4;
+}

--- a/wear/SYNC_ARCHITECTURE.md
+++ b/wear/SYNC_ARCHITECTURE.md
@@ -1,0 +1,165 @@
+# Wear-Phone Sync Architecture
+
+## Overview
+
+This document describes the sync architecture implemented for the Tasks Wear OS app.
+The system uses the Wearable Data Layer API for reliable data synchronization between
+the watch and phone, with per-field conflict resolution.
+
+## Key Components
+
+### Wear Module (Watch)
+
+#### Data Layer (`wear/src/main/java/org/tasks/data/`)
+
+1. **TaskEntity** - Room entity with sync fields:
+   - `dirty`: true if local changes not yet synced
+   - `titleUpdatedAt`, `notesUpdatedAt`, `completedUpdatedAt`: per-field timestamps for conflict resolution
+   - `syncedAt`: timestamp of last successful sync
+
+2. **OutboxOpEntity** - Queue of pending sync operations:
+   - `opId`: unique operation ID
+   - `taskId`: target task
+   - `type`: CREATE, UPDATE, DELETE, COMPLETE
+   - `payload`: JSON serialized operation data
+   - `state`: PENDING, SENDING, SENT, ACKED, FAILED
+
+3. **ProcessedOpEntity** - Tracks processed operations from phone (idempotency)
+
+4. **WearDatabase** - Room database with all entities and DAOs
+
+#### Sync Layer (`wear/src/main/java/org/tasks/data/sync/`)
+
+1. **SyncProtocol.kt** - Defines paths and keys:
+   - `/outbox/watch/{opId}` - Watch → Phone operations
+   - `/ack/watch/{opId}` - Phone → Watch acknowledgments
+   - `/outbox/phone/{opId}` - Phone → Watch operations
+   - `/ack/phone/{opId}` - Watch → Phone acknowledgments
+   - `/snapshot/tasks` - Full task snapshot
+   - `/tasks/{taskId}` - Single task updates
+
+2. **SyncRepository** - Handles transactional operations:
+   - Creates tasks + outbox ops in single transaction
+   - Applies incoming operations with conflict resolution
+   - Per-field last-write-wins strategy
+
+3. **DataLayerSyncManager** - Manages Wearable Data Layer:
+   - Sends operations via DataItem
+   - Receives and processes incoming data
+   - Handles acks and cleanup
+
+4. **WearSyncListenerService** - Background service for data changes
+
+5. **SyncWorker** - Periodic WorkManager job for:
+   - Processing pending operations
+   - Cleanup of acknowledged ops
+   - Retry of failed operations
+
+### Phone Module (App)
+
+#### Sync Layer (`app/src/main/java/org/tasks/wear/sync/`)
+
+1. **SyncProtocol.kt** - Mirrors wear module paths/keys
+
+2. **PhoneSyncManager** - Handles watch operations:
+   - Receives CREATE/UPDATE/DELETE/COMPLETE ops
+   - Applies to phone TaskDao with conflict resolution
+   - Sends acks back to watch
+   - Can send snapshots to watch
+
+3. **PhoneSyncListenerService** - Background service with Hilt injection
+
+## Sync Flow
+
+### Watch → Phone (User creates/edits task on watch)
+
+```
+1. User saves task on watch
+2. TaskRepository.saveTask() →
+3. SyncRepository.updateTitleAndNotes():
+   - Update task in Room with dirty=true
+   - Insert OutboxOpEntity
+   - (Transaction ensures atomicity)
+4. DataLayerSyncManager.processPendingOps():
+   - Create DataItem with operation data
+   - Set urgent for immediate delivery
+5. Phone receives onDataChanged()
+6. PhoneSyncManager.handleWatchOperation():
+   - Check idempotency (processedOps)
+   - Apply to TaskDao with conflict resolution
+   - Send ack via DataItem
+7. Watch receives ack, marks op as ACKED
+```
+
+### Phone → Watch (User creates/edits task on phone)
+
+```
+1. Task changed on phone
+2. PhoneSyncManager.sendTaskToWatch() or sendTasksToWatch()
+3. Create DataItem with task data + field timestamps
+4. Watch receives onDataChanged()
+5. DataLayerSyncManager.handlePhoneOperation():
+   - Check idempotency
+   - SyncRepository.applyIncomingTask():
+     - Per-field conflict resolution (last-write-wins)
+     - Update only fields where incoming timestamp > local
+6. Send ack via DataItem
+```
+
+## Conflict Resolution
+
+Uses **per-field last-write-wins** strategy:
+
+- Each field (title, notes, completed) has its own timestamp
+- When merging, compare timestamps per-field
+- Keep the value with the newer timestamp
+- This minimizes data loss compared to whole-record LWW
+
+Example:
+```
+Watch:  title="Buy milk" (12:00), notes="2 liters" (12:05)
+Phone:  title="Buy groceries" (12:10), notes="1 liter" (12:01)
+Result: title="Buy groceries" (from phone, newer)
+        notes="2 liters" (from watch, newer)
+```
+
+## Retry & Error Handling
+
+- Operations marked SENDING for >5 min are reset to PENDING
+- WorkManager runs every 15 min to process pending ops
+- Acked operations cleaned up periodically
+- Processed ops cleaned up after 7 days
+
+## DataItem Considerations
+
+- `setUrgent()` used for user-initiated actions
+- Non-urgent for batch syncs (battery friendly)
+- DataItems persist and sync when connectivity available
+- System handles retry automatically
+
+## Files Created/Modified
+
+### Wear Module
+- `data/local/TaskEntity.kt` - Added sync fields
+- `data/local/OutboxOpEntity.kt` - NEW
+- `data/local/OutboxOpDao.kt` - NEW
+- `data/local/ProcessedOpEntity.kt` - NEW
+- `data/local/ProcessedOpDao.kt` - NEW
+- `data/local/WearDatabase.kt` - Added new entities/DAOs
+- `data/local/TaskDao.kt` - Added sync queries
+- `data/local/TaskRepository.kt` - Integrated SyncRepository
+- `data/sync/SyncProtocol.kt` - NEW
+- `data/sync/SyncRepository.kt` - NEW
+- `data/sync/DataLayerSyncManager.kt` - NEW
+- `data/sync/WearSyncListenerService.kt` - NEW
+- `data/sync/SyncWorker.kt` - NEW
+- `WatchApp.kt` - Initialize sync
+- `AndroidManifest.xml` - Register service
+
+### App Module
+- `wear/sync/SyncProtocol.kt` - NEW
+- `wear/sync/PhoneSyncManager.kt` - NEW
+- `wear/sync/PhoneSyncListenerService.kt` - NEW
+- `injection/ApplicationModule.kt` - Provider for PhoneSyncManager
+- `AndroidManifest.xml` - Register service
+

--- a/wear/SYNC_ARCHITECTURE.md
+++ b/wear/SYNC_ARCHITECTURE.md
@@ -57,17 +57,23 @@ the watch and phone, with per-field conflict resolution.
 
 ### Phone Module (App)
 
-#### Sync Layer (`app/src/main/java/org/tasks/wear/sync/`)
+#### Sync Layer (`app/src/googleplay/java/org/tasks/wear/`)
 
 1. **SyncProtocol.kt** - Mirrors wear module paths/keys
 
 2. **PhoneSyncManager** - Handles watch operations:
    - Receives CREATE/UPDATE/DELETE/COMPLETE ops
-   - Applies to phone TaskDao with conflict resolution
+   - Applies to phone TaskDao with per-field last-write-wins conflict resolution
    - Sends acks back to watch
-   - Can send snapshots to watch
+   - Handles single task updates and snapshots back to the watch
 
-3. **PhoneSyncListenerService** - Background service with Hilt injection
+3. **WearRefresher** / **WearRefresherImpl** - Sends snapshots and task-level changes to watch
+
+4. **WearSyncNotifierImpl** - Bridges common KMP interface calls from `TaskSaver` and `TaskDeleter` to the Google Play `WearRefresherImpl` (lazily instantiated via `Lazy<WearRefresher>` to prevent dependency injection cycles)
+
+### Common/Shared Layer (`kmp/src/commonMain/`)
+
+1. **WearSyncNotifier** - Interface used by core business logic (in KMP) to notify platform sync modules of task mutations without introducing module circular dependencies
 
 ## Sync Flow
 
@@ -86,7 +92,8 @@ the watch and phone, with per-field conflict resolution.
 5. Phone receives onDataChanged()
 6. PhoneSyncManager.handleWatchOperation():
    - Check idempotency (processedOps)
-   - Apply to TaskDao with conflict resolution
+   - Apply to TaskDao with conflict resolution (last-write-wins comparing
+     watch field timestamps against the phone's task modificationDate)
    - Send ack via DataItem
 7. Watch receives ack, marks op as ACKED
 ```
@@ -94,34 +101,27 @@ the watch and phone, with per-field conflict resolution.
 ### Phone → Watch (User creates/edits task on phone)
 
 ```
-1. Task changed on phone
-2. PhoneSyncManager.sendTaskToWatch() or sendTasksToWatch()
-3. Create DataItem with task data + field timestamps
-4. Watch receives onDataChanged()
-5. DataLayerSyncManager.handlePhoneOperation():
-   - Check idempotency
-   - SyncRepository.applyIncomingTask():
-     - Per-field conflict resolution (last-write-wins)
-     - Update only fields where incoming timestamp > local
-6. Send ack via DataItem
+1. Task created, saved, or completed via TaskSaver or TaskCompleter
+2. TaskSaver triggers wearSyncNotifier.notifyTaskChanged(taskId)
+3. WearSyncNotifierImpl routes to WearRefresherImpl.notifyTaskChanged(taskId)
+4. PhoneSyncManager.sendTaskUpdate(task) is invoked:
+   - Creates a DataItem with task data + field modification timestamps
+   - Marks as urgent and pushes to the watch at /tasks/{taskId}
+5. Watch receives onDataChanged()
+6. DataLayerSyncManager.handleTaskUpdate():
+   - Calls SyncRepository.applyIncomingTaskWithPhoneId()
+   - Evaluates per-field last-write-wins conflict resolution (title, notes, completed)
 ```
 
 ## Conflict Resolution
 
-Uses **per-field last-write-wins** strategy:
+Uses **per-field last-write-wins** strategy in BOTH directions:
 
-- Each field (title, notes, completed) has its own timestamp
-- When merging, compare timestamps per-field
-- Keep the value with the newer timestamp
-- This minimizes data loss compared to whole-record LWW
-
-Example:
-```
-Watch:  title="Buy milk" (12:00), notes="2 liters" (12:05)
-Phone:  title="Buy groceries" (12:10), notes="1 liter" (12:01)
-Result: title="Buy groceries" (from phone, newer)
-        notes="2 liters" (from watch, newer)
-```
+- Each field (title, notes, completed) has its own timestamp.
+- On the phone, watch timestamps are compared against the task's general `modificationDate` (which acts as the baseline version marker).
+- When merging, compare timestamps per-field.
+- Keep the value with the newer timestamp.
+- This minimizes data loss compared to whole-record LWW.
 
 ## Retry & Error Handling
 
@@ -137,6 +137,7 @@ Result: title="Buy groceries" (from phone, newer)
 - DataItems persist and sync when connectivity available
 - System handles retry automatically
 
+
 ## Files Created/Modified
 
 ### Wear Module
@@ -148,7 +149,7 @@ Result: title="Buy groceries" (from phone, newer)
 - `data/local/WearDatabase.kt` - Added new entities/DAOs
 - `data/local/TaskDao.kt` - Added sync queries
 - `data/local/TaskRepository.kt` - Integrated SyncRepository
-- `data/sync/SyncProtocol.kt` - NEW
+- `data/sync/SyncProtocol.kt` - Added `KEY_MODIFICATION_DATE` to `DataMapKeys`
 - `data/sync/SyncRepository.kt` - NEW
 - `data/sync/DataLayerSyncManager.kt` - NEW
 - `data/sync/WearSyncListenerService.kt` - NEW
@@ -157,9 +158,17 @@ Result: title="Buy groceries" (from phone, newer)
 - `AndroidManifest.xml` - Register service
 
 ### App Module
-- `wear/sync/SyncProtocol.kt` - NEW
-- `wear/sync/PhoneSyncManager.kt` - NEW
-- `wear/sync/PhoneSyncListenerService.kt` - NEW
-- `injection/ApplicationModule.kt` - Provider for PhoneSyncManager
-- `AndroidManifest.xml` - Register service
+- `wear/PhoneSyncManager.kt` - Added conflict resolution and `notifyTaskDeleted`
+- `wear/WearRefresher.kt` - Added `notifyTaskChanged` / `notifyTaskDeleted` to interface
+- `wear/WearRefresherImpl.kt` - Implemented task update/delete pushes
+- `wear/WearSyncNotifierImpl.kt` - NEW (KMP-to-App bridge)
+- `injection/ApplicationModule.kt` - Wired providers for `WearSyncNotifier` and updated `providesTaskSaver`/`providesTaskDeleter`
+
+### KMP Module
+- `wear/WearSyncNotifier.kt` - NEW (Common KMP sync interface)
+- `data/TaskSaver.kt` - Added trigger for `wearSyncNotifier.notifyTaskChanged()`
+- `service/TaskDeleter.kt` - Added triggers for `wearSyncNotifier.notifyTaskDeleted()`
+- `jvmTest/kotlin/org/tasks/sync/SyncAdaptersTest.kt` - Updated mocks for TaskSaver
+- `jvmTest/kotlin/org/tasks/service/TaskMigratorTest.kt` - Updated mocks for TaskDeleter
+
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -46,7 +46,12 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            val tasksStoreFile: String? by project
+            if (tasksStoreFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            } else {
+                signingConfig = signingConfigs.getByName("debug")
+            }
         }
     }
     compileOptions {
@@ -111,6 +116,8 @@ dependencies {
     // Room Database
     implementation(libs.androidx.room)
     ksp(libs.androidx.room.compiler)
+
+    implementation("androidx.fragment:fragment:1.8.5")
 
 
     implementation(libs.wear.tiles.proto) // https://nvd.nist.gov/vuln/detail/CVE-2024-7254

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.kotlin.compose.compiler)
+    alias(libs.plugins.ksp)
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
 }
@@ -71,6 +72,11 @@ android {
     tasks.register("testClasses")
 }
 
+// Room schema export directory configuration
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(platform(libs.androidx.compose))
@@ -101,6 +107,11 @@ dependencies {
     implementation(libs.horologist.datalayer.grpc)
     implementation(libs.timber)
     implementation(libs.androidx.work)
+
+    // Room Database
+    implementation(libs.androidx.room)
+    ksp(libs.androidx.room.compiler)
+
 
     implementation(libs.wear.tiles.proto) // https://nvd.nist.gov/vuln/detail/CVE-2024-7254
 

--- a/wear/schemas/org.tasks.data.local.WearDatabase/1.json
+++ b/wear/schemas/org.tasks.data.local.WearDatabase/1.json
@@ -1,0 +1,77 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "2b373354e83ceb41ce272166a19d1c65",
+    "entities": [
+      {
+        "tableName": "tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `notes` TEXT, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `priority` INTEGER NOT NULL, `timestamp` TEXT, `repeating` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeating",
+            "columnName": "repeating",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2b373354e83ceb41ce272166a19d1c65')"
+    ]
+  }
+}

--- a/wear/schemas/org.tasks.data.local.WearDatabase/2.json
+++ b/wear/schemas/org.tasks.data.local.WearDatabase/2.json
@@ -1,0 +1,196 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "a59a8102e22ebdcd9a763b20435a4e4a",
+    "entities": [
+      {
+        "tableName": "tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `notes` TEXT, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `priority` INTEGER NOT NULL, `timestamp` TEXT, `repeating` INTEGER NOT NULL, `dirty` INTEGER NOT NULL, `titleUpdatedAt` INTEGER NOT NULL, `notesUpdatedAt` INTEGER NOT NULL, `completedUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeating",
+            "columnName": "repeating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUpdatedAt",
+            "columnName": "titleUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notesUpdatedAt",
+            "columnName": "notesUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedUpdatedAt",
+            "columnName": "completedUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outbox_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `taskId` TEXT NOT NULL, `type` TEXT NOT NULL, `payload` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `state` TEXT NOT NULL, `lastAttemptAt` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      },
+      {
+        "tableName": "processed_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` TEXT NOT NULL, `processedAt` INTEGER NOT NULL, PRIMARY KEY(`opId`))",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a59a8102e22ebdcd9a763b20435a4e4a')"
+    ]
+  }
+}

--- a/wear/schemas/org.tasks.data.local.WearDatabase/3.json
+++ b/wear/schemas/org.tasks.data.local.WearDatabase/3.json
@@ -1,0 +1,256 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "bb1c018669ebfe69684e89f6a28bbd3a",
+    "entities": [
+      {
+        "tableName": "tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `notes` TEXT, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `priority` INTEGER NOT NULL, `timestamp` TEXT, `repeating` INTEGER NOT NULL, `dirty` INTEGER NOT NULL, `titleUpdatedAt` INTEGER NOT NULL, `notesUpdatedAt` INTEGER NOT NULL, `completedUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeating",
+            "columnName": "repeating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUpdatedAt",
+            "columnName": "titleUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notesUpdatedAt",
+            "columnName": "notesUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedUpdatedAt",
+            "columnName": "completedUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outbox_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `taskId` TEXT NOT NULL, `type` TEXT NOT NULL, `payload` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `state` TEXT NOT NULL, `lastAttemptAt` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      },
+      {
+        "tableName": "processed_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` TEXT NOT NULL, `processedAt` INTEGER NOT NULL, PRIMARY KEY(`opId`))",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `showHidden` INTEGER NOT NULL, `showCompleted` INTEGER NOT NULL, `filter_value` TEXT NOT NULL, `collapsedGroups` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `dirty` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showHidden",
+            "columnName": "showHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showCompleted",
+            "columnName": "showCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filter",
+            "columnName": "filter_value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collapsedGroups",
+            "columnName": "collapsedGroups",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bb1c018669ebfe69684e89f6a28bbd3a')"
+    ]
+  }
+}

--- a/wear/schemas/org.tasks.data.local.WearDatabase/4.json
+++ b/wear/schemas/org.tasks.data.local.WearDatabase/4.json
@@ -1,0 +1,282 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "bc29663a5f41997b33df769498c529dd",
+    "entities": [
+      {
+        "tableName": "tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `notes` TEXT, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `priority` INTEGER NOT NULL, `timestamp` TEXT, `repeating` INTEGER NOT NULL, `dueDate` INTEGER, `dueTime` INTEGER, `reminder` INTEGER NOT NULL, `reminderTime` INTEGER, `dirty` INTEGER NOT NULL, `titleUpdatedAt` INTEGER NOT NULL, `notesUpdatedAt` INTEGER NOT NULL, `completedUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `phoneTaskId` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeating",
+            "columnName": "repeating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueDate",
+            "columnName": "dueDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dueTime",
+            "columnName": "dueTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "reminder",
+            "columnName": "reminder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderTime",
+            "columnName": "reminderTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUpdatedAt",
+            "columnName": "titleUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notesUpdatedAt",
+            "columnName": "notesUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedUpdatedAt",
+            "columnName": "completedUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneTaskId",
+            "columnName": "phoneTaskId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outbox_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `taskId` TEXT NOT NULL, `type` TEXT NOT NULL, `payload` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `state` TEXT NOT NULL, `lastAttemptAt` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      },
+      {
+        "tableName": "processed_ops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`opId` TEXT NOT NULL, `processedAt` INTEGER NOT NULL, PRIMARY KEY(`opId`))",
+        "fields": [
+          {
+            "fieldPath": "opId",
+            "columnName": "opId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "opId"
+          ]
+        }
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `showHidden` INTEGER NOT NULL, `showCompleted` INTEGER NOT NULL, `filter_value` TEXT NOT NULL, `collapsedGroups` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `dirty` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showHidden",
+            "columnName": "showHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showCompleted",
+            "columnName": "showCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filter",
+            "columnName": "filter_value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collapsedGroups",
+            "columnName": "collapsedGroups",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bc29663a5f41997b33df769498c529dd')"
+    ]
+  }
+}

--- a/wear/src/main/java/org/tasks/data/local/OutboxOpDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/OutboxOpDao.kt
@@ -1,0 +1,112 @@
+/**
+ * OutboxOpDao.kt — Room DAO for the `outbox_ops` table.
+ *
+ * Provides CRUD + state-transition queries for the outbound sync queue.
+ * State transitions follow the lifecycle described in [OutboxOpEntity].
+ */
+package org.tasks.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for OutboxOpEntity.
+ * Manages the queue of pending sync operations.
+ */
+@Dao
+interface OutboxOpDao {
+
+    /**
+     * Get all pending operations ordered by creation time.
+     */
+    @Query("SELECT * FROM outbox_ops WHERE state = 'PENDING' OR state = 'SENDING' ORDER BY createdAt ASC")
+    fun getPendingOps(): Flow<List<OutboxOpEntity>>
+
+    /**
+     * Get pending operations once (non-reactive).
+     */
+    @Query("SELECT * FROM outbox_ops WHERE state = 'PENDING' OR state = 'SENDING' ORDER BY createdAt ASC")
+    suspend fun getPendingOpsOnce(): List<OutboxOpEntity>
+
+    /**
+     * Get an operation by ID.
+     */
+    @Query("SELECT * FROM outbox_ops WHERE opId = :opId LIMIT 1")
+    suspend fun getOp(opId: Long): OutboxOpEntity?
+
+    /**
+     * Get operations by task ID.
+     */
+    @Query("SELECT * FROM outbox_ops WHERE taskId = :taskId ORDER BY createdAt DESC")
+    suspend fun getOpsByTaskId(taskId: String): List<OutboxOpEntity>
+
+    /**
+     * Insert a new operation.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(op: OutboxOpEntity): Long
+
+    /**
+     * Update an operation.
+     */
+    @Update
+    suspend fun update(op: OutboxOpEntity)
+
+    /**
+     * Mark operation as sending.
+     */
+    @Query("UPDATE outbox_ops SET state = 'SENDING', lastAttemptAt = :timestamp, attempts = attempts + 1 WHERE opId = :opId")
+    suspend fun markSending(opId: Long, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Mark operation as sent (waiting for ack).
+     */
+    @Query("UPDATE outbox_ops SET state = 'SENT', lastAttemptAt = :timestamp WHERE opId = :opId")
+    suspend fun markSent(opId: Long, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Mark operation as acknowledged.
+     */
+    @Query("UPDATE outbox_ops SET state = 'ACKED' WHERE opId = :opId")
+    suspend fun markAcked(opId: Long)
+
+    /**
+     * Mark operation as failed.
+     */
+    @Query("UPDATE outbox_ops SET state = 'FAILED', errorMessage = :error WHERE opId = :opId")
+    suspend fun markFailed(opId: Long, error: String?)
+
+    /**
+     * Reset stuck operations (sending for too long).
+     */
+    @Query("UPDATE outbox_ops SET state = 'PENDING' WHERE state = 'SENDING' AND lastAttemptAt < :threshold")
+    suspend fun resetStuckOps(threshold: Long)
+
+    /**
+     * Delete acknowledged operations.
+     */
+    @Query("DELETE FROM outbox_ops WHERE state = 'ACKED'")
+    suspend fun deleteAckedOps()
+
+    /**
+     * Delete operation by ID.
+     */
+    @Query("DELETE FROM outbox_ops WHERE opId = :opId")
+    suspend fun delete(opId: Long)
+
+    /**
+     * Get count of pending operations.
+     */
+    @Query("SELECT COUNT(*) FROM outbox_ops WHERE state = 'PENDING' OR state = 'SENDING'")
+    suspend fun getPendingCount(): Int
+
+    /**
+     * Get operations that need retry (failed less than max attempts).
+     */
+    @Query("SELECT * FROM outbox_ops WHERE state = 'SENT' AND lastAttemptAt < :threshold ORDER BY createdAt ASC")
+    suspend fun getOpsNeedingRetry(threshold: Long): List<OutboxOpEntity>
+}

--- a/wear/src/main/java/org/tasks/data/local/OutboxOpDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/OutboxOpDao.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
  * Manages the queue of pending sync operations.
  */
 @Dao
+@Suppress("TooManyFunctions")
 interface OutboxOpDao {
 
     /**

--- a/wear/src/main/java/org/tasks/data/local/OutboxOpEntity.kt
+++ b/wear/src/main/java/org/tasks/data/local/OutboxOpEntity.kt
@@ -1,0 +1,57 @@
+/**
+ * OutboxOpEntity.kt — Outbox queue row for watch → phone operations.
+ *
+ * ## State machine
+ * ```
+ *  PENDING ──▶ SENDING ──▶ SENT ──▶ ACKED  (happy path)
+ *     │            │          │
+ *     └────────────┴──────────┘──▶ FAILED  (after max retries)
+ * ```
+ *
+ * [SyncWorker] periodically drains the queue.  Rows in `ACKED` state
+ * are eventually cleaned up by [SyncRepository.cleanupAckedOps].
+ */
+package org.tasks.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Entity representing a pending sync operation in the outbox.
+ * Operations are queued here when the user creates/modifies/deletes tasks on the watch,
+ * then sent to the phone via Data Layer and removed once acknowledged.
+ */
+@Entity(tableName = "outbox_ops")
+data class OutboxOpEntity(
+    @PrimaryKey(autoGenerate = true)
+    val opId: Long = 0,
+    val taskId: String,
+    val type: OutboxOpType,
+    val payload: String,  // JSON-serialized operation data
+    val createdAt: Long = System.currentTimeMillis(),
+    val attempts: Int = 0,
+    val state: OutboxOpState = OutboxOpState.PENDING,
+    val lastAttemptAt: Long = 0,
+    val errorMessage: String? = null,
+)
+
+/**
+ * Type of outbox operation.
+ */
+enum class OutboxOpType {
+    CREATE,
+    UPDATE,
+    DELETE,
+    COMPLETE,
+}
+
+/**
+ * State of an outbox operation.
+ */
+enum class OutboxOpState {
+    PENDING,     // Not yet sent
+    SENDING,     // Currently being sent
+    SENT,        // Sent, waiting for ack
+    ACKED,       // Acknowledged by phone
+    FAILED,      // Failed after max retries
+}

--- a/wear/src/main/java/org/tasks/data/local/ProcessedOpDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/ProcessedOpDao.kt
@@ -1,0 +1,39 @@
+/**
+ * ProcessedOpDao.kt — Room DAO for the `processed_ops` idempotency table.
+ *
+ * Provides three simple operations:
+ * - [isProcessed]   — O(1) check before applying an incoming phone operation.
+ * - [markProcessed] — Insert after successful application.
+ * - [cleanupOld]    — Purge entries older than a configurable threshold.
+ */
+package org.tasks.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * DAO for tracking processed operations from phone.
+ */
+@Dao
+interface ProcessedOpDao {
+
+    /**
+     * Check if an operation has already been processed.
+     */
+    @Query("SELECT EXISTS(SELECT 1 FROM processed_ops WHERE opId = :opId)")
+    suspend fun isProcessed(opId: String): Boolean
+
+    /**
+     * Mark an operation as processed.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun markProcessed(op: ProcessedOpEntity)
+
+    /**
+     * Clean up old processed operations (older than threshold).
+     */
+    @Query("DELETE FROM processed_ops WHERE processedAt < :threshold")
+    suspend fun cleanupOld(threshold: Long)
+}

--- a/wear/src/main/java/org/tasks/data/local/ProcessedOpEntity.kt
+++ b/wear/src/main/java/org/tasks/data/local/ProcessedOpEntity.kt
@@ -1,0 +1,26 @@
+/**
+ * ProcessedOpEntity.kt — Idempotency guard for phone → watch operations.
+ *
+ * Stores the `opId` of every incoming phone operation that has been
+ * applied. Before applying a new operation, [SyncRepository] checks
+ * this table to skip duplicates.
+ *
+ * Old entries are purged by [SyncRepository.cleanupOldProcessedOps]
+ * (default: 7 days).
+ */
+package org.tasks.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Entity to track processed operations from phone to avoid duplicates (idempotency).
+ * When we receive an operation from the phone, we store its ID here to prevent
+ * processing it again if it arrives multiple times.
+ */
+@Entity(tableName = "processed_ops")
+data class ProcessedOpEntity(
+    @PrimaryKey
+    val opId: String,  // Unique operation ID from phone
+    val processedAt: Long = System.currentTimeMillis(),
+)

--- a/wear/src/main/java/org/tasks/data/local/SettingsDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/SettingsDao.kt
@@ -1,0 +1,75 @@
+/**
+ * SettingsDao.kt — Room DAO for the singleton `settings` table.
+ *
+ * Every write method sets `dirty = 1` so the sync layer knows
+ * there are local changes to push to the phone.
+ */
+package org.tasks.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for SettingsEntity.
+ * Provides methods for accessing local settings.
+ */
+@Dao
+interface SettingsDao {
+
+    /**
+     * Get settings as a Flow for reactive updates.
+     */
+    @Query("SELECT * FROM settings WHERE id = 1 LIMIT 1")
+    fun getSettings(): Flow<SettingsEntity?>
+
+    /**
+     * Get settings once (non-reactive).
+     */
+    @Query("SELECT * FROM settings WHERE id = 1 LIMIT 1")
+    suspend fun getSettingsOnce(): SettingsEntity?
+
+    /**
+     * Insert or replace settings.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrUpdate(settings: SettingsEntity)
+
+    /**
+     * Update show hidden setting.
+     */
+    @Query("UPDATE settings SET showHidden = :showHidden, updatedAt = :timestamp, dirty = 1 WHERE id = 1")
+    suspend fun setShowHidden(showHidden: Boolean, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update show completed setting.
+     */
+    @Query("UPDATE settings SET showCompleted = :showCompleted, updatedAt = :timestamp, dirty = 1 WHERE id = 1")
+    suspend fun setShowCompleted(showCompleted: Boolean, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update filter.
+     */
+    @Query("UPDATE settings SET filter_value = :filter, collapsedGroups = :collapsedGroups, updatedAt = :timestamp, dirty = 1 WHERE id = 1")
+    suspend fun setFilter(filter: String, collapsedGroups: String = "", timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update collapsed groups.
+     */
+    @Query("UPDATE settings SET collapsedGroups = :collapsedGroups, updatedAt = :timestamp, dirty = 1 WHERE id = 1")
+    suspend fun setCollapsedGroups(collapsedGroups: String, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Mark settings as synced.
+     */
+    @Query("UPDATE settings SET dirty = 0, syncedAt = :timestamp WHERE id = 1")
+    suspend fun markSynced(timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Check if settings exist.
+     */
+    @Query("SELECT COUNT(*) > 0 FROM settings WHERE id = 1")
+    suspend fun hasSettings(): Boolean
+}

--- a/wear/src/main/java/org/tasks/data/local/SettingsEntity.kt
+++ b/wear/src/main/java/org/tasks/data/local/SettingsEntity.kt
@@ -1,0 +1,35 @@
+/**
+ * SettingsEntity.kt — Singleton settings row for the Wear app.
+ *
+ * The table always has exactly one row (`id = 1`).
+ * [SettingsRepository.ensureSettingsExist] creates the default row
+ * on first launch.
+ *
+ * Settings are written locally first (setting `dirty = true`) and
+ * synced to the phone when connectivity is available. Incoming
+ * settings from the phone are only applied when the local row is
+ * *not* dirty, so local edits are never silently overwritten.
+ */
+package org.tasks.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room Entity representing local settings for the Wear app.
+ * These settings are stored locally and synced with the phone when connected.
+ */
+@Entity(tableName = "settings")
+data class SettingsEntity(
+    @PrimaryKey
+    val id: Int = 1,  // Always use id=1 for singleton settings
+    val showHidden: Boolean = false,
+    val showCompleted: Boolean = false,
+    @ColumnInfo(name = "filter_value")
+    val filter: String = "",
+    val collapsedGroups: String = "",  // Comma-separated list of collapsed group IDs
+    val updatedAt: Long = System.currentTimeMillis(),
+    val dirty: Boolean = false,  // True if local changes not yet synced
+    val syncedAt: Long = 0L,  // Last successful sync timestamp
+)

--- a/wear/src/main/java/org/tasks/data/local/SettingsRepository.kt
+++ b/wear/src/main/java/org/tasks/data/local/SettingsRepository.kt
@@ -1,0 +1,164 @@
+/**
+ * SettingsRepository.kt — Read / write access for user preferences on Wear.
+ *
+ * Wraps [SettingsDao] and adds business logic:
+ * - [ensureSettingsExist] seeds the default singleton row.
+ * - Mutators ([setShowHidden], [setShowCompleted], etc.) implicitly
+ *   mark the row as `dirty = true`.
+ * - [applyFromPhone] merges incoming phone settings **only when the
+ *   local row is not dirty**, so user changes made while offline are
+ *   never silently overwritten.
+ *
+ * ## Singleton
+ * Accessed via [SettingsRepository.getInstance].
+ */
+package org.tasks.data.local
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import timber.log.Timber
+
+/**
+ * Repository that provides access to local settings.
+ * Works offline and syncs with phone when connected.
+ */
+class SettingsRepository(context: Context) {
+
+    private val database = WearDatabase.getInstance(context)
+    private val settingsDao = database.settingsDao()
+
+    /**
+     * Get settings as a Flow for reactive updates.
+     * Returns default settings if none exist.
+     */
+    fun getSettings(): Flow<SettingsEntity> {
+        return settingsDao.getSettings().map { it ?: SettingsEntity() }
+    }
+
+    /**
+     * Get settings once (non-reactive).
+     */
+    suspend fun getSettingsOnce(): SettingsEntity {
+        return settingsDao.getSettingsOnce() ?: SettingsEntity()
+    }
+
+    /**
+     * Ensure settings exist in the database.
+     */
+    suspend fun ensureSettingsExist() {
+        if (!settingsDao.hasSettings()) {
+            settingsDao.insertOrUpdate(SettingsEntity())
+            Timber.d("Created default settings")
+        }
+    }
+
+    /**
+     * Update show hidden setting.
+     */
+    suspend fun setShowHidden(showHidden: Boolean) {
+        ensureSettingsExist()
+        settingsDao.setShowHidden(showHidden)
+        Timber.d("Set showHidden=$showHidden")
+    }
+
+    /**
+     * Update show completed setting.
+     */
+    suspend fun setShowCompleted(showCompleted: Boolean) {
+        ensureSettingsExist()
+        settingsDao.setShowCompleted(showCompleted)
+        Timber.d("Set showCompleted=$showCompleted")
+    }
+
+    /**
+     * Update filter.
+     */
+    suspend fun setFilter(filter: String, collapsedGroups: String = "") {
+        ensureSettingsExist()
+        settingsDao.setFilter(filter, collapsedGroups)
+        Timber.d("Set filter=$filter")
+    }
+
+    /**
+     * Add or remove a group from collapsed list.
+     */
+    suspend fun toggleGroupCollapsed(groupId: Long, collapsed: Boolean) {
+        ensureSettingsExist()
+        val settings = getSettingsOnce()
+        val collapsedList = settings.collapsedGroups
+            .split(",")
+            .filter { it.isNotBlank() }
+            .map { it.toLong() }
+            .toMutableSet()
+
+        if (collapsed) {
+            collapsedList.add(groupId)
+        } else {
+            collapsedList.remove(groupId)
+        }
+
+        settingsDao.setCollapsedGroups(collapsedList.joinToString(","))
+        Timber.d("Toggled group $groupId collapsed=$collapsed")
+    }
+
+    /**
+     * Get collapsed group IDs as a set.
+     */
+    suspend fun getCollapsedGroups(): Set<Long> {
+        val settings = getSettingsOnce()
+        return settings.collapsedGroups
+            .split(",")
+            .filter { it.isNotBlank() }
+            .mapNotNull { it.toLongOrNull() }
+            .toSet()
+    }
+
+    /**
+     * Apply settings from phone (sync).
+     */
+    suspend fun applyFromPhone(
+        showHidden: Boolean,
+        showCompleted: Boolean,
+        filter: String,
+        collapsedGroups: Set<Long>,
+    ) {
+        ensureSettingsExist()
+        val current = getSettingsOnce()
+
+        // Only apply if not dirty (local changes take priority)
+        if (!current.dirty) {
+            settingsDao.insertOrUpdate(
+                SettingsEntity(
+                    showHidden = showHidden,
+                    showCompleted = showCompleted,
+                    filter = filter,
+                    collapsedGroups = collapsedGroups.joinToString(","),
+                    dirty = false,
+                    syncedAt = System.currentTimeMillis(),
+                )
+            )
+            Timber.d("Applied settings from phone")
+        } else {
+            Timber.d("Skipped applying settings from phone (local changes pending)")
+        }
+    }
+
+    /**
+     * Mark settings as synced.
+     */
+    suspend fun markSynced() {
+        settingsDao.markSynced()
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: SettingsRepository? = null
+
+        fun getInstance(context: Context): SettingsRepository {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: SettingsRepository(context).also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/data/local/TaskDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/TaskDao.kt
@@ -1,0 +1,224 @@
+/**
+ * TaskDao.kt — Room DAO for the `tasks` table.
+ *
+ * ## Query groups
+ * | Group                | Methods                                       | Used by                |
+ * |----------------------|-----------------------------------------------|------------------------|
+ * | **Read (UI)**        | getTasks, getTasksOnce, getTask, getTaskFlow  | TaskRepository → UI    |
+ * | **Write (local)**    | insert, update, softDelete, setCompleted, …    | SyncRepository         |
+ * | **Conflict resolve** | updateTitleIfNewer, updateNotesIfNewer, …      | SyncRepository (inbox) |
+ * | **Sync helpers**     | getDirtyTasks, markSynced, getTaskByPhoneId   | SyncRepository         |
+ * | **Cleanup**          | cleanupDeletedTasks, hardDelete                | SyncWorker             |
+ * | **Notifications**    | getTasksWithReminders                          | WearNotificationMgr   |
+ *
+ * All write methods except the `IfNewer` variants set `dirty = 1` so the
+ * outbox knows there are pending local changes.
+ */
+package org.tasks.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for TaskEntity.
+ * Provides methods for accessing the tasks table.
+ */
+@Dao
+interface TaskDao {
+
+    /**
+     * Get all non-deleted tasks ordered by updatedAt descending.
+     * Returns a Flow for reactive updates.
+     */
+    @Query("SELECT * FROM tasks WHERE deleted = 0 ORDER BY updatedAt DESC")
+    fun getTasks(): Flow<List<TaskEntity>>
+
+    /**
+     * Get all non-deleted tasks (non-reactive, for one-shot reads).
+     */
+    @Query("SELECT * FROM tasks WHERE deleted = 0 ORDER BY updatedAt DESC")
+    suspend fun getTasksOnce(): List<TaskEntity>
+
+    /**
+     * Get a single task by ID.
+     */
+    @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
+    suspend fun getTask(id: String): TaskEntity?
+
+    /**
+     * Get a single task by ID as Flow for reactive updates.
+     */
+    @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
+    fun getTaskFlow(id: String): Flow<TaskEntity?>
+
+    /**
+     * Insert a new task. If conflict, replace the existing one.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(task: TaskEntity)
+
+    /**
+     * Insert multiple tasks. If conflict, replace existing ones.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(tasks: List<TaskEntity>)
+
+    /**
+     * Update an existing task.
+     */
+    @Update
+    suspend fun update(task: TaskEntity)
+
+    /**
+     * Soft delete a task (set deleted = true).
+     */
+    @Query("UPDATE tasks SET deleted = 1, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun softDelete(id: String, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Hard delete a task (remove from database).
+     */
+    @Query("DELETE FROM tasks WHERE id = :id")
+    suspend fun delete(id: String)
+
+    /**
+     * Mark a task as completed or not.
+     */
+    @Query("UPDATE tasks SET completed = :completed, completedUpdatedAt = :timestamp, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun setCompleted(id: String, completed: Boolean, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update task title and notes with per-field timestamps.
+     */
+    @Query("UPDATE tasks SET title = :title, titleUpdatedAt = :timestamp, notes = :notes, notesUpdatedAt = :timestamp, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun updateTitleAndNotes(id: String, title: String, notes: String?, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update only the title with its timestamp.
+     */
+    @Query("UPDATE tasks SET title = :title, titleUpdatedAt = :timestamp, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun updateTitle(id: String, title: String, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update only the notes with its timestamp.
+     */
+    @Query("UPDATE tasks SET notes = :notes, notesUpdatedAt = :timestamp, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun updateNotes(id: String, notes: String?, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Get count of non-deleted tasks.
+     */
+    @Query("SELECT COUNT(*) FROM tasks WHERE deleted = 0")
+    suspend fun getTaskCount(): Int
+
+    // ===== Sync-related queries =====
+
+    /**
+     * Get all dirty tasks (local changes not yet synced).
+     */
+    @Query("SELECT * FROM tasks WHERE dirty = 1")
+    suspend fun getDirtyTasks(): List<TaskEntity>
+
+    /**
+     * Mark a task as synced (clean).
+     */
+    @Query("UPDATE tasks SET dirty = 0, syncedAt = :timestamp WHERE id = :id")
+    suspend fun markSynced(id: String, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Mark multiple tasks as synced.
+     */
+    @Query("UPDATE tasks SET dirty = 0, syncedAt = :timestamp WHERE id IN (:ids)")
+    suspend fun markSyncedBatch(ids: List<String>, timestamp: Long = System.currentTimeMillis())
+
+    /**
+     * Update title only if the incoming timestamp is newer (for conflict resolution).
+     */
+    @Query("UPDATE tasks SET title = :title, titleUpdatedAt = :timestamp WHERE id = :id AND titleUpdatedAt < :timestamp")
+    suspend fun updateTitleIfNewer(id: String, title: String, timestamp: Long): Int
+
+    /**
+     * Update notes only if the incoming timestamp is newer (for conflict resolution).
+     */
+    @Query("UPDATE tasks SET notes = :notes, notesUpdatedAt = :timestamp WHERE id = :id AND notesUpdatedAt < :timestamp")
+    suspend fun updateNotesIfNewer(id: String, notes: String?, timestamp: Long): Int
+
+    /**
+     * Update completed only if the incoming timestamp is newer (for conflict resolution).
+     */
+    @Query("UPDATE tasks SET completed = :completed, completedUpdatedAt = :timestamp WHERE id = :id AND completedUpdatedAt < :timestamp")
+    suspend fun updateCompletedIfNewer(id: String, completed: Boolean, timestamp: Long): Int
+
+    /**
+     * Get all tasks including deleted ones (for sync).
+     */
+    @Query("SELECT * FROM tasks ORDER BY updatedAt DESC")
+    suspend fun getAllTasksForSync(): List<TaskEntity>
+
+    /**
+     * Get tasks modified after a certain timestamp (for incremental sync).
+     */
+    @Query("SELECT * FROM tasks WHERE updatedAt > :since ORDER BY updatedAt ASC")
+    suspend fun getTasksModifiedAfter(since: Long): List<TaskEntity>
+
+    /**
+     * Hard delete tasks that are deleted and synced (cleanup).
+     */
+    @Query("DELETE FROM tasks WHERE deleted = 1 AND dirty = 0 AND syncedAt > 0 AND syncedAt < :threshold")
+    suspend fun cleanupDeletedTasks(threshold: Long)
+
+    /**
+     * Find a task by its phone task ID (for sync mapping).
+     */
+    @Query("SELECT * FROM tasks WHERE phoneTaskId = :phoneId LIMIT 1")
+    suspend fun getTaskByPhoneId(phoneId: Long): TaskEntity?
+
+    /**
+     * Find dirty tasks matching a title (for duplicate detection during initial sync).
+     * This helps match locally created tasks with their phone counterparts.
+     */
+    @Query("SELECT * FROM tasks WHERE title = :title AND dirty = 1 AND phoneTaskId IS NULL LIMIT 1")
+    suspend fun findDirtyTaskByTitle(title: String): TaskEntity?
+
+    /**
+     * Hard delete a task by ID (used when phone reports deletion).
+     */
+    @Query("DELETE FROM tasks WHERE id = :id")
+    suspend fun hardDelete(id: String)
+
+    /**
+     * Hard delete a task by phone ID (used when phone reports deletion).
+     */
+    @Query("DELETE FROM tasks WHERE phoneTaskId = :phoneId")
+    suspend fun hardDeleteByPhoneId(phoneId: Long)
+
+    /**
+     * Update the phoneTaskId for a task.
+     */
+    @Query("UPDATE tasks SET phoneTaskId = :phoneId WHERE id = :id")
+    suspend fun setPhoneTaskId(id: String, phoneId: Long)
+
+    /**
+     * Update due date, time and reminder for a task.
+     */
+    @Query("UPDATE tasks SET dueDate = :dueDate, dueTime = :dueTime, reminder = :reminder, reminderTime = :reminderTime, updatedAt = :timestamp, dirty = 1 WHERE id = :id")
+    suspend fun updateDueDateAndReminder(
+        id: String,
+        dueDate: Long?,
+        dueTime: Long?,
+        reminder: Boolean,
+        reminderTime: Long?,
+        timestamp: Long = System.currentTimeMillis()
+    )
+
+    /**
+     * Get all tasks that have reminders enabled and are not completed/deleted.
+     */
+    @Query("SELECT * FROM tasks WHERE reminder = 1 AND completed = 0 AND deleted = 0")
+    suspend fun getTasksWithReminders(): List<TaskEntity>
+}
+

--- a/wear/src/main/java/org/tasks/data/local/TaskDao.kt
+++ b/wear/src/main/java/org/tasks/data/local/TaskDao.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.Flow
  * Provides methods for accessing the tasks table.
  */
 @Dao
+@Suppress("TooManyFunctions", "LongParameterList")
 interface TaskDao {
 
     /**

--- a/wear/src/main/java/org/tasks/data/local/TaskEntity.kt
+++ b/wear/src/main/java/org/tasks/data/local/TaskEntity.kt
@@ -1,0 +1,60 @@
+/**
+ * TaskEntity.kt — Room entity for the `tasks` table on Wear OS.
+ *
+ * Each row is a local copy of a task. The phone app is the ultimate
+ * source of truth; this table enables full offline operation on the
+ * watch.
+ *
+ * ## Per-field conflict resolution
+ * [titleUpdatedAt], [notesUpdatedAt] and [completedUpdatedAt] track
+ * the last-write timestamp per field. When an incoming update arrives
+ * from the phone, [SyncRepository] compares timestamps and keeps
+ * whichever value was written more recently ("last writer wins").
+ *
+ * ## Phone ID mapping
+ * [phoneTaskId] stores the phone's numeric task PK. This prevents
+ * duplicate creation when the same task arrives in both a snapshot
+ * and an incremental update.
+ */
+package org.tasks.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room Entity representing a task in the local Wear database.
+ * This entity maps to the "tasks" table.
+ *
+ * Sync-related fields:
+ * - dirty: true if this task has local changes not yet synced to phone
+ * - deleted: tombstone flag for soft-delete (needed for sync)
+ * - titleUpdatedAt: timestamp of last title change (for per-field conflict resolution)
+ * - notesUpdatedAt: timestamp of last notes change (for per-field conflict resolution)
+ * - completedUpdatedAt: timestamp of last completed change (for per-field conflict resolution)
+ * - syncedAt: timestamp of last successful sync with phone
+ */
+@Entity(tableName = "tasks")
+data class TaskEntity(
+    @PrimaryKey
+    val id: String,
+    val title: String,
+    val notes: String? = null,
+    val updatedAt: Long = System.currentTimeMillis(),
+    val deleted: Boolean = false,
+    val completed: Boolean = false,
+    val priority: Int = 0,
+    val timestamp: String? = null,
+    val repeating: Boolean = false,
+    // Date/time and notification fields
+    val dueDate: Long? = null,  // Due date timestamp (null = no due date)
+    val dueTime: Long? = null,  // Due time timestamp (null = no specific time)
+    val reminder: Boolean = false,  // Whether to send a reminder notification
+    val reminderTime: Long? = null,  // When to send reminder (null = at due date/time)
+    // Sync-related fields
+    val dirty: Boolean = false,  // True if local changes not yet synced
+    val titleUpdatedAt: Long = System.currentTimeMillis(),  // Per-field timestamp for conflict resolution
+    val notesUpdatedAt: Long = System.currentTimeMillis(),  // Per-field timestamp for conflict resolution
+    val completedUpdatedAt: Long = System.currentTimeMillis(),  // Per-field timestamp for conflict resolution
+    val syncedAt: Long = 0L,  // Last successful sync timestamp
+    val phoneTaskId: Long? = null,  // Original phone task ID for mapping
+)

--- a/wear/src/main/java/org/tasks/data/local/TaskRepository.kt
+++ b/wear/src/main/java/org/tasks/data/local/TaskRepository.kt
@@ -1,0 +1,258 @@
+/**
+ * TaskRepository.kt — Single point of access for task CRUD on Wear OS.
+ *
+ * ## Role in the architecture
+ * ```
+ * UI (ViewModel)
+ *       │
+ *       ▼
+ *  TaskRepository  ──▶  SyncRepository  ──▶  OutboxOpDao  (queue for phone)
+ *       │                    │
+ *       ▼                    ▼
+ *    TaskDao             WearDatabase
+ * ```
+ *
+ * Every mutating method (save, toggle complete, delete) writes the change
+ * **atomically** via [SyncRepository] so that a matching outbox operation
+ * is always created inside the same Room transaction.
+ *
+ * Read methods return [TaskLite] (the UI model), converting from
+ * [TaskEntity] via the private `toTaskLite()` extension.
+ *
+ * Also integrates with [WearNotificationManager] to schedule / cancel
+ * reminder alarms whenever a task is saved or completed.
+ *
+ * ## Singleton
+ * Accessed via [TaskRepository.getInstance].
+ */
+package org.tasks.data.local
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.tasks.data.sync.SyncRepository
+import org.tasks.notifications.WearNotificationManager
+import org.tasks.presentation.model.TaskLite
+import java.util.UUID
+
+/**
+ * Repository that provides access to task data.
+ * Abstracts the data source (Room) from the UI layer.
+ * Operations that modify data use SyncRepository to queue sync operations.
+ */
+class TaskRepository(private val context: Context) {
+
+    private val database = WearDatabase.getInstance(context)
+    private val taskDao = database.taskDao()
+    private val syncRepository = SyncRepository.getInstance(context)
+    private val notificationManager = WearNotificationManager.getInstance(context)
+
+    /**
+     * Get all tasks as a Flow of TaskLite list.
+     * The Flow will emit new values when the database changes.
+     */
+    fun getTasks(): Flow<List<TaskLite>> {
+        return taskDao.getTasks().map { entities ->
+            entities.map { it.toTaskLite() }
+        }
+    }
+
+    /**
+     * Get all tasks once (non-reactive).
+     */
+    suspend fun getTasksOnce(): List<TaskLite> {
+        return taskDao.getTasksOnce().map { it.toTaskLite() }
+    }
+
+    /**
+     * Get a single task by ID.
+     */
+    suspend fun getTask(id: String): TaskLite? {
+        return taskDao.getTask(id)?.toTaskLite()
+    }
+
+    /**
+     * Get a single task by Long ID (for backward compatibility).
+     */
+    suspend fun getTask(id: Long): TaskLite? {
+        return getTask(id.toString())
+    }
+
+    /**
+     * Get a task as Flow for reactive updates.
+     */
+    fun getTaskFlow(id: String): Flow<TaskLite?> {
+        return taskDao.getTaskFlow(id).map { it?.toTaskLite() }
+    }
+
+    /**
+     * Save a task (create or update) with sync support.
+     * If id is null, creates a new task with generated ID.
+     * Returns the ID of the saved task.
+     */
+    suspend fun saveTask(
+        id: String?,
+        title: String,
+        notes: String?,
+        dueDate: Long? = null,
+        dueTime: Long? = null,
+        reminder: Boolean = false,
+        reminderTime: Long? = null,
+    ): String {
+        val taskId = id ?: UUID.randomUUID().toString()
+        val existingTask = if (id != null) taskDao.getTask(id) else null
+
+        if (existingTask != null) {
+            // Update existing task - use sync repository to queue the operation
+            syncRepository.updateTitleAndNotes(taskId, title, notes)
+            // Update due date/time and reminder separately if they changed
+            if (dueDate != existingTask.dueDate || dueTime != existingTask.dueTime ||
+                reminder != existingTask.reminder || reminderTime != existingTask.reminderTime) {
+                syncRepository.updateDueDate(taskId, dueDate, dueTime, reminder, reminderTime)
+            }
+        } else {
+            // Create new task - use sync repository to queue the operation
+            val timestamp = System.currentTimeMillis()
+            val newTask = TaskEntity(
+                id = taskId,
+                title = title,
+                notes = notes,
+                updatedAt = timestamp,
+                titleUpdatedAt = timestamp,
+                notesUpdatedAt = timestamp,
+                completedUpdatedAt = timestamp,
+                deleted = false,
+                completed = false,
+                priority = 0,
+                dirty = true,
+                dueDate = dueDate,
+                dueTime = dueTime,
+                reminder = reminder,
+                reminderTime = reminderTime,
+            )
+            syncRepository.createTask(newTask)
+        }
+
+        // Schedule or cancel reminder notification
+        val savedTask = taskDao.getTask(taskId)
+        if (savedTask != null) {
+            notificationManager.scheduleReminder(savedTask)
+        }
+
+        return taskId
+    }
+
+    /**
+     * Save a task with Long ID (for backward compatibility).
+     */
+    suspend fun saveTask(id: Long?, title: String, notes: String): String {
+        return saveTask(id?.toString(), title, notes)
+    }
+
+    /**
+     * Toggle task completion status with sync support.
+     */
+    suspend fun toggleComplete(id: String, completed: Boolean) {
+        syncRepository.setCompleted(id, completed)
+        if (completed) {
+            notificationManager.cancelReminder(id)
+        } else {
+            // Re-schedule reminder if task is un-completed and has a reminder
+            val task = taskDao.getTask(id)
+            if (task != null) {
+                notificationManager.scheduleReminder(task)
+            }
+        }
+    }
+
+    /**
+     * Toggle task completion status with Long ID.
+     */
+    suspend fun toggleComplete(id: Long, completed: Boolean) {
+        toggleComplete(id.toString(), completed)
+    }
+
+    /**
+     * Soft delete a task with sync support.
+     */
+    suspend fun deleteTask(id: String) {
+        notificationManager.cancelReminder(id)
+        syncRepository.deleteTask(id)
+    }
+
+    /**
+     * Soft delete a task with Long ID.
+     */
+    suspend fun deleteTask(id: Long) {
+        deleteTask(id.toString())
+    }
+
+    /**
+     * Previously used to insert sample data for testing/demo purposes.
+     * Now empty - tasks come from sync with phone.
+     */
+    suspend fun insertSampleDataIfEmpty() {
+        // No longer inserting sample data
+        // Tasks are synced from the phone app
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: TaskRepository? = null
+
+        /**
+         * Get the singleton repository instance.
+         */
+        fun getInstance(context: Context): TaskRepository {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: TaskRepository(context).also { INSTANCE = it }
+            }
+        }
+    }
+}
+
+/**
+ * Extension function to convert TaskEntity to TaskLite.
+ */
+private fun TaskEntity.toTaskLite(): TaskLite {
+    return TaskLite(
+        id = this.id.toLongOrNull() ?: this.id.hashCode().toLong(),
+        stringId = this.id, // Store original string ID for unique keys
+        title = this.title,
+        notes = this.notes ?: "",
+        updatedAt = this.updatedAt,
+        timestamp = this.timestamp,
+        completed = this.completed,
+        hidden = false,
+        numSubtasks = 0,
+        collapsed = false,
+        indent = 0,
+        repeating = this.repeating,
+        priority = this.priority,
+        dueDate = this.dueDate,
+        dueTime = this.dueTime,
+        reminder = this.reminder,
+        reminderTime = this.reminderTime,
+    )
+}
+
+/**
+ * Extension function to convert TaskLite to TaskEntity.
+ */
+fun TaskLite.toEntity(): TaskEntity {
+    return TaskEntity(
+        id = this.stringId.ifEmpty { this.id.toString() },
+        title = this.title,
+        notes = this.notes.ifEmpty { null },
+        updatedAt = this.updatedAt,
+        deleted = false,
+        completed = this.completed,
+        priority = this.priority,
+        timestamp = this.timestamp,
+        repeating = this.repeating,
+        dueDate = this.dueDate,
+        dueTime = this.dueTime,
+        reminder = this.reminder,
+        reminderTime = this.reminderTime,
+    )
+}

--- a/wear/src/main/java/org/tasks/data/local/TaskRepository.kt
+++ b/wear/src/main/java/org/tasks/data/local/TaskRepository.kt
@@ -40,6 +40,7 @@ import java.util.UUID
  * Abstracts the data source (Room) from the UI layer.
  * Operations that modify data use SyncRepository to queue sync operations.
  */
+@Suppress("TooManyFunctions", "LongParameterList")
 class TaskRepository(private val context: Context) {
 
     private val database = WearDatabase.getInstance(context)
@@ -106,8 +107,9 @@ class TaskRepository(private val context: Context) {
             // Update existing task - use sync repository to queue the operation
             syncRepository.updateTitleAndNotes(taskId, title, notes)
             // Update due date/time and reminder separately if they changed
-            if (dueDate != existingTask.dueDate || dueTime != existingTask.dueTime ||
-                reminder != existingTask.reminder || reminderTime != existingTask.reminderTime) {
+            val dateChanged = dueDate != existingTask.dueDate || dueTime != existingTask.dueTime
+            val reminderChanged = reminder != existingTask.reminder || reminderTime != existingTask.reminderTime
+            if (dateChanged || reminderChanged) {
                 syncRepository.updateDueDate(taskId, dueDate, dueTime, reminder, reminderTime)
             }
         } else {
@@ -211,9 +213,6 @@ class TaskRepository(private val context: Context) {
     }
 }
 
-/**
- * Extension function to convert TaskEntity to TaskLite.
- */
 private fun TaskEntity.toTaskLite(): TaskLite {
     return TaskLite(
         id = this.id.toLongOrNull() ?: this.id.hashCode().toLong(),

--- a/wear/src/main/java/org/tasks/data/local/WearDatabase.kt
+++ b/wear/src/main/java/org/tasks/data/local/WearDatabase.kt
@@ -1,0 +1,92 @@
+/**
+ * WearDatabase.kt — Room database for the Wear OS app.
+ *
+ * ## Tables
+ * | Table            | Entity               | Purpose                                       |
+ * |------------------|-----------------------|-----------------------------------------------|
+ * | `tasks`          | [TaskEntity]          | Local copy of tasks (synced with phone)        |
+ * | `outbox_ops`     | [OutboxOpEntity]      | Queue of pending watch → phone operations      |
+ * | `processed_ops`  | [ProcessedOpEntity]   | Idempotency guard for phone → watch operations |
+ * | `settings`       | [SettingsEntity]      | Singleton row for user preferences             |
+ *
+ * Uses `fallbackToDestructiveMigration` so a schema bump wipes and
+ * recreates — acceptable because the phone is the source of truth.
+ *
+ * ## Singleton
+ * Accessed via [WearDatabase.getInstance].
+ */
+package org.tasks.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+
+/**
+ * Type converters for Room database.
+ */
+class Converters {
+    @TypeConverter
+    fun fromOutboxOpType(value: OutboxOpType): String = value.name
+
+    @TypeConverter
+    fun toOutboxOpType(value: String): OutboxOpType = OutboxOpType.valueOf(value)
+
+    @TypeConverter
+    fun fromOutboxOpState(value: OutboxOpState): String = value.name
+
+    @TypeConverter
+    fun toOutboxOpState(value: String): OutboxOpState = OutboxOpState.valueOf(value)
+}
+
+/**
+ * Room Database for the Wear app.
+ * Contains local task storage, settings, and sync-related tables.
+ */
+@Database(
+    entities = [
+        TaskEntity::class,
+        OutboxOpEntity::class,
+        ProcessedOpEntity::class,
+        SettingsEntity::class,
+    ],
+    version = 4,
+    exportSchema = true
+)
+@TypeConverters(Converters::class)
+abstract class WearDatabase : RoomDatabase() {
+
+    abstract fun taskDao(): TaskDao
+    abstract fun outboxOpDao(): OutboxOpDao
+    abstract fun processedOpDao(): ProcessedOpDao
+    abstract fun settingsDao(): SettingsDao
+
+    companion object {
+        private const val DATABASE_NAME = "wear.db"
+
+        @Volatile
+        private var INSTANCE: WearDatabase? = null
+
+        /**
+         * Get the singleton database instance.
+         * Creates the database if it doesn't exist.
+         */
+        fun getInstance(context: Context): WearDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: buildDatabase(context).also { INSTANCE = it }
+            }
+        }
+
+        private fun buildDatabase(context: Context): WearDatabase {
+            return Room.databaseBuilder(
+                context.applicationContext,
+                WearDatabase::class.java,
+                DATABASE_NAME
+            )
+                .fallbackToDestructiveMigration(dropAllTables = true)
+                .build()
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/data/sync/DataLayerSyncManager.kt
+++ b/wear/src/main/java/org/tasks/data/sync/DataLayerSyncManager.kt
@@ -1,0 +1,460 @@
+/**
+ * DataLayerSyncManager.kt — Bridges the Wearable Data Layer API with Room.
+ *
+ * ## Responsibilities
+ * 1. **Outbound** ([processPendingOps]):
+ *    Reads pending [OutboxOpEntity] rows, serialises them into
+ *    [PutDataMapRequest] items at `/outbox/watch/{opId}` and pushes
+ *    them via [DataClient].
+ *
+ * 2. **Inbound** ([onDataChanged]):
+ *    Listens for [DataEvent]s.  Routes each event by path prefix:
+ *    - `/ack/watch/{id}`    → marks the outbox op as acknowledged.
+ *    - `/outbox/phone/{id}` → calls [SyncRepository.applyIncomingTask]
+ *                              and sends an ack back.
+ *    - `/snapshot/tasks`    → full snapshot merge.
+ *    - `/tasks/{id}`        → single-task incremental update.
+ *
+ * 3. **State** ([syncState]):
+ *    Exposes a [SyncState] flow (`IDLE`, `SYNCING`, `ERROR`)
+ *    consumed by the settings screen's connection-status chip.
+ *
+ * ## Threading
+ * All work runs on a dedicated [CoroutineScope] backed by
+ * `Dispatchers.IO + SupervisorJob`.
+ *
+ * ## Singleton
+ * Accessed via [DataLayerSyncManager.getInstance].
+ */
+
+package org.tasks.data.sync
+
+import android.content.Context
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.json.JSONObject
+import org.tasks.data.local.OutboxOpEntity
+import org.tasks.data.local.OutboxOpType
+import timber.log.Timber
+
+/**
+ * Manager for syncing data between Watch and Phone via Wearable Data Layer API.
+ *
+ * Uses DataClient (DataItem) for persistent sync:
+ * - DataItems are automatically synced when connectivity is available
+ * - System handles retry and delivery
+ * - Supports urgent (immediate) and batched delivery
+ */
+class DataLayerSyncManager(
+    private val context: Context,
+    private val syncRepository: SyncRepository,
+) : DataClient.OnDataChangedListener {
+
+    private val dataClient: DataClient = Wearable.getDataClient(context)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _syncState = MutableStateFlow(SyncState.IDLE)
+    val syncState: StateFlow<SyncState> = _syncState
+
+    /**
+     * Start listening for data changes from phone.
+     */
+    fun startListening() {
+        dataClient.addListener(this)
+        Timber.d("Started listening for data changes")
+    }
+
+    /**
+     * Stop listening for data changes.
+     */
+    fun stopListening() {
+        dataClient.removeListener(this)
+        Timber.d("Stopped listening for data changes")
+    }
+
+    /**
+     * Process pending outbox operations and send them to phone.
+     */
+    suspend fun processPendingOps() {
+        val pendingOps = syncRepository.getPendingOpsOnce()
+        if (pendingOps.isEmpty()) {
+            Timber.d("No pending operations to sync")
+            return
+        }
+
+        _syncState.value = SyncState.SYNCING
+        Timber.d("Processing ${pendingOps.size} pending operations")
+
+        for (op in pendingOps) {
+            try {
+                sendOperation(op)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to send operation ${op.opId}")
+                syncRepository.markFailed(op.opId, e.message)
+            }
+        }
+
+        _syncState.value = SyncState.IDLE
+    }
+
+    /**
+     * Send a single operation to phone via DataItem.
+     */
+    private suspend fun sendOperation(op: OutboxOpEntity) {
+        syncRepository.markSending(op.opId)
+
+        val path = SyncPaths.watchOutboxPath(op.opId)
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putLong(DataMapKeys.KEY_OP_ID, op.opId)
+            dataMap.putString(DataMapKeys.KEY_TASK_ID, op.taskId)
+            dataMap.putString(DataMapKeys.KEY_OP_TYPE, op.type.name)
+            dataMap.putString("payload", op.payload)
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, op.createdAt)
+
+            // Parse payload JSON and add fields to DataMap for easier processing on phone
+            try {
+                val payload = JSONObject(op.payload)
+                when (op.type) {
+                    OutboxOpType.CREATE, OutboxOpType.UPDATE -> {
+                        payload.optString(DataMapKeys.KEY_TITLE)?.let {
+                            dataMap.putString(DataMapKeys.KEY_TITLE, it)
+                        }
+                        payload.optLong(DataMapKeys.KEY_TITLE_UPDATED_AT).takeIf { it > 0 }?.let {
+                            dataMap.putLong(DataMapKeys.KEY_TITLE_UPDATED_AT, it)
+                        }
+                        payload.optString(DataMapKeys.KEY_NOTES)?.let {
+                            dataMap.putString(DataMapKeys.KEY_NOTES, it)
+                        }
+                        payload.optLong(DataMapKeys.KEY_NOTES_UPDATED_AT).takeIf { it > 0 }?.let {
+                            dataMap.putLong(DataMapKeys.KEY_NOTES_UPDATED_AT, it)
+                        }
+                        if (payload.has(DataMapKeys.KEY_COMPLETED)) {
+                            dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
+                        }
+                        payload.optLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT).takeIf { it > 0 }?.let {
+                            dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, it)
+                        }
+                        if (payload.has(DataMapKeys.KEY_PRIORITY)) {
+                            dataMap.putInt(DataMapKeys.KEY_PRIORITY, payload.getInt(DataMapKeys.KEY_PRIORITY))
+                        }
+                        payload.optLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }?.let {
+                            dataMap.putLong(DataMapKeys.KEY_DUE_DATE, it)
+                        }
+                    }
+                    OutboxOpType.COMPLETE -> {
+                        dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
+                        dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, payload.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT))
+                    }
+                    OutboxOpType.DELETE -> {
+                        dataMap.putBoolean(DataMapKeys.KEY_DELETED, true)
+                        dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, payload.getLong(DataMapKeys.KEY_TIMESTAMP))
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to parse payload for operation ${op.opId}")
+            }
+        }
+
+        // Use urgent for user-initiated actions (create, update, delete)
+        // Non-urgent for batch syncs
+        val shouldBeUrgent = op.type in listOf(OutboxOpType.CREATE, OutboxOpType.UPDATE, OutboxOpType.DELETE, OutboxOpType.COMPLETE)
+        if (shouldBeUrgent) {
+            request.setUrgent()
+        }
+
+        val putDataRequest = request.asPutDataRequest()
+        dataClient.putDataItem(putDataRequest).await()
+        syncRepository.markSent(op.opId)
+
+        Timber.d("Sent operation ${op.opId} (${op.type}) for task ${op.taskId}")
+    }
+
+    /**
+     * Handle data changes from phone.
+     * NOTE: DataEventBuffer is closed after onDataChanged returns,
+     * so we must extract data BEFORE launching coroutines.
+     */
+    override fun onDataChanged(events: DataEventBuffer) {
+        Timber.d("Received ${events.count} data events")
+
+        // Extract all data synchronously BEFORE the buffer is closed
+        val dataEvents = mutableListOf<Pair<Int, DataEvent>>()
+        for (event in events) {
+            // Freeze/copy the event data to avoid buffer-closed errors
+            dataEvents.add(Pair(event.type, event.freeze()))
+        }
+
+        // Now we can safely process asynchronously
+        scope.launch {
+            for ((type, frozenEvent) in dataEvents) {
+                try {
+                    when (type) {
+                        DataEvent.TYPE_CHANGED -> handleDataChanged(frozenEvent)
+                        DataEvent.TYPE_DELETED -> handleDataDeleted(frozenEvent)
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Error processing data event")
+                }
+            }
+        }
+    }
+
+    private suspend fun handleDataChanged(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        Timber.d("Data changed: $path")
+
+        when {
+            // Acknowledgment from phone for our operation
+            path.startsWith(SyncPaths.WATCH_ACK_PREFIX) -> {
+                handleWatchAck(event)
+            }
+            // Task update from phone
+            path.startsWith(SyncPaths.PHONE_OUTBOX_PREFIX) -> {
+                handlePhoneOperation(event)
+            }
+            // Single task update from phone
+            path.startsWith(SyncPaths.TASK_UPDATE_PREFIX) -> {
+                handleTaskUpdate(event)
+            }
+            // Full snapshot from phone
+            path == SyncPaths.TASKS_SNAPSHOT -> {
+                handleSnapshot(event)
+            }
+        }
+    }
+
+    /**
+     * Handle acknowledgment from phone for our operation.
+     */
+    private suspend fun handleWatchAck(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        val opId = SyncPaths.extractWatchOpId(path) ?: return
+
+        val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+        val dataMap = dataMapItem.dataMap
+        val success = dataMap.getBoolean(DataMapKeys.KEY_SUCCESS, true)
+
+        if (success) {
+            syncRepository.markAcked(opId)
+            Timber.d("Received ack for operation $opId")
+
+            // Delete the DataItem now that it's acked
+            try {
+                dataClient.deleteDataItems(event.dataItem.uri).await()
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to delete ack DataItem")
+            }
+        } else {
+            val error = dataMap.getString(DataMapKeys.KEY_ERROR)
+            syncRepository.markFailed(opId, error)
+            Timber.w("Operation $opId failed on phone: $error")
+        }
+    }
+
+    /**
+     * Handle operation from phone (create, update, delete).
+     */
+    private suspend fun handlePhoneOperation(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        val opId = SyncPaths.extractPhoneOpId(path) ?: return
+
+        // Check idempotency
+        if (syncRepository.isOpProcessed(opId)) {
+            Timber.d("Operation $opId already processed, sending ack")
+            sendPhoneAck(opId, true)
+            return
+        }
+
+        val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+        val dataMap = dataMapItem.dataMap
+
+        val taskId = dataMap.getString(DataMapKeys.KEY_TASK_ID) ?: return
+        val opType = dataMap.getString(DataMapKeys.KEY_OP_TYPE)
+
+        try {
+            val result = syncRepository.applyIncomingTask(
+                opId = opId,
+                taskId = taskId,
+                title = dataMap.getString(DataMapKeys.KEY_TITLE),
+                titleUpdatedAt = dataMap.getLong(DataMapKeys.KEY_TITLE_UPDATED_AT).takeIf { it > 0 },
+                notes = dataMap.getString(DataMapKeys.KEY_NOTES),
+                notesUpdatedAt = dataMap.getLong(DataMapKeys.KEY_NOTES_UPDATED_AT).takeIf { it > 0 },
+                completed = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED)) dataMap.getBoolean(DataMapKeys.KEY_COMPLETED) else null,
+                completedUpdatedAt = dataMap.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT).takeIf { it > 0 },
+                deleted = if (dataMap.containsKey(DataMapKeys.KEY_DELETED)) dataMap.getBoolean(DataMapKeys.KEY_DELETED) else null,
+                priority = if (dataMap.containsKey(DataMapKeys.KEY_PRIORITY)) dataMap.getInt(DataMapKeys.KEY_PRIORITY) else null,
+                dueDate = dataMap.getLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 },
+            )
+
+            sendPhoneAck(opId, result)
+            Timber.d("Applied phone operation $opId ($opType) for task $taskId")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to apply phone operation $opId")
+            sendPhoneAck(opId, false, e.message)
+        }
+    }
+
+    /**
+     * Handle single task update from phone.
+     */
+    private suspend fun handleTaskUpdate(event: DataEvent) {
+        val path = event.dataItem.uri.path ?: return
+        val taskId = SyncPaths.extractTaskId(path) ?: return
+
+        val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+        val dataMap = dataMapItem.dataMap
+
+        val opId = "task_update_${taskId}_${dataMap.getLong(DataMapKeys.KEY_TIMESTAMP)}"
+
+        // Read phoneId explicitly if provided, otherwise try to parse from taskId
+        val phoneId = dataMap.getLong("phoneId").takeIf { it > 0 } ?: taskId.toLongOrNull()
+
+        try {
+            syncRepository.applyIncomingTaskWithPhoneId(
+                opId = opId,
+                taskId = taskId,
+                phoneId = phoneId,
+                title = dataMap.getString(DataMapKeys.KEY_TITLE),
+                titleUpdatedAt = dataMap.getLong(DataMapKeys.KEY_TITLE_UPDATED_AT).takeIf { it > 0 },
+                notes = dataMap.getString(DataMapKeys.KEY_NOTES),
+                notesUpdatedAt = dataMap.getLong(DataMapKeys.KEY_NOTES_UPDATED_AT).takeIf { it > 0 },
+                completed = if (dataMap.containsKey(DataMapKeys.KEY_COMPLETED)) dataMap.getBoolean(DataMapKeys.KEY_COMPLETED) else null,
+                completedUpdatedAt = dataMap.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT).takeIf { it > 0 },
+                deleted = if (dataMap.containsKey(DataMapKeys.KEY_DELETED)) dataMap.getBoolean(DataMapKeys.KEY_DELETED) else null,
+                priority = if (dataMap.containsKey(DataMapKeys.KEY_PRIORITY)) dataMap.getInt(DataMapKeys.KEY_PRIORITY) else null,
+                dueDate = dataMap.getLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 },
+            )
+            Timber.d("Applied task update for task $taskId (phoneId: $phoneId)")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to apply task update for $taskId")
+        }
+    }
+
+    /**
+     * Handle full snapshot from phone.
+     */
+    private suspend fun handleSnapshot(event: DataEvent) {
+        val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+        val dataMap = dataMapItem.dataMap
+
+        val taskCount = dataMap.getInt(DataMapKeys.KEY_TASK_COUNT, 0)
+        val snapshotTimestamp = dataMap.getLong(DataMapKeys.KEY_SNAPSHOT_TIMESTAMP, 0)
+
+        Timber.d("Received snapshot with $taskCount tasks at $snapshotTimestamp")
+
+        // Tasks are serialized as a list of DataMaps
+        // This is a simplified implementation - in practice you might use Asset for large data
+        val tasksData = mutableListOf<TaskSnapshotData>()
+
+        for (i in 0 until taskCount) {
+            val prefix = "task_$i"
+            val taskId = dataMap.getString("${prefix}_id") ?: continue
+
+            tasksData.add(TaskSnapshotData(
+                taskId = taskId,
+                title = dataMap.getString("${prefix}_title"),
+                titleUpdatedAt = dataMap.getLong("${prefix}_titleUpdatedAt").takeIf { it > 0 },
+                notes = dataMap.getString("${prefix}_notes"),
+                notesUpdatedAt = dataMap.getLong("${prefix}_notesUpdatedAt").takeIf { it > 0 },
+                completed = if (dataMap.containsKey("${prefix}_completed")) dataMap.getBoolean("${prefix}_completed") else null,
+                completedUpdatedAt = dataMap.getLong("${prefix}_completedUpdatedAt").takeIf { it > 0 },
+                deleted = if (dataMap.containsKey("${prefix}_deleted")) dataMap.getBoolean("${prefix}_deleted") else null,
+                priority = if (dataMap.containsKey("${prefix}_priority")) dataMap.getInt("${prefix}_priority") else null,
+                phoneId = dataMap.getLong("${prefix}_phoneId").takeIf { it > 0 },
+                dueDate = dataMap.getLong("${prefix}_dueDate").takeIf { it > 0 },
+            ))
+        }
+
+        syncRepository.applySnapshot(tasksData)
+    }
+
+    private fun handleDataDeleted(event: DataEvent) {
+        val path = event.dataItem.uri.path
+        Timber.d("Data deleted: $path")
+        // Usually we don't need to do anything when DataItems are deleted
+        // since deletion typically happens after processing
+    }
+
+    /**
+     * Send acknowledgment to phone for their operation.
+     */
+    private suspend fun sendPhoneAck(opId: String, success: Boolean, error: String? = null) {
+        val path = SyncPaths.phoneAckPath(opId)
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putString(DataMapKeys.KEY_OP_ID, opId)
+            dataMap.putBoolean(DataMapKeys.KEY_SUCCESS, success)
+            if (error != null) {
+                dataMap.putString(DataMapKeys.KEY_ERROR, error)
+            }
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, System.currentTimeMillis())
+        }
+
+        // Acks should be urgent
+        request.setUrgent()
+
+        val putDataRequest = request.asPutDataRequest()
+        try {
+            dataClient.putDataItem(putDataRequest).await()
+            Timber.d("Sent ack for phone operation $opId (success=$success)")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to send ack for phone operation $opId")
+        }
+    }
+
+    /**
+     * Request a full sync from phone.
+     * Uses a unique nonce to ensure the DataItem is considered "changed" each time.
+     */
+    suspend fun requestSync() {
+        val path = "/sync/request"
+        val timestamp = System.currentTimeMillis()
+        val request = PutDataMapRequest.create(path).apply {
+            dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, timestamp)
+            // Add a unique nonce to ensure data is always different
+            dataMap.putLong("nonce", System.nanoTime())
+            setUrgent()
+        }
+
+        val putDataRequest = request.asPutDataRequest()
+        try {
+            dataClient.putDataItem(putDataRequest).await()
+            Timber.d("Requested sync from phone (timestamp=$timestamp)")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to request sync")
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: DataLayerSyncManager? = null
+
+        fun getInstance(context: Context): DataLayerSyncManager {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: DataLayerSyncManager(
+                    context,
+                    SyncRepository.getInstance(context)
+                ).also { INSTANCE = it }
+            }
+        }
+    }
+}
+
+/**
+ * Sync state enum.
+ */
+enum class SyncState {
+    IDLE,
+    SYNCING,
+    ERROR,
+}

--- a/wear/src/main/java/org/tasks/data/sync/DataLayerSyncManager.kt
+++ b/wear/src/main/java/org/tasks/data/sync/DataLayerSyncManager.kt
@@ -56,6 +56,7 @@ import timber.log.Timber
  * - System handles retry and delivery
  * - Supports urgent (immediate) and batched delivery
  */
+@Suppress("TooManyFunctions", "TooGenericExceptionCaught")
 class DataLayerSyncManager(
     private val context: Context,
     private val syncRepository: SyncRepository,
@@ -108,9 +109,50 @@ class DataLayerSyncManager(
         _syncState.value = SyncState.IDLE
     }
 
-    /**
-     * Send a single operation to phone via DataItem.
-     */
+    private fun populateDataMapFromPayload(dataMap: com.google.android.gms.wearable.DataMap, opType: OutboxOpType, payloadJson: String) {
+        try {
+            val payload = JSONObject(payloadJson)
+            when (opType) {
+                OutboxOpType.CREATE, OutboxOpType.UPDATE -> {
+                    payload.optString(DataMapKeys.KEY_TITLE)?.let {
+                        dataMap.putString(DataMapKeys.KEY_TITLE, it)
+                    }
+                    payload.optLong(DataMapKeys.KEY_TITLE_UPDATED_AT).takeIf { it > 0 }?.let {
+                        dataMap.putLong(DataMapKeys.KEY_TITLE_UPDATED_AT, it)
+                    }
+                    payload.optString(DataMapKeys.KEY_NOTES)?.let {
+                        dataMap.putString(DataMapKeys.KEY_NOTES, it)
+                    }
+                    payload.optLong(DataMapKeys.KEY_NOTES_UPDATED_AT).takeIf { it > 0 }?.let {
+                        dataMap.putLong(DataMapKeys.KEY_NOTES_UPDATED_AT, it)
+                    }
+                    if (payload.has(DataMapKeys.KEY_COMPLETED)) {
+                        dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
+                    }
+                    payload.optLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT).takeIf { it > 0 }?.let {
+                        dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, it)
+                    }
+                    if (payload.has(DataMapKeys.KEY_PRIORITY)) {
+                        dataMap.putInt(DataMapKeys.KEY_PRIORITY, payload.getInt(DataMapKeys.KEY_PRIORITY))
+                    }
+                    payload.optLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }?.let {
+                        dataMap.putLong(DataMapKeys.KEY_DUE_DATE, it)
+                    }
+                }
+                OutboxOpType.COMPLETE -> {
+                    dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
+                    dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, payload.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT))
+                }
+                OutboxOpType.DELETE -> {
+                    dataMap.putBoolean(DataMapKeys.KEY_DELETED, true)
+                    dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, payload.getLong(DataMapKeys.KEY_TIMESTAMP))
+                }
+            }
+        } catch (e: org.json.JSONException) {
+            Timber.w(e, "Failed to parse payload JSON")
+        }
+    }
+
     private suspend fun sendOperation(op: OutboxOpEntity) {
         syncRepository.markSending(op.opId)
 
@@ -123,47 +165,7 @@ class DataLayerSyncManager(
             dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, op.createdAt)
 
             // Parse payload JSON and add fields to DataMap for easier processing on phone
-            try {
-                val payload = JSONObject(op.payload)
-                when (op.type) {
-                    OutboxOpType.CREATE, OutboxOpType.UPDATE -> {
-                        payload.optString(DataMapKeys.KEY_TITLE)?.let {
-                            dataMap.putString(DataMapKeys.KEY_TITLE, it)
-                        }
-                        payload.optLong(DataMapKeys.KEY_TITLE_UPDATED_AT).takeIf { it > 0 }?.let {
-                            dataMap.putLong(DataMapKeys.KEY_TITLE_UPDATED_AT, it)
-                        }
-                        payload.optString(DataMapKeys.KEY_NOTES)?.let {
-                            dataMap.putString(DataMapKeys.KEY_NOTES, it)
-                        }
-                        payload.optLong(DataMapKeys.KEY_NOTES_UPDATED_AT).takeIf { it > 0 }?.let {
-                            dataMap.putLong(DataMapKeys.KEY_NOTES_UPDATED_AT, it)
-                        }
-                        if (payload.has(DataMapKeys.KEY_COMPLETED)) {
-                            dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
-                        }
-                        payload.optLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT).takeIf { it > 0 }?.let {
-                            dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, it)
-                        }
-                        if (payload.has(DataMapKeys.KEY_PRIORITY)) {
-                            dataMap.putInt(DataMapKeys.KEY_PRIORITY, payload.getInt(DataMapKeys.KEY_PRIORITY))
-                        }
-                        payload.optLong(DataMapKeys.KEY_DUE_DATE).takeIf { it > 0 }?.let {
-                            dataMap.putLong(DataMapKeys.KEY_DUE_DATE, it)
-                        }
-                    }
-                    OutboxOpType.COMPLETE -> {
-                        dataMap.putBoolean(DataMapKeys.KEY_COMPLETED, payload.getBoolean(DataMapKeys.KEY_COMPLETED))
-                        dataMap.putLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT, payload.getLong(DataMapKeys.KEY_COMPLETED_UPDATED_AT))
-                    }
-                    OutboxOpType.DELETE -> {
-                        dataMap.putBoolean(DataMapKeys.KEY_DELETED, true)
-                        dataMap.putLong(DataMapKeys.KEY_TIMESTAMP, payload.getLong(DataMapKeys.KEY_TIMESTAMP))
-                    }
-                }
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to parse payload for operation ${op.opId}")
-            }
+            populateDataMapFromPayload(dataMap, op.type, op.payload)
         }
 
         // Use urgent for user-initiated actions (create, update, delete)
@@ -234,9 +236,6 @@ class DataLayerSyncManager(
         }
     }
 
-    /**
-     * Handle acknowledgment from phone for our operation.
-     */
     private suspend fun handleWatchAck(event: DataEvent) {
         val path = event.dataItem.uri.path ?: return
         val opId = SyncPaths.extractWatchOpId(path) ?: return
@@ -262,9 +261,6 @@ class DataLayerSyncManager(
         }
     }
 
-    /**
-     * Handle operation from phone (create, update, delete).
-     */
     private suspend fun handlePhoneOperation(event: DataEvent) {
         val path = event.dataItem.uri.path ?: return
         val opId = SyncPaths.extractPhoneOpId(path) ?: return
@@ -305,9 +301,6 @@ class DataLayerSyncManager(
         }
     }
 
-    /**
-     * Handle single task update from phone.
-     */
     private suspend fun handleTaskUpdate(event: DataEvent) {
         val path = event.dataItem.uri.path ?: return
         val taskId = SyncPaths.extractTaskId(path) ?: return
@@ -341,9 +334,6 @@ class DataLayerSyncManager(
         }
     }
 
-    /**
-     * Handle full snapshot from phone.
-     */
     private suspend fun handleSnapshot(event: DataEvent) {
         val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
         val dataMap = dataMapItem.dataMap
@@ -386,9 +376,6 @@ class DataLayerSyncManager(
         // since deletion typically happens after processing
     }
 
-    /**
-     * Send acknowledgment to phone for their operation.
-     */
     private suspend fun sendPhoneAck(opId: String, success: Boolean, error: String? = null) {
         val path = SyncPaths.phoneAckPath(opId)
         val request = PutDataMapRequest.create(path).apply {

--- a/wear/src/main/java/org/tasks/data/sync/SyncProtocol.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncProtocol.kt
@@ -1,0 +1,122 @@
+/**
+ * SyncProtocol.kt — Constants that define the Data Layer sync protocol.
+ *
+ * ## Path conventions
+ * | Path pattern                | Direction      | Description                         |
+ * |-----------------------------|----------------|-------------------------------------|
+ * | `/outbox/watch/{opId}`      | Watch → Phone  | Queued operation from watch          |
+ * | `/ack/watch/{opId}`         | Phone → Watch  | Ack for a watch operation            |
+ * | `/outbox/phone/{opId}`      | Phone → Watch  | Queued operation from phone          |
+ * | `/ack/phone/{opId}`         | Watch → Phone  | Ack for a phone operation            |
+ * | `/snapshot/tasks`           | Phone → Watch  | Full task list snapshot              |
+ * | `/tasks/{taskId}`           | Phone → Watch  | Single-task incremental update       |
+ *
+ * ## Key objects
+ * - [SyncPaths] — path builders and extractors.
+ * - [DataMapKeys] — string keys used inside `DataMap` items.
+ * - [OpTypes] — operation type constants (`CREATE`, `UPDATE`, etc.).
+ */
+package org.tasks.data.sync
+
+/**
+ * Constants for Data Layer sync protocol between Watch and Phone.
+ *
+ * Path structure:
+ * - /outbox/watch/{opId}  -> Operations from watch to phone
+ * - /ack/watch/{opId}     -> Acknowledgments from phone to watch
+ * - /outbox/phone/{opId}  -> Operations from phone to watch
+ * - /ack/phone/{opId}     -> Acknowledgments from watch to phone
+ * - /snapshot/tasks       -> Full task snapshot from phone to watch
+ */
+object SyncPaths {
+    // Watch -> Phone operations
+    const val WATCH_OUTBOX_PREFIX = "/outbox/watch/"
+    fun watchOutboxPath(opId: Long) = "$WATCH_OUTBOX_PREFIX$opId"
+
+    // Phone -> Watch acknowledgments
+    const val WATCH_ACK_PREFIX = "/ack/watch/"
+    fun watchAckPath(opId: Long) = "$WATCH_ACK_PREFIX$opId"
+
+    // Phone -> Watch operations
+    const val PHONE_OUTBOX_PREFIX = "/outbox/phone/"
+    fun phoneOutboxPath(opId: String) = "$PHONE_OUTBOX_PREFIX$opId"
+
+    // Watch -> Phone acknowledgments
+    const val PHONE_ACK_PREFIX = "/ack/phone/"
+    fun phoneAckPath(opId: String) = "$PHONE_ACK_PREFIX$opId"
+
+    // Full snapshot from phone to watch
+    const val TASKS_SNAPSHOT = "/snapshot/tasks"
+
+    // Single task update from phone
+    const val TASK_UPDATE_PREFIX = "/tasks/"
+    fun taskUpdatePath(taskId: String) = "$TASK_UPDATE_PREFIX$taskId"
+
+    // Extract opId from path
+    fun extractWatchOpId(path: String): Long? {
+        return when {
+            path.startsWith(WATCH_OUTBOX_PREFIX) -> path.removePrefix(WATCH_OUTBOX_PREFIX).toLongOrNull()
+            path.startsWith(WATCH_ACK_PREFIX) -> path.removePrefix(WATCH_ACK_PREFIX).toLongOrNull()
+            else -> null
+        }
+    }
+
+    fun extractPhoneOpId(path: String): String? {
+        return when {
+            path.startsWith(PHONE_OUTBOX_PREFIX) -> path.removePrefix(PHONE_OUTBOX_PREFIX).takeIf { it.isNotEmpty() }
+            path.startsWith(PHONE_ACK_PREFIX) -> path.removePrefix(PHONE_ACK_PREFIX).takeIf { it.isNotEmpty() }
+            else -> null
+        }
+    }
+
+    fun extractTaskId(path: String): String? {
+        return if (path.startsWith(TASK_UPDATE_PREFIX)) {
+            path.removePrefix(TASK_UPDATE_PREFIX).takeIf { it.isNotEmpty() }
+        } else null
+    }
+}
+
+/**
+ * Keys for DataMap serialization.
+ */
+object DataMapKeys {
+    // Common keys
+    const val KEY_OP_ID = "opId"
+    const val KEY_TASK_ID = "taskId"
+    const val KEY_OP_TYPE = "opType"
+    const val KEY_TIMESTAMP = "timestamp"
+    const val KEY_URGENT = "urgent"
+
+    // Task field keys
+    const val KEY_TITLE = "title"
+    const val KEY_TITLE_UPDATED_AT = "titleUpdatedAt"
+    const val KEY_NOTES = "notes"
+    const val KEY_NOTES_UPDATED_AT = "notesUpdatedAt"
+    const val KEY_COMPLETED = "completed"
+    const val KEY_COMPLETED_UPDATED_AT = "completedUpdatedAt"
+    const val KEY_DELETED = "deleted"
+    const val KEY_PRIORITY = "priority"
+    const val KEY_DUE_DATE = "dueDate"
+    const val KEY_REPEATING = "repeating"
+
+    // Snapshot keys
+    const val KEY_TASKS = "tasks"
+    const val KEY_SNAPSHOT_TIMESTAMP = "snapshotTimestamp"
+    const val KEY_TASK_COUNT = "taskCount"
+
+    // Ack keys
+    const val KEY_SUCCESS = "success"
+    const val KEY_ERROR = "error"
+}
+
+/**
+ * Operation types for sync.
+ */
+object OpTypes {
+    const val CREATE = "CREATE"
+    const val UPDATE = "UPDATE"
+    const val DELETE = "DELETE"
+    const val COMPLETE = "COMPLETE"
+    const val UPDATE_TITLE = "UPDATE_TITLE"
+    const val UPDATE_NOTES = "UPDATE_NOTES"
+}

--- a/wear/src/main/java/org/tasks/data/sync/SyncProtocol.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncProtocol.kt
@@ -97,6 +97,7 @@ object DataMapKeys {
     const val KEY_DELETED = "deleted"
     const val KEY_PRIORITY = "priority"
     const val KEY_DUE_DATE = "dueDate"
+    const val KEY_MODIFICATION_DATE = "modificationDate"
     const val KEY_REPEATING = "repeating"
 
     // Snapshot keys

--- a/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
@@ -1,0 +1,642 @@
+/**
+ * SyncRepository.kt — Transactional layer for watch ↔ phone sync operations.
+ *
+ * ## Purpose
+ * Every task mutation on the watch must be persisted **and** queued for sync
+ * in the same Room transaction. This class wraps [TaskDao] + [OutboxOpDao]
+ * together with `database.withTransaction { … }` to guarantee consistency.
+ *
+ * ## Watch → Phone (outbox)
+ * - [createTask], [updateTitle], [updateNotes], [updateTitleAndNotes],
+ *   [setCompleted], [deleteTask], [updateDueDate]
+ * Each method:
+ *   1. Writes the change to `tasks`.
+ *   2. Inserts a matching [OutboxOpEntity] into `outbox_ops`.
+ *
+ * ## Phone → Watch (inbox)
+ * - [processPhoneSnapshot] — merges a full task list from the phone.
+ * - [processPhoneTaskUpdate] — applies a single task update with
+ *   per-field last-writer-wins conflict resolution.
+ * - [processPhoneDelete] — hard-deletes a task on watch.
+ *
+ * ## Idempotency
+ * Uses [ProcessedOpDao] to record processed phone operation IDs
+ * ([isPhoneOpProcessed] / [markPhoneOpProcessed]) so duplicate
+ * deliveries are safely ignored.
+ *
+ * ## Cleanup helpers
+ * [cleanupAckedOps], [cleanupOldProcessedOps], [cleanupDeletedTasks],
+ * [resetStuckOps] — called periodically by [SyncWorker].
+ *
+ * ## Singleton
+ * Accessed via [SyncRepository.getInstance].
+ */
+package org.tasks.data.sync
+
+import android.content.Context
+import androidx.room.withTransaction
+import kotlinx.coroutines.flow.Flow
+import org.tasks.data.local.OutboxOpDao
+import org.tasks.data.local.OutboxOpEntity
+import org.tasks.data.local.OutboxOpState
+import org.tasks.data.local.OutboxOpType
+import org.tasks.data.local.ProcessedOpDao
+import org.tasks.data.local.ProcessedOpEntity
+import org.tasks.data.local.TaskDao
+import org.tasks.data.local.TaskEntity
+import org.tasks.data.local.WearDatabase
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.UUID
+
+/**
+ * Repository that handles sync operations with transactional consistency.
+ * Ensures that task modifications and outbox operations are always in sync.
+ */
+class SyncRepository(context: Context) {
+
+    private val database = WearDatabase.getInstance(context)
+    private val taskDao: TaskDao = database.taskDao()
+    private val outboxOpDao: OutboxOpDao = database.outboxOpDao()
+    private val processedOpDao: ProcessedOpDao = database.processedOpDao()
+
+    // ===== Task operations with outbox (Watch -> Phone) =====
+
+    /**
+     * Create a new task and queue the operation for sync.
+     * Uses a transaction to ensure atomicity.
+     */
+    suspend fun createTask(task: TaskEntity): String {
+        val taskId = task.id.ifEmpty { UUID.randomUUID().toString() }
+        val timestamp = System.currentTimeMillis()
+
+        val newTask = task.copy(
+            id = taskId,
+            dirty = true,
+            updatedAt = timestamp,
+            titleUpdatedAt = timestamp,
+            notesUpdatedAt = timestamp,
+            completedUpdatedAt = timestamp,
+        )
+
+        val payload = createTaskPayload(newTask)
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.CREATE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.insert(newTask)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Created task $taskId and queued sync operation")
+        return taskId
+    }
+
+    /**
+     * Update task title and queue the operation for sync.
+     */
+    suspend fun updateTitle(taskId: String, title: String) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_TITLE, title)
+            put(DataMapKeys.KEY_TITLE_UPDATED_AT, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.UPDATE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.updateTitle(taskId, title, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Updated title for task $taskId and queued sync operation")
+    }
+
+    /**
+     * Update task notes and queue the operation for sync.
+     */
+    suspend fun updateNotes(taskId: String, notes: String?) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_NOTES, notes ?: "")
+            put(DataMapKeys.KEY_NOTES_UPDATED_AT, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.UPDATE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.updateNotes(taskId, notes, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Updated notes for task $taskId and queued sync operation")
+    }
+
+    /**
+     * Update task title and notes and queue the operation for sync.
+     */
+    suspend fun updateTitleAndNotes(taskId: String, title: String, notes: String?) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_TITLE, title)
+            put(DataMapKeys.KEY_TITLE_UPDATED_AT, timestamp)
+            put(DataMapKeys.KEY_NOTES, notes ?: "")
+            put(DataMapKeys.KEY_NOTES_UPDATED_AT, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.UPDATE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.updateTitleAndNotes(taskId, title, notes, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Updated title and notes for task $taskId and queued sync operation")
+    }
+
+    /**
+     * Update task due date and queue the operation for sync.
+     */
+    suspend fun updateDueDate(taskId: String, dueDate: Long?, dueTime: Long?, reminder: Boolean, reminderTime: Long?) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_DUE_DATE, dueDate ?: 0L)
+            put(DataMapKeys.KEY_TIMESTAMP, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.UPDATE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.updateDueDateAndReminder(taskId, dueDate, dueTime, reminder, reminderTime, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Updated due date for task $taskId and queued sync operation")
+    }
+
+    /**
+     * Toggle task completion and queue the operation for sync.
+     */
+    suspend fun setCompleted(taskId: String, completed: Boolean) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_COMPLETED, completed)
+            put(DataMapKeys.KEY_COMPLETED_UPDATED_AT, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.COMPLETE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.setCompleted(taskId, completed, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Set completed=$completed for task $taskId and queued sync operation")
+    }
+
+    /**
+     * Soft delete a task and queue the operation for sync.
+     */
+    suspend fun deleteTask(taskId: String) {
+        val timestamp = System.currentTimeMillis()
+
+        val payload = JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, taskId)
+            put(DataMapKeys.KEY_DELETED, true)
+            put(DataMapKeys.KEY_TIMESTAMP, timestamp)
+        }.toString()
+
+        val outboxOp = OutboxOpEntity(
+            taskId = taskId,
+            type = OutboxOpType.DELETE,
+            payload = payload,
+            createdAt = timestamp,
+        )
+
+        database.withTransaction {
+            taskDao.softDelete(taskId, timestamp)
+            outboxOpDao.insert(outboxOp)
+        }
+
+        Timber.d("Deleted task $taskId and queued sync operation")
+    }
+
+    // ===== Outbox operations =====
+
+    /**
+     * Get pending operations to sync.
+     */
+    fun getPendingOps(): Flow<List<OutboxOpEntity>> = outboxOpDao.getPendingOps()
+
+    /**
+     * Get pending operations once.
+     */
+    suspend fun getPendingOpsOnce(): List<OutboxOpEntity> = outboxOpDao.getPendingOpsOnce()
+
+    /**
+     * Mark operation as being sent.
+     */
+    suspend fun markSending(opId: Long) = outboxOpDao.markSending(opId)
+
+    /**
+     * Mark operation as sent (waiting for ack).
+     */
+    suspend fun markSent(opId: Long) = outboxOpDao.markSent(opId)
+
+    /**
+     * Mark operation as acknowledged and clean up.
+     */
+    suspend fun markAcked(opId: Long) {
+        database.withTransaction {
+            outboxOpDao.markAcked(opId)
+            // Optionally delete immediately or leave for batch cleanup
+        }
+        Timber.d("Operation $opId acknowledged")
+    }
+
+    /**
+     * Mark operation as failed.
+     */
+    suspend fun markFailed(opId: Long, error: String?) = outboxOpDao.markFailed(opId, error)
+
+    /**
+     * Clean up acknowledged operations.
+     */
+    suspend fun cleanupAckedOps() = outboxOpDao.deleteAckedOps()
+
+    /**
+     * Reset stuck operations (e.g., after timeout).
+     */
+    suspend fun resetStuckOps(timeout: Long = 5 * 60 * 1000L) {
+        val threshold = System.currentTimeMillis() - timeout
+        outboxOpDao.resetStuckOps(threshold)
+    }
+
+    // ===== Incoming operations (Phone -> Watch) with conflict resolution =====
+
+    /**
+     * Check if an operation has already been processed (idempotency).
+     */
+    suspend fun isOpProcessed(opId: String): Boolean = processedOpDao.isProcessed(opId)
+
+    /**
+     * Apply an incoming task from phone with per-field conflict resolution.
+     * Uses last-write-wins strategy per field.
+     * Handles phone task ID mapping to avoid duplicates.
+     */
+    suspend fun applyIncomingTask(
+        opId: String,
+        taskId: String,
+        title: String?,
+        titleUpdatedAt: Long?,
+        notes: String?,
+        notesUpdatedAt: Long?,
+        completed: Boolean?,
+        completedUpdatedAt: Long?,
+        deleted: Boolean?,
+        priority: Int?,
+        dueDate: Long? = null,
+    ): Boolean {
+        // Check idempotency
+        if (processedOpDao.isProcessed(opId)) {
+            Timber.d("Operation $opId already processed, skipping")
+            return true
+        }
+
+        val phoneId = taskId.toLongOrNull()
+
+        database.withTransaction {
+            // Try to find task by phoneTaskId first, then by id
+            var existingTask = if (phoneId != null) {
+                taskDao.getTaskByPhoneId(phoneId) ?: taskDao.getTask(taskId)
+            } else {
+                taskDao.getTask(taskId)
+            }
+
+            // Handle deletion from phone
+            if (deleted == true) {
+                if (existingTask != null) {
+                    // Hard delete the task since phone deleted it
+                    taskDao.hardDelete(existingTask.id)
+                    Timber.d("Hard deleted task ${existingTask.id} (phoneId: $phoneId) from phone")
+                } else if (phoneId != null) {
+                    // Also try to delete by phoneId directly
+                    taskDao.hardDeleteByPhoneId(phoneId)
+                    Timber.d("Hard deleted task by phoneId $phoneId from phone")
+                }
+                // Mark operation as processed
+                processedOpDao.markProcessed(ProcessedOpEntity(opId))
+                return@withTransaction
+            }
+
+            if (existingTask == null) {
+                // Task doesn't exist locally, create it
+                val newTask = TaskEntity(
+                    id = taskId,
+                    title = title ?: "",
+                    titleUpdatedAt = titleUpdatedAt ?: System.currentTimeMillis(),
+                    notes = notes,
+                    notesUpdatedAt = notesUpdatedAt ?: System.currentTimeMillis(),
+                    completed = completed ?: false,
+                    completedUpdatedAt = completedUpdatedAt ?: System.currentTimeMillis(),
+                    deleted = false,  // Never create as deleted
+                    priority = priority ?: 0,
+                    dirty = false,  // Not dirty since it came from phone
+                    syncedAt = System.currentTimeMillis(),
+                    phoneTaskId = phoneId,  // Store phone task ID for mapping
+                    dueDate = dueDate,
+                    reminder = dueDate != null && dueDate > 0,
+                )
+                taskDao.insert(newTask)
+                Timber.d("Created new task $taskId from phone (phoneTaskId: $phoneId)")
+            } else {
+                // Task exists, apply per-field conflict resolution
+                var updated = false
+
+                // Update title if incoming is newer
+                if (title != null && titleUpdatedAt != null && titleUpdatedAt > existingTask.titleUpdatedAt) {
+                    taskDao.updateTitleIfNewer(taskId, title, titleUpdatedAt)
+                    updated = true
+                    Timber.d("Updated title for task $taskId (incoming newer)")
+                } else if (title != null && titleUpdatedAt != null) {
+                    Timber.d("Kept local title for task $taskId (local newer)")
+                }
+
+                // Update notes if incoming is newer
+                if (notes != null && notesUpdatedAt != null && notesUpdatedAt > existingTask.notesUpdatedAt) {
+                    taskDao.updateNotesIfNewer(taskId, notes, notesUpdatedAt)
+                    updated = true
+                    Timber.d("Updated notes for task $taskId (incoming newer)")
+                } else if (notesUpdatedAt != null) {
+                    Timber.d("Kept local notes for task $taskId (local newer)")
+                }
+
+                // Update completed if incoming is newer
+                if (completed != null && completedUpdatedAt != null && completedUpdatedAt > existingTask.completedUpdatedAt) {
+                    taskDao.updateCompletedIfNewer(taskId, completed, completedUpdatedAt)
+                    updated = true
+                    Timber.d("Updated completed for task $taskId (incoming newer)")
+                } else if (completedUpdatedAt != null) {
+                    Timber.d("Kept local completed for task $taskId (local newer)")
+                }
+
+                // Handle deletion
+                if (deleted == true && !existingTask.deleted) {
+                    taskDao.softDelete(taskId)
+                    updated = true
+                    Timber.d("Deleted task $taskId from phone")
+                }
+
+                if (updated) {
+                    // Mark as synced since we just received from phone
+                    taskDao.markSynced(taskId)
+                }
+            }
+
+            // Mark operation as processed for idempotency
+            processedOpDao.markProcessed(ProcessedOpEntity(opId))
+        }
+
+        return true
+    }
+
+    /**
+     * Apply an incoming task from phone with phoneId for better duplicate detection.
+     * This version is used for snapshots where we have the phone's task ID.
+     */
+    suspend fun applyIncomingTaskWithPhoneId(
+        opId: String,
+        taskId: String,
+        phoneId: Long?,
+        title: String?,
+        titleUpdatedAt: Long?,
+        notes: String?,
+        notesUpdatedAt: Long?,
+        completed: Boolean?,
+        completedUpdatedAt: Long?,
+        deleted: Boolean?,
+        priority: Int?,
+        dueDate: Long? = null,
+    ): Boolean {
+        database.withTransaction {
+            // Try to find existing task by phoneTaskId first, then by taskId, then by phoneId as string
+            var existingTask = if (phoneId != null && phoneId > 0) {
+                taskDao.getTaskByPhoneId(phoneId)
+                    ?: taskDao.getTask(taskId)
+                    ?: taskDao.getTask(phoneId.toString())
+            } else {
+                taskDao.getTask(taskId)
+            }
+
+            // If not found, try to find a dirty local task with matching title
+            // This helps match tasks created on watch with their phone counterparts
+            if (existingTask == null && title != null) {
+                existingTask = taskDao.findDirtyTaskByTitle(title)
+                if (existingTask != null) {
+                    Timber.d("Found matching dirty task by title: ${existingTask.id} for phone task $taskId")
+                }
+            }
+
+            // Handle deletion from phone
+            if (deleted == true) {
+                if (existingTask != null) {
+                    taskDao.hardDelete(existingTask.id)
+                    Timber.d("Hard deleted task ${existingTask.id} (phoneId: $phoneId) from snapshot")
+                } else if (phoneId != null && phoneId > 0) {
+                    taskDao.hardDeleteByPhoneId(phoneId)
+                    Timber.d("Hard deleted task by phoneId $phoneId from snapshot")
+                }
+                return@withTransaction
+            }
+
+            if (existingTask == null) {
+                // Task doesn't exist locally, create it
+                val newTask = TaskEntity(
+                    id = taskId,
+                    title = title ?: "",
+                    titleUpdatedAt = titleUpdatedAt ?: System.currentTimeMillis(),
+                    notes = notes,
+                    notesUpdatedAt = notesUpdatedAt ?: System.currentTimeMillis(),
+                    completed = completed ?: false,
+                    completedUpdatedAt = completedUpdatedAt ?: System.currentTimeMillis(),
+                    deleted = false,
+                    priority = priority ?: 0,
+                    dirty = false,
+                    syncedAt = System.currentTimeMillis(),
+                    phoneTaskId = phoneId,
+                    dueDate = dueDate,
+                    reminder = dueDate != null && dueDate > 0,
+                )
+                taskDao.insert(newTask)
+                Timber.d("Created new task $taskId from snapshot (phoneTaskId: $phoneId, dueDate: $dueDate)")
+            } else {
+                // Task exists - update phoneTaskId if not set and apply per-field updates
+                if (existingTask.phoneTaskId == null && phoneId != null && phoneId > 0) {
+                    taskDao.setPhoneTaskId(existingTask.id, phoneId)
+                    Timber.d("Linked local task ${existingTask.id} to phone task $phoneId")
+                }
+
+                // Update title if incoming is newer
+                if (title != null && titleUpdatedAt != null && titleUpdatedAt > existingTask.titleUpdatedAt) {
+                    taskDao.updateTitleIfNewer(existingTask.id, title, titleUpdatedAt)
+                }
+
+                // Update notes if incoming is newer
+                if (notes != null && notesUpdatedAt != null && notesUpdatedAt > existingTask.notesUpdatedAt) {
+                    taskDao.updateNotesIfNewer(existingTask.id, notes, notesUpdatedAt)
+                }
+
+                // Update completed if incoming is newer
+                if (completed != null && completedUpdatedAt != null && completedUpdatedAt > existingTask.completedUpdatedAt) {
+                    taskDao.updateCompletedIfNewer(existingTask.id, completed, completedUpdatedAt)
+                }
+
+                // Update dueDate from phone (phone is authoritative for due dates)
+                if (dueDate != null && dueDate != (existingTask.dueDate ?: 0L)) {
+                    taskDao.updateDueDateAndReminder(
+                        id = existingTask.id,
+                        dueDate = dueDate.takeIf { it > 0 },
+                        dueTime = null,
+                        reminder = dueDate > 0,
+                        reminderTime = null,
+                    )
+                    Timber.d("Updated dueDate for task ${existingTask.id} to $dueDate")
+                }
+
+                taskDao.markSynced(existingTask.id)
+            }
+        }
+
+        return true
+    }
+
+    /**
+     * Apply a full snapshot from phone.
+     * For each task in snapshot, apply with conflict resolution.
+     */
+    suspend fun applySnapshot(tasks: List<TaskSnapshotData>) {
+        for (task in tasks) {
+            // Use deterministic opId so re-applying the same snapshot doesn't create duplicates
+            // We skip idempotency check for snapshots and always upsert instead
+            applyIncomingTaskWithPhoneId(
+                opId = "snapshot_${task.taskId}_${task.phoneId ?: 0}",
+                taskId = task.taskId,
+                phoneId = task.phoneId,
+                title = task.title,
+                titleUpdatedAt = task.titleUpdatedAt,
+                notes = task.notes,
+                notesUpdatedAt = task.notesUpdatedAt,
+                completed = task.completed,
+                completedUpdatedAt = task.completedUpdatedAt,
+                deleted = task.deleted,
+                priority = task.priority,
+                dueDate = task.dueDate,
+            )
+        }
+        Timber.d("Applied snapshot with ${tasks.size} tasks")
+    }
+
+    // ===== Cleanup =====
+
+    /**
+     * Clean up old processed operations (older than 7 days).
+     */
+    suspend fun cleanupOldProcessedOps(maxAge: Long = 7 * 24 * 60 * 60 * 1000L) {
+        val threshold = System.currentTimeMillis() - maxAge
+        processedOpDao.cleanupOld(threshold)
+    }
+
+    /**
+     * Clean up deleted and synced tasks (older than 30 days).
+     */
+    suspend fun cleanupDeletedTasks(maxAge: Long = 30 * 24 * 60 * 60 * 1000L) {
+        val threshold = System.currentTimeMillis() - maxAge
+        taskDao.cleanupDeletedTasks(threshold)
+    }
+
+    // ===== Helpers =====
+
+    private fun createTaskPayload(task: TaskEntity): String {
+        return JSONObject().apply {
+            put(DataMapKeys.KEY_TASK_ID, task.id)
+            put(DataMapKeys.KEY_TITLE, task.title)
+            put(DataMapKeys.KEY_TITLE_UPDATED_AT, task.titleUpdatedAt)
+            put(DataMapKeys.KEY_NOTES, task.notes ?: "")
+            put(DataMapKeys.KEY_NOTES_UPDATED_AT, task.notesUpdatedAt)
+            put(DataMapKeys.KEY_COMPLETED, task.completed)
+            put(DataMapKeys.KEY_COMPLETED_UPDATED_AT, task.completedUpdatedAt)
+            put(DataMapKeys.KEY_DELETED, task.deleted)
+            put(DataMapKeys.KEY_PRIORITY, task.priority)
+            put(DataMapKeys.KEY_DUE_DATE, task.dueDate ?: 0L)
+            put(DataMapKeys.KEY_TIMESTAMP, task.updatedAt)
+        }.toString()
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: SyncRepository? = null
+
+        fun getInstance(context: Context): SyncRepository {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: SyncRepository(context).also { INSTANCE = it }
+            }
+        }
+    }
+}
+
+/**
+ * Data class for task snapshot from phone.
+ */
+data class TaskSnapshotData(
+    val taskId: String,
+    val title: String?,
+    val titleUpdatedAt: Long?,
+    val notes: String?,
+    val notesUpdatedAt: Long?,
+    val completed: Boolean?,
+    val completedUpdatedAt: Long?,
+    val deleted: Boolean?,
+    val priority: Int?,
+    val phoneId: Long? = null,  // Phone task ID for mapping to avoid duplicates
+    val dueDate: Long? = null,  // Due date timestamp from phone
+)
+

--- a/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
@@ -53,6 +53,7 @@ import java.util.UUID
  * Repository that handles sync operations with transactional consistency.
  * Ensures that task modifications and outbox operations are always in sync.
  */
+@Suppress("TooManyFunctions", "LongParameterList", "LongMethod", "LabeledExpression")
 class SyncRepository(context: Context) {
 
     private val database = WearDatabase.getInstance(context)

--- a/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncRepository.kt
@@ -184,10 +184,11 @@ class SyncRepository(context: Context) {
      */
     suspend fun updateDueDate(taskId: String, dueDate: Long?, dueTime: Long?, reminder: Boolean, reminderTime: Long?) {
         val timestamp = System.currentTimeMillis()
+        val combinedDueDate = combineDueDateAndTime(dueDate, dueTime)
 
         val payload = JSONObject().apply {
             put(DataMapKeys.KEY_TASK_ID, taskId)
-            put(DataMapKeys.KEY_DUE_DATE, dueDate ?: 0L)
+            put(DataMapKeys.KEY_DUE_DATE, combinedDueDate)
             put(DataMapKeys.KEY_TIMESTAMP, timestamp)
         }.toString()
 
@@ -370,6 +371,7 @@ class SyncRepository(context: Context) {
 
             if (existingTask == null) {
                 // Task doesn't exist locally, create it
+                val (parsedDueDate, parsedDueTime) = splitDueDate(dueDate)
                 val newTask = TaskEntity(
                     id = taskId,
                     title = title ?: "",
@@ -383,8 +385,9 @@ class SyncRepository(context: Context) {
                     dirty = false,  // Not dirty since it came from phone
                     syncedAt = System.currentTimeMillis(),
                     phoneTaskId = phoneId,  // Store phone task ID for mapping
-                    dueDate = dueDate,
-                    reminder = dueDate != null && dueDate > 0,
+                    dueDate = parsedDueDate,
+                    dueTime = parsedDueTime,
+                    reminder = parsedDueDate != null && parsedDueDate > 0,
                 )
                 taskDao.insert(newTask)
                 Timber.d("Created new task $taskId from phone (phoneTaskId: $phoneId)")
@@ -417,6 +420,20 @@ class SyncRepository(context: Context) {
                     Timber.d("Updated completed for task $taskId (incoming newer)")
                 } else if (completedUpdatedAt != null) {
                     Timber.d("Kept local completed for task $taskId (local newer)")
+                }
+
+                // Update dueDate if incoming is different
+                if (dueDate != null && dueDate != (existingTask.dueDate ?: 0L)) {
+                    val (parsedDueDate, parsedDueTime) = splitDueDate(dueDate)
+                    taskDao.updateDueDateAndReminder(
+                        id = existingTask.id,
+                        dueDate = parsedDueDate,
+                        dueTime = parsedDueTime,
+                        reminder = parsedDueDate != null && parsedDueDate > 0,
+                        reminderTime = null,
+                    )
+                    updated = true
+                    Timber.d("Updated dueDate for task $taskId from phone operation")
                 }
 
                 // Handle deletion
@@ -490,6 +507,7 @@ class SyncRepository(context: Context) {
 
             if (existingTask == null) {
                 // Task doesn't exist locally, create it
+                val (parsedDueDate, parsedDueTime) = splitDueDate(dueDate)
                 val newTask = TaskEntity(
                     id = taskId,
                     title = title ?: "",
@@ -503,11 +521,12 @@ class SyncRepository(context: Context) {
                     dirty = false,
                     syncedAt = System.currentTimeMillis(),
                     phoneTaskId = phoneId,
-                    dueDate = dueDate,
-                    reminder = dueDate != null && dueDate > 0,
+                    dueDate = parsedDueDate,
+                    dueTime = parsedDueTime,
+                    reminder = parsedDueDate != null && parsedDueDate > 0,
                 )
                 taskDao.insert(newTask)
-                Timber.d("Created new task $taskId from snapshot (phoneTaskId: $phoneId, dueDate: $dueDate)")
+                Timber.d("Created new task $taskId from snapshot (phoneTaskId: $phoneId, dueDate: $parsedDueDate)")
             } else {
                 // Task exists - update phoneTaskId if not set and apply per-field updates
                 if (existingTask.phoneTaskId == null && phoneId != null && phoneId > 0) {
@@ -532,14 +551,15 @@ class SyncRepository(context: Context) {
 
                 // Update dueDate from phone (phone is authoritative for due dates)
                 if (dueDate != null && dueDate != (existingTask.dueDate ?: 0L)) {
+                    val (parsedDueDate, parsedDueTime) = splitDueDate(dueDate)
                     taskDao.updateDueDateAndReminder(
                         id = existingTask.id,
-                        dueDate = dueDate.takeIf { it > 0 },
-                        dueTime = null,
-                        reminder = dueDate > 0,
+                        dueDate = parsedDueDate,
+                        dueTime = parsedDueTime,
+                        reminder = parsedDueDate != null && parsedDueDate > 0,
                         reminderTime = null,
                     )
-                    Timber.d("Updated dueDate for task ${existingTask.id} to $dueDate")
+                    Timber.d("Updated dueDate for task ${existingTask.id} to $parsedDueDate (dueTime: $parsedDueTime)")
                 }
 
                 taskDao.markSynced(existingTask.id)
@@ -595,7 +615,43 @@ class SyncRepository(context: Context) {
 
     // ===== Helpers =====
 
+    private fun splitDueDate(combinedDueDate: Long?): Pair<Long?, Long?> {
+        if (combinedDueDate == null || combinedDueDate <= 0) return Pair(null, null)
+        val hasTime = combinedDueDate % 60000 > 0
+        if (hasTime) {
+            val midnightCal = java.util.Calendar.getInstance().apply {
+                timeInMillis = combinedDueDate
+                set(java.util.Calendar.HOUR_OF_DAY, 0)
+                set(java.util.Calendar.MINUTE, 0)
+                set(java.util.Calendar.SECOND, 0)
+                set(java.util.Calendar.MILLISECOND, 0)
+            }
+            return Pair(midnightCal.timeInMillis, combinedDueDate)
+        } else {
+            return Pair(combinedDueDate, null)
+        }
+    }
+
+    private fun combineDueDateAndTime(dueDate: Long?, dueTime: Long?): Long {
+        if (dueDate == null || dueDate <= 0) return 0L
+        if (dueTime == null || dueTime <= 0) return dueDate
+        
+        val dateCal = java.util.Calendar.getInstance().apply { timeInMillis = dueDate }
+        val timeCal = java.util.Calendar.getInstance().apply { timeInMillis = dueTime }
+        
+        return java.util.Calendar.getInstance().apply {
+            set(java.util.Calendar.YEAR, dateCal.get(java.util.Calendar.YEAR))
+            set(java.util.Calendar.MONTH, dateCal.get(java.util.Calendar.MONTH))
+            set(java.util.Calendar.DAY_OF_MONTH, dateCal.get(java.util.Calendar.DAY_OF_MONTH))
+            set(java.util.Calendar.HOUR_OF_DAY, timeCal.get(java.util.Calendar.HOUR_OF_DAY))
+            set(java.util.Calendar.MINUTE, timeCal.get(java.util.Calendar.MINUTE))
+            set(java.util.Calendar.SECOND, 1) // Add 1 second for dueTime flag
+            set(java.util.Calendar.MILLISECOND, 0)
+        }.timeInMillis
+    }
+
     private fun createTaskPayload(task: TaskEntity): String {
+        val combinedDueDate = combineDueDateAndTime(task.dueDate, task.dueTime)
         return JSONObject().apply {
             put(DataMapKeys.KEY_TASK_ID, task.id)
             put(DataMapKeys.KEY_TITLE, task.title)
@@ -606,7 +662,7 @@ class SyncRepository(context: Context) {
             put(DataMapKeys.KEY_COMPLETED_UPDATED_AT, task.completedUpdatedAt)
             put(DataMapKeys.KEY_DELETED, task.deleted)
             put(DataMapKeys.KEY_PRIORITY, task.priority)
-            put(DataMapKeys.KEY_DUE_DATE, task.dueDate ?: 0L)
+            put(DataMapKeys.KEY_DUE_DATE, combinedDueDate)
             put(DataMapKeys.KEY_TIMESTAMP, task.updatedAt)
         }.toString()
     }

--- a/wear/src/main/java/org/tasks/data/sync/SyncWorker.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncWorker.kt
@@ -1,0 +1,124 @@
+/**
+ * SyncWorker.kt — Periodic WorkManager worker for background sync.
+ *
+ * Scheduled every 15 minutes (with `NetworkType.CONNECTED` constraint)
+ * via [SyncWorker.schedule].  Each run:
+ *
+ * 1. Resets stuck outbox operations that stayed in `SENDING` too long.
+ * 2. Sends pending outbox operations via [DataLayerSyncManager].
+ * 3. Cleans up acknowledged outbox rows.
+ * 4. Purges old processed-op idempotency records.
+ * 5. Removes soft-deleted tasks that have been synced.
+ * 6. Reschedules reminder alarms for newly synced tasks.
+ *
+ * Also provides [syncNow] for on-demand immediate sync.
+ */
+package org.tasks.data.sync
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import org.tasks.notifications.WearNotificationManager
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+/**
+ * Worker that periodically processes pending sync operations.
+ *
+ * This handles:
+ * - Retrying failed operations
+ * - Cleaning up acknowledged operations
+ * - Resetting stuck operations
+ * - Requesting sync from phone if needed
+ */
+class SyncWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    private val syncManager = DataLayerSyncManager.getInstance(applicationContext)
+    private val syncRepository = SyncRepository.getInstance(applicationContext)
+
+    override suspend fun doWork(): Result {
+        Timber.d("SyncWorker starting")
+
+        return try {
+            // Reset stuck operations (sending for too long)
+            syncRepository.resetStuckOps()
+
+            // Process pending operations
+            syncManager.processPendingOps()
+
+            // Clean up acknowledged operations
+            syncRepository.cleanupAckedOps()
+
+            // Clean up old processed ops
+            syncRepository.cleanupOldProcessedOps()
+
+            // Clean up deleted tasks that have been synced
+            syncRepository.cleanupDeletedTasks()
+
+            // Reschedule reminders for any newly synced tasks
+            WearNotificationManager.getInstance(applicationContext).rescheduleAll()
+
+            Timber.d("SyncWorker completed successfully")
+            Result.success()
+        } catch (e: Exception) {
+            Timber.e(e, "SyncWorker failed")
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "sync_worker"
+        private const val SYNC_INTERVAL_MINUTES = 15L
+
+        /**
+         * Schedule periodic sync work.
+         */
+        fun schedule(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val syncRequest = PeriodicWorkRequestBuilder<SyncWorker>(
+                SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES
+            )
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                syncRequest
+            )
+
+            Timber.d("Scheduled periodic sync every $SYNC_INTERVAL_MINUTES minutes")
+        }
+
+        /**
+         * Cancel scheduled sync work.
+         */
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Timber.d("Cancelled periodic sync")
+        }
+
+        /**
+         * Trigger an immediate sync.
+         */
+        suspend fun syncNow(context: Context) {
+            val syncManager = DataLayerSyncManager.getInstance(context)
+            val syncRepository = SyncRepository.getInstance(context)
+
+            syncRepository.resetStuckOps()
+            syncManager.processPendingOps()
+            syncRepository.cleanupAckedOps()
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/data/sync/SyncWorker.kt
+++ b/wear/src/main/java/org/tasks/data/sync/SyncWorker.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit
  * - Resetting stuck operations
  * - Requesting sync from phone if needed
  */
+@Suppress("TooGenericExceptionCaught")
 class SyncWorker(
     context: Context,
     params: WorkerParameters

--- a/wear/src/main/java/org/tasks/data/sync/WearSyncListenerService.kt
+++ b/wear/src/main/java/org/tasks/data/sync/WearSyncListenerService.kt
@@ -1,0 +1,60 @@
+/**
+ * WearSyncListenerService.kt — System-started service for Data Layer events.
+ *
+ * Extends [WearableListenerService], which the OS wakes whenever a
+ * [DataItem] changes — even if the Wear app isn't running.
+ *
+ * The service simply delegates every [DataEventBuffer] to
+ * [DataLayerSyncManager.onDataChanged], which routes events to the
+ * appropriate handler (ack, incoming operation, snapshot, etc.).
+ */
+package org.tasks.data.sync
+
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.WearableListenerService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import timber.log.Timber
+
+/**
+ * Background service that listens for data changes from phone.
+ * This service is started automatically by the system when data changes occur,
+ * even if the app is not running.
+ *
+ * Note: The Data Layer persists data and will deliver it when the device reconnects,
+ * so this doesn't need to be running all the time.
+ */
+class WearSyncListenerService : WearableListenerService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private lateinit var syncManager: DataLayerSyncManager
+    private lateinit var syncRepository: SyncRepository
+
+    override fun onCreate() {
+        super.onCreate()
+        syncRepository = SyncRepository.getInstance(applicationContext)
+        syncManager = DataLayerSyncManager.getInstance(applicationContext)
+        Timber.d("WearSyncListenerService created")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+        Timber.d("WearSyncListenerService destroyed")
+    }
+
+    /**
+     * Called when data items are changed.
+     * This is called even when the app is not in the foreground.
+     */
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        Timber.d("WearSyncListenerService: onDataChanged with ${dataEvents.count} events")
+
+        // Delegate to the sync manager which handles the actual processing
+        syncManager.onDataChanged(dataEvents)
+    }
+}
+

--- a/wear/src/main/java/org/tasks/notifications/BootReceiver.kt
+++ b/wear/src/main/java/org/tasks/notifications/BootReceiver.kt
@@ -1,0 +1,31 @@
+/**
+ * BootReceiver.kt — Reschedules task reminders after device reboot.
+ *
+ * [AlarmManager] alarms are cleared on reboot. This receiver listens
+ * for [Intent.ACTION_BOOT_COMPLETED] and calls
+ * [WearNotificationManager.rescheduleAll] to re-register alarms for
+ * every pending reminder.
+ *
+ * Registered in `AndroidManifest.xml` with the `RECEIVE_BOOT_COMPLETED`
+ * permission.
+ */
+package org.tasks.notifications
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+/**
+ * Reschedules all task reminders after device boot.
+ */
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            Timber.d("Boot completed - rescheduling all wear reminders")
+            val manager = WearNotificationManager.getInstance(context)
+            manager.createNotificationChannel()
+            manager.rescheduleAll()
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/notifications/WearNotificationManager.kt
+++ b/wear/src/main/java/org/tasks/notifications/WearNotificationManager.kt
@@ -1,0 +1,307 @@
+/**
+ * WearNotificationManager.kt — Local reminder notifications on Wear OS.
+ *
+ * ## How it works
+ * 1. When a task with `reminder = true` is saved, [scheduleReminder] sets
+ *    an exact [AlarmManager] alarm at the task's `reminderTime` (or `dueDate`).
+ * 2. When the alarm fires, [ReminderReceiver] (inner broadcast receiver)
+ *    creates and posts a [NotificationCompat] notification with:
+ *    - A "Complete" action that marks the task done.
+ *    - A content tap that opens [MainActivity].
+ * 3. [cancelReminder] removes both the alarm and any existing notification.
+ *
+ * ## Boot persistence
+ * Alarms are lost on reboot.  [BootReceiver] calls [rescheduleAll] after
+ * `ACTION_BOOT_COMPLETED` to re-register every pending reminder.
+ *
+ * ## Singleton
+ * Accessed via [WearNotificationManager.getInstance].
+ */
+package org.tasks.notifications
+
+import android.Manifest
+import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.tasks.R
+import org.tasks.data.local.TaskEntity
+import org.tasks.data.local.WearDatabase
+import org.tasks.presentation.MainActivity
+import timber.log.Timber
+
+/**
+ * Manages local notifications on the Wear OS device.
+ * Handles scheduling, displaying and cancelling task reminder notifications.
+ */
+class WearNotificationManager private constructor(private val context: Context) {
+
+    private val notificationManager = NotificationManagerCompat.from(context)
+    private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    companion object {
+        const val CHANNEL_ID = "wear_task_reminders"
+        const val CHANNEL_NAME = "Task Reminders"
+        private const val ACTION_REMINDER = "org.tasks.wear.REMINDER"
+        private const val ACTION_COMPLETE = "org.tasks.wear.COMPLETE_TASK"
+        private const val EXTRA_TASK_ID = "extra_task_id"
+        private const val EXTRA_TASK_TITLE = "extra_task_title"
+        private const val NOTIFICATION_ID_OFFSET = 10000
+
+        @Volatile
+        private var instance: WearNotificationManager? = null
+
+        fun getInstance(context: Context): WearNotificationManager {
+            return instance ?: synchronized(this) {
+                instance ?: WearNotificationManager(context.applicationContext).also {
+                    instance = it
+                }
+            }
+        }
+    }
+
+    /**
+     * Create notification channel. Must be called at app startup.
+     */
+    fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Reminders for tasks with due dates"
+            enableVibration(true)
+            vibrationPattern = longArrayOf(0, 200, 100, 200)
+        }
+        val systemManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        systemManager.createNotificationChannel(channel)
+        Timber.d("Wear notification channel created")
+    }
+
+    /**
+     * Check if we have permission to post notifications.
+     */
+    fun canNotify(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    /**
+     * Schedule a reminder for a task.
+     * @param task The task to remind about
+     */
+    fun scheduleReminder(task: TaskEntity) {
+        if (!task.reminder) {
+            cancelReminder(task.id)
+            return
+        }
+
+        // Determine when to fire the reminder
+        val triggerTime = task.reminderTime
+            ?: task.dueTime
+            ?: task.dueDate
+            ?: return // No time to schedule
+
+        if (triggerTime <= System.currentTimeMillis()) {
+            // Already past due - fire immediately
+            showNotification(task.id, task.title)
+            return
+        }
+
+        val intent = Intent(context, ReminderReceiver::class.java).apply {
+            action = ACTION_REMINDER
+            putExtra(EXTRA_TASK_ID, task.id)
+            putExtra(EXTRA_TASK_TITLE, task.title)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            task.id.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        try {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerTime,
+                pendingIntent,
+            )
+            Timber.d("Scheduled reminder for task '${task.title}' at $triggerTime")
+        } catch (e: SecurityException) {
+            // Fallback: try inexact alarm
+            try {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerTime,
+                    pendingIntent,
+                )
+                Timber.w("Used inexact alarm for task '${task.title}' (exact alarm permission denied)")
+            } catch (e2: Exception) {
+                Timber.e(e2, "Failed to schedule any alarm for task '${task.title}'")
+            }
+        }
+    }
+
+    /**
+     * Cancel a scheduled reminder for a task.
+     */
+    fun cancelReminder(taskId: String) {
+        val intent = Intent(context, ReminderReceiver::class.java).apply {
+            action = ACTION_REMINDER
+            putExtra(EXTRA_TASK_ID, taskId)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            taskId.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_NO_CREATE,
+        )
+        pendingIntent?.let {
+            alarmManager.cancel(it)
+            it.cancel()
+            Timber.d("Cancelled reminder for task $taskId")
+        }
+        // Also cancel any shown notification
+        notificationManager.cancel(taskId.hashCode() + NOTIFICATION_ID_OFFSET)
+    }
+
+    /**
+     * Show a notification for a task.
+     */
+    fun showNotification(taskId: String, title: String) {
+        if (!canNotify()) {
+            Timber.w("Cannot show notification - permission denied")
+            return
+        }
+
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val tapPendingIntent = PendingIntent.getActivity(
+            context,
+            taskId.hashCode(),
+            tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        // Complete action
+        val completeIntent = Intent(context, ReminderReceiver::class.java).apply {
+            action = ACTION_COMPLETE
+            putExtra(EXTRA_TASK_ID, taskId)
+        }
+        val completePendingIntent = PendingIntent.getBroadcast(
+            context,
+            taskId.hashCode() + 1000,
+            completeIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText("Task reminder")
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(tapPendingIntent)
+            .addAction(
+                R.mipmap.ic_launcher,
+                "Done",
+                completePendingIntent,
+            )
+            .setVibrate(longArrayOf(0, 200, 100, 200))
+            .build()
+
+        try {
+            notificationManager.notify(
+                taskId.hashCode() + NOTIFICATION_ID_OFFSET,
+                notification,
+            )
+            Timber.d("Showed notification for task '$title' (id: $taskId)")
+        } catch (e: SecurityException) {
+            Timber.e(e, "SecurityException posting notification")
+        }
+    }
+
+    /**
+     * Reschedule all reminders (e.g., after boot or app update).
+     */
+    fun rescheduleAll() {
+        scope.launch {
+            try {
+                val db = WearDatabase.getInstance(context)
+                val tasks = db.taskDao().getTasksWithReminders()
+                var scheduled = 0
+                for (task in tasks) {
+                    val triggerTime = task.reminderTime ?: task.dueTime ?: task.dueDate
+                    if (triggerTime != null && triggerTime > System.currentTimeMillis()) {
+                        scheduleReminder(task)
+                        scheduled++
+                    }
+                }
+                Timber.d("Rescheduled $scheduled reminders out of ${tasks.size} tasks with reminders")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to reschedule reminders")
+            }
+        }
+    }
+
+    /**
+     * BroadcastReceiver that fires when a reminder alarm triggers or when a user acts on a notification.
+     */
+    class ReminderReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return
+
+            when (intent.action) {
+                ACTION_REMINDER -> {
+                    val title = intent.getStringExtra(EXTRA_TASK_TITLE) ?: "Task reminder"
+                    Timber.d("Reminder triggered for task: $taskId ($title)")
+                    getInstance(context).showNotification(taskId, title)
+                }
+                ACTION_COMPLETE -> {
+                    Timber.d("Complete action for task: $taskId")
+                    // Cancel the notification
+                    NotificationManagerCompat.from(context)
+                        .cancel(taskId.hashCode() + NOTIFICATION_ID_OFFSET)
+
+                    // Mark task as completed in database
+                    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+                    scope.launch {
+                        try {
+                            val db = WearDatabase.getInstance(context)
+                            db.taskDao().setCompleted(taskId, true, System.currentTimeMillis())
+                            Timber.d("Task $taskId marked complete from notification")
+                        } catch (e: Exception) {
+                            Timber.e(e, "Failed to complete task $taskId from notification")
+                        }
+                    }
+                }
+                Intent.ACTION_BOOT_COMPLETED -> {
+                    Timber.d("Boot completed - rescheduling all reminders")
+                    getInstance(context).rescheduleAll()
+                }
+            }
+        }
+    }
+}
+
+

--- a/wear/src/main/java/org/tasks/notifications/WearNotificationManager.kt
+++ b/wear/src/main/java/org/tasks/notifications/WearNotificationManager.kt
@@ -46,6 +46,7 @@ import timber.log.Timber
  * Manages local notifications on the Wear OS device.
  * Handles scheduling, displaying and cancelling task reminder notifications.
  */
+@Suppress("TooGenericExceptionCaught")
 class WearNotificationManager private constructor(private val context: Context) {
 
     private val notificationManager = NotificationManagerCompat.from(context)

--- a/wear/src/main/java/org/tasks/presentation/MainActivity.kt
+++ b/wear/src/main/java/org/tasks/presentation/MainActivity.kt
@@ -1,67 +1,67 @@
-/* While this template provides a good starting point for using Wear Compose, you can always
- * take a look at https://github.com/android/wear-os-samples/tree/main/ComposeStarter to find the
- * most up to date changes to the libraries and their usages.
+/**
+ * MainActivity.kt — Single Activity host for the Wear OS Tasks app.
+ *
+ * ## Architecture
+ * Uses Jetpack Compose for Wear OS with a [SwipeDismissableNavHost] that
+ * provides swipe-to-dismiss navigation between three screens:
+ *
+ * | Route            | Screen                      | ViewModel                       |
+ * |------------------|-----------------------------|----------------------------------|
+ * | `task_list`      | [OfflineTaskListScreen]      | [OfflineTaskListViewModel]       |
+ * | `task_edit`      | [OfflineTaskEditScreen]      | [OfflineTaskEditViewModel]       |
+ * | `settings`       | [OfflineSettingsScreen]      | [OfflineSettingsViewModel]       |
+ *
+ * ## Offline-first design
+ * All data is stored in a local Room database ([WearDatabase]).
+ * When the paired phone is reachable, the app syncs via the
+ * Wearable Data Layer API (see [DataLayerSyncManager]).
+ *
+ * ## Permissions
+ * On Android 13+ (Tiramisu) the app requests `POST_NOTIFICATIONS` at launch
+ * so that task reminders can be shown.
  */
 
 package org.tasks.presentation
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.LifecycleResumeEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.compose.layout.AppScaffold
-import kotlinx.coroutines.delay
-import org.jetbrains.compose.resources.stringResource
-import org.tasks.presentation.screens.MenuScreen
-import org.tasks.presentation.screens.MenuViewModel
-import org.tasks.presentation.screens.SettingsScreen
-import org.tasks.presentation.screens.SettingsViewModel
-import org.tasks.presentation.screens.SortPickerScreen
-import org.tasks.presentation.screens.TaskEditScreen
-import org.tasks.presentation.screens.TaskEditViewModel
-import org.tasks.presentation.screens.TaskEditViewModelFactory
-import org.tasks.presentation.screens.TaskListScreen
-import org.tasks.presentation.screens.TaskListViewModel
+import org.tasks.presentation.screens.OfflineSettingsScreen
+import org.tasks.presentation.screens.OfflineSettingsViewModel
+import org.tasks.presentation.screens.OfflineTaskEditScreen
+import org.tasks.presentation.screens.OfflineTaskEditViewModel
+import org.tasks.presentation.screens.OfflineTaskEditViewModelFactory
+import org.tasks.presentation.screens.OfflineTaskListScreen
+import org.tasks.presentation.screens.OfflineTaskListViewModel
 import org.tasks.presentation.theme.TasksTheme
-import org.tasks.complications.EXTRA_ADD_TASK
-import org.tasks.complications.EXTRA_COMPLICATION_FILTER
-import tasks.kmp.generated.resources.Res
-import tasks.kmp.generated.resources.wear_install_app
-import tasks.kmp.generated.resources.wear_phone_update_required
-import tasks.kmp.generated.resources.wear_connecting_to_phone
-import tasks.kmp.generated.resources.wear_unknown_error
+import timber.log.Timber
 
 class MainActivity : ComponentActivity() {
-    private val viewModel: MainActivityViewModel by viewModels()
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        Timber.d("POST_NOTIFICATIONS permission granted: $isGranted")
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -70,6 +70,9 @@ class MainActivity : ComponentActivity() {
 
         setTheme(android.R.style.Theme_DeviceDefault)
 
+        // Request notification permission on Android 13+
+        requestNotificationPermission()
+
         setContent {
             TasksTheme {
                 AppScaffold(
@@ -77,262 +80,98 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.background(MaterialTheme.colors.background),
                 ) {
                     val navController = rememberSwipeDismissableNavController()
-                    val taskListViewModel: TaskListViewModel = viewModel()
-                    val taskListItems = taskListViewModel.uiItems.collectAsLazyPagingItems()
-                    val menuViewModel: MenuViewModel = viewModel()
-                    val menuItems = menuViewModel.uiItems.collectAsLazyPagingItems()
-                    val settingsViewModel: SettingsViewModel = viewModel()
-                    val connected = viewModel.uiState.collectAsStateWithLifecycle().value
-                    LifecycleResumeEffect(Unit) {
-                        taskListViewModel.invalidate()
-                        onPauseOrDispose {}
-                    }
-                    LaunchedEffect(connected) {
-                        when (connected) {
-                            NodesActionScreenState.ApiNotAvailable -> {
-                                navController.popBackStack()
-                                navController.navigate("error")
-                            }
 
-                            is NodesActionScreenState.Loaded -> {
-                                navController.popBackStack()
-                                if (connected.nodeList.any { it.type == NodeTypeUiModel.PHONE && it.appInstalled }) {
-                                    if (connected.phoneUpdateRequired) {
-                                        val phoneNodeId = connected.nodeList
-                                            .first { it.type == NodeTypeUiModel.PHONE && it.appInstalled }
-                                            .id
-                                        navController.navigate("error?type=${Errors.PHONE_UPDATE_REQUIRED},nodeId=$phoneNodeId")
-                                    } else {
-                                        intent.getStringExtra(EXTRA_COMPLICATION_FILTER)?.let { complicationFilter ->
-                                            settingsViewModel.setFilter(complicationFilter)
-                                            intent.removeExtra(EXTRA_COMPLICATION_FILTER)
-                                        }
-                                        val addTask = intent.getBooleanExtra(EXTRA_ADD_TASK, false)
-                                        if (addTask) {
-                                            intent.removeExtra(EXTRA_ADD_TASK)
-                                        }
-                                        navController.navigate("task_list")
-                                        if (addTask) {
-                                            navController.navigate("task_edit?taskId=0")
-                                        }
-                                    }
-                                } else {
-                                    connected
-                                        .nodeList
-                                        .firstOrNull { it.type == NodeTypeUiModel.UNKNOWN }
-                                        ?.let {
-                                            navController.navigate("error?type=${Errors.APP_NOT_INSTALLED},nodeId=${it.id}")
-                                        }
-                                        ?: navController.navigate("error")
-                                }
-                            }
+                    // Offline-first: use local database and sync when connected
+                    val taskListViewModel: OfflineTaskListViewModel = viewModel()
+                    val settingsViewModel: OfflineSettingsViewModel = viewModel()
 
-                            else -> {}
-                        }
-                    }
                     SwipeDismissableNavHost(
-                        startDestination = "loading",
+                        startDestination = "task_list",
                         navController = navController,
                     ) {
-                        composable("loading") {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                CircularProgressIndicator()
-                            }
-                        }
-                        composable(
-                            route = "error?type={type},nodeId={nodeId}",
-                            arguments = listOf(
-                                navArgument("type") {
-                                    type = NavType.EnumType(Errors::class.java)
-                                    defaultValue = Errors.UNKNOWN
-                                },
-                                navArgument("nodeId") {
-                                    type = NavType.StringType
-                                    nullable = true
-                                }
-                            )
-                        ) {
-                            val type = it.arguments?.getSerializable("type") as? Errors
-                            val nodeId = it.arguments?.getString("nodeId")
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                when (type) {
-                                    Errors.APP_NOT_INSTALLED -> {
-                                        LaunchedEffect(Unit) {
-                                            while (true) {
-                                                delay(5000)
-                                                viewModel.loadNodes()
-                                            }
-                                        }
-                                        Chip(
-                                            onClick = { viewModel.installOnNode(nodeId) },
-                                            label = {
-                                                Text(
-                                                    text = stringResource(Res.string.wear_install_app),
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis
-                                                )
-                                            },
-                                        )
-                                    }
-
-                                    Errors.PHONE_UPDATE_REQUIRED -> {
-                                        LaunchedEffect(Unit) {
-                                            while (true) {
-                                                delay(5000)
-                                                viewModel.loadNodes()
-                                            }
-                                        }
-                                        Chip(
-                                            onClick = { viewModel.installOnNode(nodeId) },
-                                            label = {
-                                                Text(
-                                                    text = stringResource(Res.string.wear_phone_update_required),
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis
-                                                )
-                                            },
-                                        )
-                                    }
-
-                                    else -> {
-                                        LaunchedEffect(Unit) {
-                                            while (true) {
-                                                delay(5000)
-                                                viewModel.loadNodes()
-                                            }
-                                        }
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                            verticalArrangement = Arrangement.Center,
-                                        ) {
-                                            CircularProgressIndicator(
-                                                modifier = Modifier.size(24.dp),
-                                            )
-                                            Spacer(modifier = Modifier.height(8.dp))
-                                            Text(
-                                                text = stringResource(Res.string.wear_connecting_to_phone),
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        // Main task list screen
                         composable("task_list") {
-                            TaskListScreen(
-                                uiItems = taskListItems,
-                                toggleGroup = { value, collapsed ->
-                                    taskListViewModel.toggleGroup(value, collapsed)
+                            val viewState = taskListViewModel.viewState.collectAsStateWithLifecycle().value
+                            OfflineTaskListScreen(
+                                viewState = viewState,
+                                onTaskClick = { stringId ->
+                                    navController.navigate("task_edit?taskId=$stringId")
                                 },
-                                onComplete = { id, completed ->
-                                    taskListViewModel.completeTask(id, completed)
+                                onToggleComplete = { stringId, completed ->
+                                    taskListViewModel.toggleComplete(stringId, completed)
                                 },
-                                openTask = { navController.navigate("task_edit?taskId=$it") },
-                                addTask = { navController.navigate("task_edit?taskId=0")},
-                                openMenu = { navController.navigate("menu") },
+                                onAddTask = {
+                                    navController.navigate("task_edit?taskId=")
+                                },
                                 openSettings = { navController.navigate("settings") },
-                                toggleSubtasks = { id, collapsed ->
-                                    taskListViewModel.toggleSubtasks(id, collapsed)
-                                }
+                                onRefresh = { taskListViewModel.refresh() },
                             )
                         }
+
+                        // Task edit screen
                         composable(
                             route = "task_edit?taskId={taskId}",
                             arguments = listOf(
                                 navArgument("taskId") {
-                                    type = NavType.LongType
+                                    type = NavType.StringType
+                                    defaultValue = ""
                                 }
                             )
                         ) { navBackStackEntry ->
-                            val taskId = navBackStackEntry.arguments?.getLong("taskId") ?: 0
+                            val taskId = navBackStackEntry.arguments?.getString("taskId") ?: ""
                             val context = LocalContext.current
-                            val editViewModel: TaskEditViewModel = viewModel(
+                            val editViewModel: OfflineTaskEditViewModel = viewModel(
                                 viewModelStoreOwner = navBackStackEntry,
-                                factory = TaskEditViewModelFactory(
-                                    applicationContext = context.applicationContext,
-                                    taskId = taskId,
+                                factory = OfflineTaskEditViewModelFactory(
+                                    application = context.applicationContext as android.app.Application,
+                                    taskId = taskId.ifEmpty { null },
                                 )
                             )
                             val uiState = editViewModel.uiState.collectAsStateWithLifecycle().value
-                            LaunchedEffect(uiState.error) {
-                                if (uiState.error) {
-                                    navController.popBackStack()
-                                }
-                            }
-                            LaunchedEffect(Unit) {
-                                editViewModel.navigateBack.collect {
-                                    navController.popBackStack()
-                                }
-                            }
-                            TaskEditScreen(
+                            OfflineTaskEditScreen(
                                 uiState = uiState,
-                                setTitle = { editViewModel.setTitle(it) },
-                                toggleCompleted = { editViewModel.setCompleted(!uiState.completed) { navController.popBackStack() } },
-                                save = { editViewModel.save { navController.popBackStack() } },
-                                back = { navController.popBackStack() },
+                                onTitleChange = { editViewModel.setTitle(it) },
+                                onNotesChange = { editViewModel.setNotes(it) },
+                                onToggleCompleted = { editViewModel.toggleCompleted() },
+                                onSave = { editViewModel.save { navController.popBackStack() } },
+                                onDelete = { editViewModel.delete { navController.popBackStack() } },
+                                onBack = { navController.popBackStack() },
+                                onSetDueDate = { editViewModel.setDueDate(it) },
+                                onSetDueTime = { editViewModel.setDueTime(it) },
+                                onToggleReminder = { editViewModel.toggleReminder() },
+                                onShowDatePicker = { editViewModel.showDatePicker(true) },
+                                onShowTimePicker = { editViewModel.showTimePicker(true) },
+                                onClearDueDate = { editViewModel.clearDueDate() },
+                                onDismissDatePicker = { editViewModel.showDatePicker(false) },
+                                onDismissTimePicker = { editViewModel.showTimePicker(false) },
                             )
                         }
-                        composable(
-                            route = "menu",
-                        ) {
-                            MenuScreen(
-                                items = menuItems,
-                                selectFilter = {
-                                    settingsViewModel.setFilter(it.id)
-                                    navController.popBackStack()
-                                },
-                            )
-                        }
-                        composable(
-                            route = "settings",
-                        ) {
-                            val viewState =
-                                settingsViewModel.viewState.collectAsStateWithLifecycle().value
-                            SettingsScreen(
-                                showHidden = viewState.showHidden,
-                                showCompleted = viewState.showCompleted,
-                                sortMode = viewState.sortMode,
-                                groupMode = viewState.groupMode,
+
+                        // Settings screen
+                        composable("settings") {
+                            val viewState = settingsViewModel.viewState.collectAsStateWithLifecycle().value
+                            OfflineSettingsScreen(
+                                viewState = viewState,
                                 toggleShowHidden = { settingsViewModel.setShowHidden(it) },
                                 toggleShowCompleted = { settingsViewModel.setShowCompleted(it) },
-                                openSortPicker = { navController.navigate("sort_picker") },
-                                openGroupPicker = { navController.navigate("group_picker") },
-                            )
-                        }
-                        composable(
-                            route = "sort_picker",
-                        ) {
-                            val viewState =
-                                settingsViewModel.viewState.collectAsStateWithLifecycle().value
-                            SortPickerScreen(
-                                selected = viewState.sortMode,
-                                includeNone = false,
-                                onSelect = {
-                                    settingsViewModel.setSortMode(it)
-                                    navController.popBackStack()
-                                },
-                            )
-                        }
-                        composable(
-                            route = "group_picker",
-                        ) {
-                            val viewState =
-                                settingsViewModel.viewState.collectAsStateWithLifecycle().value
-                            SortPickerScreen(
-                                selected = viewState.groupMode,
-                                includeNone = true,
-                                onSelect = {
-                                    settingsViewModel.setGroupMode(it)
-                                    navController.popBackStack()
-                                },
                             )
                         }
                     }
+                }
+            }
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    // Already granted
+                }
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }
             }
         }

--- a/wear/src/main/java/org/tasks/presentation/components/Card.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/Card.kt
@@ -1,3 +1,16 @@
+/**
+ * Card.kt — Reusable card wrapper for Wear OS list items.
+ *
+ * Wraps the standard Wear [Card] composable with a simpler API
+ * that provides:
+ * - A flat [backgroundColor] (no gradient) via [ColorPainter].
+ * - Zero content padding so callers can control their own spacing.
+ * - An optional leading [icon] slot (e.g. a checkbox) aligned vertically
+ *   with the main [content] in a [Row].
+ *
+ * Used by [TaskCard], [EmptyCard], and anywhere a clickable card is needed
+ * in the task list.
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,6 +24,14 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Card
 import androidx.wear.compose.material.MaterialTheme
 
+/**
+ * A simplified card composable for Wear OS.
+ *
+ * @param backgroundColor Background color of the card (defaults to the theme surface color).
+ * @param icon            Optional leading composable (e.g. a [Checkbox]).
+ * @param onClick         Callback when the card is tapped.
+ * @param content         The main body composable rendered in a [RowScope].
+ */
 @Composable
 fun Card(
     backgroundColor: Color = MaterialTheme.colors.surface,

--- a/wear/src/main/java/org/tasks/presentation/components/Checkbox.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/Checkbox.kt
@@ -1,3 +1,16 @@
+/**
+ * Checkbox.kt — Task completion checkbox for the Wear OS task list.
+ *
+ * Renders a tappable icon that reflects the current completion state of a task:
+ * - **Completed** → filled check box icon
+ * - **Repeating** → repeat icon (to signal recurring tasks)
+ * - **Incomplete** → empty check box outline
+ *
+ * The icon color is derived from the task's priority using [ColorProvider.priorityColor]
+ * (higher priority → more vivid color).
+ *
+ * Used inside [TaskRow] as the leading icon of each task card.
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.material.icons.Icons
@@ -11,6 +24,14 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import org.tasks.kmp.org.tasks.themes.ColorProvider
 
+/**
+ * Tappable checkbox icon showing the task's completion state.
+ *
+ * @param completed      Whether the task is marked as done.
+ * @param repeating      Whether the task is recurring.
+ * @param priority       Task priority (0–3); determines icon tint color.
+ * @param toggleComplete Callback invoked when the user taps the checkbox.
+ */
 @Composable
 fun Checkbox(
     completed: Boolean,

--- a/wear/src/main/java/org/tasks/presentation/components/Chevron.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/Chevron.kt
@@ -1,3 +1,13 @@
+/**
+ * Chevron.kt — Expand/collapse chevron indicator.
+ *
+ * Displays a small down-pointing or up-pointing chevron icon
+ * to indicate whether a group of subtasks is collapsed or expanded.
+ *
+ * Used inside [TaskCard] when the task has subtasks ([numSubtasks] > 0).
+ *
+ * @param collapsed `true` → shows ExpandMore (▼); `false` → shows ExpandLess (▲).
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.animation.core.animateFloatAsState

--- a/wear/src/main/java/org/tasks/presentation/components/CollapsibleHeader.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/CollapsibleHeader.kt
@@ -1,3 +1,14 @@
+/**
+ * CollapsibleHeader.kt — Tappable section header with an animated chevron.
+ *
+ * Used in the task list to render group headers (e.g. "Overdue", "Today")
+ * that the user can tap to collapse or expand. Delegates rendering to
+ * [Header] and appends a [Chevron] after the title text.
+ *
+ * @param title     The section label (e.g. "Today").
+ * @param collapsed `true` if the section is currently collapsed.
+ * @param onClick   Callback to toggle the collapsed state.
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.foundation.layout.Spacer

--- a/wear/src/main/java/org/tasks/presentation/components/EmptyCard.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/EmptyCard.kt
@@ -1,3 +1,11 @@
+/**
+ * EmptyCard.kt — Placeholder card used for visual padding/spacing.
+ *
+ * Renders an empty, non-interactive card. Useful at the bottom of a
+ * [ScalingLazyColumn] to ensure the last real item can scroll fully
+ * into view on round Wear screens.
+ */
+
 package org.tasks.presentation.components
 
 import androidx.compose.runtime.Composable

--- a/wear/src/main/java/org/tasks/presentation/components/Header.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/Header.kt
@@ -1,3 +1,12 @@
+/**
+ * Header.kt — Section header for Wear OS scrollable lists.
+ *
+ * Renders a centered, horizontally-padded row that can optionally be tappable.
+ * There are two overloads:
+ * - `Header(text)` — Non-clickable; just renders a centered [Text].
+ * - `Header(clickable, onClick, content)` — Optionally clickable; accepts
+ *   arbitrary composable content (used by [CollapsibleHeader]).
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.foundation.clickable

--- a/wear/src/main/java/org/tasks/presentation/components/TaskCard.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/TaskCard.kt
@@ -1,3 +1,25 @@
+/**
+ * TaskCard.kt — Visual card for a single task in the Wear OS task list.
+ *
+ * Layout:
+ * ```
+ * ┌──────────────────────────────────────────────┐
+ * │ [icon]  Task title text       Timestamp / ▼  │
+ * │                              (subtask count)  │
+ * └──────────────────────────────────────────────┘
+ * ```
+ *
+ * Features:
+ * - Leading [icon] slot (typically a [Checkbox] from [TaskRow]).
+ * - Two-line ellipsised title with optional 60 % opacity for hidden tasks.
+ * - If the task has subtasks, a clickable button with a [Chevron] and subtask
+ *   count replaces the plain timestamp.
+ * - Otherwise a small [Timestamp] label is rendered on the right.
+ *
+ * @see TaskRow   — Convenience wrapper that plugs a [Checkbox] into the icon slot.
+ * @see Chevron   — Animated expand/collapse arrow.
+ * @see Timestamp — Tiny caption showing the task's due date/time.
+ */
 package org.tasks.presentation.components
 
 import androidx.compose.foundation.layout.Column

--- a/wear/src/main/java/org/tasks/presentation/components/TaskRow.kt
+++ b/wear/src/main/java/org/tasks/presentation/components/TaskRow.kt
@@ -1,0 +1,45 @@
+/**
+ * TaskRow.kt — Convenience composable that wires a [Checkbox] into a [TaskCard].
+ *
+ * This is the composable used by [OfflineTaskListScreen] to render each task
+ * in the scrollable list. It maps the [TaskLite] model to the visual [TaskCard]
+ * and handles the three user interactions:
+ *
+ * 1. **Tap the card** → opens the task for editing ([onClick]).
+ * 2. **Tap the checkbox** → toggles completion ([onToggleComplete]).
+ * 3. **Tap the subtask button** → collapses/expands subtasks ([onToggleSubtasks]).
+ */
+package org.tasks.presentation.components
+
+import androidx.compose.runtime.Composable
+import org.tasks.presentation.model.TaskLite
+
+/**
+ * A row component for displaying a task in a list.
+ * Combines TaskCard with a Checkbox for task completion.
+ */
+@Composable
+fun TaskRow(
+    task: TaskLite,
+    onClick: () -> Unit,
+    onToggleComplete: () -> Unit,
+    onToggleSubtasks: () -> Unit,
+) {
+    TaskCard(
+        text = task.title,
+        timestamp = task.timestamp,
+        hidden = task.hidden,
+        numSubtasks = task.numSubtasks,
+        subtasksCollapsed = task.collapsed,
+        toggleSubtasks = onToggleSubtasks,
+        icon = {
+            Checkbox(
+                completed = task.completed,
+                repeating = task.repeating,
+                priority = task.priority,
+                toggleComplete = onToggleComplete,
+            )
+        },
+        onClick = onClick,
+    )
+}

--- a/wear/src/main/java/org/tasks/presentation/model/TaskLite.kt
+++ b/wear/src/main/java/org/tasks/presentation/model/TaskLite.kt
@@ -1,0 +1,35 @@
+/**
+ * TaskLite.kt — Lightweight read-only model exposed to the Wear UI layer.
+ *
+ * [TaskLite] is the UI-facing projection of [TaskEntity]. It strips sync-
+ * related metadata (dirty, syncedAt, phoneTaskId, per-field timestamps)
+ * and adds a [stringId] field used as a stable key in [ScalingLazyColumn].
+ *
+ * Conversion: [TaskEntity.toTaskLite()] (extension in [TaskRepository]).
+ */
+package org.tasks.presentation.model
+
+/**
+ * Lightweight task model for the Wear app.
+ * Will be replaced by Room entity in the future.
+ */
+data class TaskLite(
+    val id: Long,
+    val stringId: String = "", // Original string ID for unique keys
+    val title: String,
+    val notes: String = "",
+    val updatedAt: Long = System.currentTimeMillis(),
+    val timestamp: String? = null,
+    val completed: Boolean = false,
+    val hidden: Boolean = false,
+    val numSubtasks: Int = 0,
+    val collapsed: Boolean = false,
+    val indent: Int = 0,
+    val repeating: Boolean = false,
+    val priority: Int = 0,
+    // Date/time and reminder fields
+    val dueDate: Long? = null,
+    val dueTime: Long? = null,
+    val reminder: Boolean = false,
+    val reminderTime: Long? = null,
+)

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsScreen.kt
@@ -1,0 +1,170 @@
+/**
+ * OfflineSettingsScreen.kt — Settings screen for the Wear OS Tasks app.
+ *
+ * Provides two toggles:
+ * - **Show completed tasks** — when off, completed tasks are hidden from the list.
+ * - **Show hidden tasks** — when off, tasks flagged as hidden are filtered out.
+ *
+ * Also displays a read-only connection-status row so the user knows whether
+ * the watch is currently paired with the phone.
+ *
+ * All settings are persisted to the local Room database via
+ * [OfflineSettingsViewModel] / [SettingsRepository] and take effect immediately.
+ */
+package org.tasks.presentation.screens
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.google.android.horologist.compose.material.ToggleChip
+import com.google.android.horologist.compose.material.ToggleChipToggleControl
+import org.jetbrains.compose.resources.stringResource
+import org.tasks.data.sync.SyncState
+import org.tasks.presentation.theme.TasksTheme
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.show_completed
+import tasks.kmp.generated.resources.show_unstarted
+
+/**
+ * Settings screen that works offline.
+ * Shows connection status and syncs with phone when available.
+ */
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun OfflineSettingsScreen(
+    viewState: OfflineSettingsViewState,
+    toggleShowHidden: (Boolean) -> Unit,
+    toggleShowCompleted: (Boolean) -> Unit,
+) {
+    val columnState = rememberResponsiveColumnState()
+    ScreenScaffold(
+        scrollState = columnState,
+    ) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            columnState = columnState,
+        ) {
+            // Connection status indicator
+            item(key = "offline_settings_connection_status") {
+                ConnectionStatusChip(
+                    isConnected = viewState.isConnected,
+                    syncState = viewState.syncState,
+                )
+            }
+
+            // Show hidden (unstarted) toggle
+            item(key = "offline_settings_show_hidden") {
+                ToggleChip(
+                    checked = viewState.showHidden,
+                    onCheckedChanged = { toggleShowHidden(it) },
+                    label = stringResource(Res.string.show_unstarted),
+                    toggleControl = ToggleChipToggleControl.Switch,
+                )
+            }
+
+            // Show completed toggle
+            item(key = "offline_settings_show_completed") {
+                ToggleChip(
+                    checked = viewState.showCompleted,
+                    onCheckedChanged = { toggleShowCompleted(it) },
+                    label = stringResource(Res.string.show_completed),
+                    toggleControl = ToggleChipToggleControl.Switch,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Chip showing connection status.
+ */
+@Composable
+private fun ConnectionStatusChip(
+    isConnected: Boolean,
+    syncState: SyncState,
+) {
+    Row(
+        modifier = Modifier.padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when {
+            syncState == SyncState.SYNCING -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Syncing...",
+                    style = MaterialTheme.typography.caption2,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                )
+            }
+            isConnected -> {
+                Icon(
+                    imageVector = Icons.Outlined.Cloud,
+                    contentDescription = "Connected",
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colors.primary,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Connected",
+                    style = MaterialTheme.typography.caption2,
+                    color = MaterialTheme.colors.primary,
+                )
+            }
+            else -> {
+                Icon(
+                    imageVector = Icons.Outlined.CloudOff,
+                    contentDescription = "Offline",
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colors.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Offline mode",
+                    style = MaterialTheme.typography.caption2,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OfflineSettingsScreenPreview() {
+    TasksTheme {
+        OfflineSettingsScreen(
+            viewState = OfflineSettingsViewState(
+                isConnected = true,
+                syncState = SyncState.IDLE,
+                showHidden = true,
+                showCompleted = false,
+            ),
+            toggleShowHidden = {},
+            toggleShowCompleted = {},
+        )
+    }
+}

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsScreen.kt
@@ -95,9 +95,6 @@ fun OfflineSettingsScreen(
     }
 }
 
-/**
- * Chip showing connection status.
- */
 @Composable
 private fun ConnectionStatusChip(
     isConnected: Boolean,

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsViewModel.kt
@@ -1,0 +1,194 @@
+/**
+ * OfflineSettingsViewModel.kt — ViewModel for the Wear OS settings screen.
+ *
+ * ## Responsibilities
+ * - Reads settings from [SettingsRepository] (Room-backed).
+ * - Polls phone connectivity via [NodeClient] every 5 seconds.
+ * - Combines settings + connectivity + sync state into
+ *   [OfflineSettingsViewState] exposed as [viewState].
+ * - Provides write methods ([setShowHidden], [setShowCompleted], etc.)
+ *   that persist to Room and attempt a sync when connected.
+ *
+ * ## Data flow
+ * ```
+ * SettingsEntity (Flow)        ─┐
+ * isConnected (MutableState)   ─┤── combine ──▶ OfflineSettingsViewState
+ * syncState (StateFlow)        ─┘
+ * ```
+ */
+package org.tasks.presentation.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.wearable.NodeClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.tasks.data.local.SettingsEntity
+import org.tasks.data.local.SettingsRepository
+import org.tasks.data.sync.DataLayerSyncManager
+import org.tasks.data.sync.SyncState
+import timber.log.Timber
+
+/**
+ * UI state for the offline-capable settings screen.
+ */
+data class OfflineSettingsViewState(
+    val initialized: Boolean = false,
+    val showHidden: Boolean = false,
+    val showCompleted: Boolean = false,
+    val filter: String = "",
+    val collapsedGroups: Set<Long> = emptySet(),
+    val isConnected: Boolean = false,
+    val syncState: SyncState = SyncState.IDLE,
+)
+
+/**
+ * ViewModel for settings that works offline.
+ * Stores settings locally and syncs with phone when connected.
+ */
+class OfflineSettingsViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val settingsRepository = SettingsRepository.getInstance(application)
+    private val syncManager = DataLayerSyncManager.getInstance(application)
+    private val nodeClient: NodeClient = Wearable.getNodeClient(application)
+
+    private val _isConnected = MutableStateFlow(false)
+
+    val viewState: StateFlow<OfflineSettingsViewState> = combine(
+        settingsRepository.getSettings(),
+        _isConnected,
+        syncManager.syncState,
+    ) { settings, connected, syncState ->
+        OfflineSettingsViewState(
+            initialized = true,
+            showHidden = settings.showHidden,
+            showCompleted = settings.showCompleted,
+            filter = settings.filter,
+            collapsedGroups = settings.collapsedGroups
+                .split(",")
+                .filter { it.isNotBlank() }
+                .mapNotNull { it.toLongOrNull() }
+                .toSet(),
+            isConnected = connected,
+            syncState = syncState,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = OfflineSettingsViewState()
+    )
+
+    init {
+        // Ensure settings exist
+        viewModelScope.launch {
+            settingsRepository.ensureSettingsExist()
+        }
+
+        // Check connection status periodically
+        checkConnectionStatus()
+
+        // Start sync manager listener
+        syncManager.startListening()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        syncManager.stopListening()
+    }
+
+    /**
+     * Check if phone is connected using NodeClient.
+     */
+    private fun checkConnectionStatus() {
+        viewModelScope.launch {
+            // Check periodically
+            while (true) {
+                try {
+                    val connectedNodes = nodeClient.connectedNodes.await()
+                    _isConnected.value = connectedNodes.isNotEmpty()
+                    Timber.d("Phone connection status: ${_isConnected.value}")
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to check connection status")
+                    _isConnected.value = false
+                }
+                // Check every 5 seconds
+                delay(5000)
+            }
+        }
+    }
+
+    /**
+     * Set show hidden setting (works offline).
+     */
+    fun setShowHidden(showHidden: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setShowHidden(showHidden)
+            trySyncSettings()
+        }
+    }
+
+    /**
+     * Set show completed setting (works offline).
+     */
+    fun setShowCompleted(showCompleted: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setShowCompleted(showCompleted)
+            trySyncSettings()
+        }
+    }
+
+    /**
+     * Set filter (works offline).
+     */
+    fun setFilter(filter: String) {
+        viewModelScope.launch {
+            settingsRepository.setFilter(filter)
+            trySyncSettings()
+        }
+    }
+
+    /**
+     * Toggle group collapsed state (works offline).
+     */
+    fun toggleGroup(groupId: Long, collapsed: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.toggleGroupCollapsed(groupId, collapsed)
+            trySyncSettings()
+        }
+    }
+
+    /**
+     * Try to sync settings with phone if connected.
+     */
+    private suspend fun trySyncSettings() {
+        if (_isConnected.value) {
+            try {
+                syncManager.processPendingOps()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to sync settings")
+            }
+        }
+    }
+
+    /**
+     * Force refresh connection status and sync.
+     */
+    fun refresh() {
+        checkConnectionStatus()
+        viewModelScope.launch {
+            syncManager.processPendingOps()
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineSettingsViewModel.kt
@@ -56,6 +56,7 @@ data class OfflineSettingsViewState(
  * ViewModel for settings that works offline.
  * Stores settings locally and syncs with phone when connected.
  */
+@Suppress("TooGenericExceptionCaught")
 class OfflineSettingsViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
@@ -108,9 +109,6 @@ class OfflineSettingsViewModel(
         syncManager.stopListening()
     }
 
-    /**
-     * Check if phone is connected using NodeClient.
-     */
     private fun checkConnectionStatus() {
         viewModelScope.launch {
             // Check periodically
@@ -169,9 +167,6 @@ class OfflineSettingsViewModel(
         }
     }
 
-    /**
-     * Try to sync settings with phone if connected.
-     */
     private suspend fun trySyncSettings() {
         if (_isConnected.value) {
             try {

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditScreen.kt
@@ -1,0 +1,802 @@
+/**
+ * OfflineTaskEditScreen.kt — Create / Edit screen for a single task on Wear OS.
+ *
+ * ## Layout (top → bottom inside a [ScalingLazyColumn]):
+ *
+ * 1. **Connection status** — small banner showing phone connectivity.
+ * 2. **Title field** — inline [BasicTextField]; tapping opens the soft keyboard.
+ *    Pressing the IME "Done" action saves the text and dismisses the keyboard.
+ * 3. **Notes field** — same pattern as title.
+ * 4. **Due date chip** — opens [WearDatePicker] (day / month / year wheels with haptic).
+ * 5. **Due time chip** — opens [WearTimePicker] (24 h hour / minute wheels with haptic).
+ * 6. **Reminder toggle** — enables/disables the notification for this task.
+ * 7. **Save button** — persists the task to Room and queues a sync operation.
+ * 8. **Delete button** — only shown when editing an existing task.
+ *
+ * ## Date/Time pickers
+ * [WearDatePicker] and [WearTimePicker] are custom Wear Compose pickers
+ * that use the Horologist [Picker] component with rotary-scroll support
+ * and haptic feedback on value changes.
+ *
+ * ## Keyboard handling
+ * The screen uses `imeOptions = IME_ACTION_DONE` so that the physical
+ * hardware enter key on some Wear keyboards triggers a save-and-close
+ * instead of inserting a newline.
+ *
+ * @see OfflineTaskEditViewModel — drives the state for this screen.
+ * @see WearDatePicker             — date selection with day/month/year wheels.
+ * @see WearTimePicker             — 24-hour time selection with hour/minute wheels.
+ */
+package org.tasks.presentation.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Picker
+import androidx.wear.compose.material.Switch
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.ToggleChip
+import androidx.wear.compose.material.ToggleChipDefaults
+import androidx.wear.compose.material.rememberPickerState
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import org.tasks.presentation.components.Checkbox
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Task edit screen that works fully offline.
+ * Saves to local database and syncs when connected.
+ */
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun OfflineTaskEditScreen(
+    uiState: OfflineEditUiState,
+    onTitleChange: (String) -> Unit,
+    onNotesChange: (String) -> Unit,
+    onToggleCompleted: () -> Unit,
+    onSave: () -> Unit,
+    onDelete: () -> Unit,
+    onBack: () -> Unit,
+    onSetDueDate: (Long?) -> Unit = {},
+    onSetDueTime: (Long?) -> Unit = {},
+    onToggleReminder: () -> Unit = {},
+    onShowDatePicker: () -> Unit = {},
+    onShowTimePicker: () -> Unit = {},
+    onClearDueDate: () -> Unit = {},
+    onDismissDatePicker: () -> Unit = {},
+    onDismissTimePicker: () -> Unit = {},
+) {
+    // Show date picker dialog if requested
+    if (uiState.showDatePicker) {
+        WearDatePicker(
+            initialDate = uiState.dueDate,
+            onDateSelected = { date ->
+                onSetDueDate(date)
+                onDismissDatePicker()
+            },
+            onDismiss = onDismissDatePicker,
+        )
+        return
+    }
+
+    // Show time picker dialog if requested
+    if (uiState.showTimePicker) {
+        WearTimePicker(
+            initialTime = uiState.dueTime,
+            onTimeSelected = { time ->
+                onSetDueTime(time)
+                onDismissTimePicker()
+            },
+            onDismiss = onDismissTimePicker,
+        )
+        return
+    }
+    val columnState = rememberResponsiveColumnState()
+
+
+    if (uiState.isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            columnState = columnState,
+        ) {
+            // Title with connection status
+            item(key = "offline_edit_header") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = if (uiState.taskId != null) "Edit Task" else "New Task",
+                        style = MaterialTheme.typography.title3,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    // Connection indicator
+                    Icon(
+                        imageVector = if (uiState.isConnected)
+                            Icons.Outlined.Cloud
+                        else
+                            Icons.Outlined.CloudOff,
+                        contentDescription = if (uiState.isConnected) "Connected" else "Offline",
+                        modifier = Modifier.size(14.dp),
+                        tint = if (uiState.isConnected)
+                            MaterialTheme.colors.primary
+                        else
+                            MaterialTheme.colors.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Checkbox for completion status
+            item(key = "offline_edit_checkbox") {
+                Checkbox(
+                    completed = uiState.completed,
+                    repeating = uiState.repeating,
+                    priority = uiState.priority,
+                    toggleComplete = onToggleCompleted
+                )
+            }
+
+            // Title input - inline text field
+            item(key = "offline_edit_title_input") {
+                val keyboardController = LocalSoftwareKeyboardController.current
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "Title",
+                        style = MaterialTheme.typography.caption2,
+                        color = MaterialTheme.colors.onSurfaceVariant,
+                    )
+                    BasicTextField(
+                        value = uiState.title,
+                        onValueChange = { newValue ->
+                            // Remove newlines - Enter should save, not add newline
+                            onTitleChange(newValue.replace("\n", ""))
+                        },
+                        textStyle = MaterialTheme.typography.body1.copy(
+                            color = MaterialTheme.colors.onSurface
+                        ),
+                        cursorBrush = SolidColor(MaterialTheme.colors.primary),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                keyboardController?.hide()
+                            }
+                        ),
+                        decorationBox = { innerTextField ->
+                            Box {
+                                if (uiState.title.isEmpty()) {
+                                    Text(
+                                        text = "Enter title...",
+                                        style = MaterialTheme.typography.body1,
+                                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f)
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
+                    )
+                    // Underline
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(MaterialTheme.colors.onSurface.copy(alpha = 0.3f))
+                    )
+                }
+            }
+
+            // Notes input - inline text field
+            item(key = "offline_edit_notes_input") {
+                val keyboardController = LocalSoftwareKeyboardController.current
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "Notes",
+                        style = MaterialTheme.typography.caption2,
+                        color = MaterialTheme.colors.onSurfaceVariant,
+                    )
+                    BasicTextField(
+                        value = uiState.notes,
+                        onValueChange = { newValue ->
+                            // Remove newlines - Enter should save, not add newline
+                            onNotesChange(newValue.replace("\n", ""))
+                        },
+                        textStyle = MaterialTheme.typography.body1.copy(
+                            color = MaterialTheme.colors.onSurface
+                        ),
+                        cursorBrush = SolidColor(MaterialTheme.colors.primary),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                keyboardController?.hide()
+                            }
+                        ),
+                        decorationBox = { innerTextField ->
+                            Box {
+                                if (uiState.notes.isEmpty()) {
+                                    Text(
+                                        text = "Add notes...",
+                                        style = MaterialTheme.typography.body1,
+                                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f)
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
+                    )
+                    // Underline
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(MaterialTheme.colors.onSurface.copy(alpha = 0.3f))
+                    )
+                }
+            }
+
+            // Due date section
+            item(key = "offline_edit_duedate_label") {
+                Text(
+                    text = "Due Date",
+                    style = MaterialTheme.typography.caption1,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                )
+            }
+
+            // Due date chip
+            item(key = "offline_edit_duedate_chip") {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Chip(
+                        onClick = onShowDatePicker,
+                        label = {
+                            Text(
+                                text = uiState.dueDate?.let { formatDate(it) } ?: "Set date",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.CalendarToday,
+                                contentDescription = "Date",
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        colors = ChipDefaults.secondaryChipColors(),
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (uiState.dueDate != null) {
+                        Button(
+                            onClick = onClearDueDate,
+                            colors = ButtonDefaults.iconButtonColors(),
+                            modifier = Modifier
+                                .padding(start = 4.dp)
+                                .size(32.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Close,
+                                contentDescription = "Clear",
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Due time chip (only show if date is set)
+            if (uiState.dueDate != null) {
+                item(key = "offline_edit_duetime_chip") {
+                    Chip(
+                        onClick = onShowTimePicker,
+                        label = {
+                            Text(
+                                text = uiState.dueTime?.let { formatTime(it) } ?: "Set time",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.AccessTime,
+                                contentDescription = "Time",
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        colors = ChipDefaults.secondaryChipColors(),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            // Reminder toggle
+            item(key = "offline_edit_reminder_toggle") {
+                ToggleChip(
+                    checked = uiState.reminder,
+                    onCheckedChange = { onToggleReminder() },
+                    label = {
+                        Text(
+                            text = "Reminder",
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    appIcon = {
+                        Icon(
+                            imageVector = if (uiState.reminder)
+                                Icons.Outlined.Notifications
+                            else
+                                Icons.Outlined.NotificationsOff,
+                            contentDescription = "Reminder",
+                            modifier = Modifier.size(16.dp),
+                        )
+                    },
+                    toggleControl = {
+                        Switch(
+                            checked = uiState.reminder,
+                        )
+                    },
+                    colors = ToggleChipDefaults.toggleChipColors(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                )
+            }
+
+            // Save button
+            item(key = "offline_edit_save_button") {
+                Button(
+                    onClick = onSave,
+                    enabled = !uiState.isSaving && uiState.title.isNotBlank(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.colors.primary,
+                        contentColor = MaterialTheme.colors.onPrimary,
+                    )
+                ) {
+                    if (uiState.isSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Text(
+                            text = if (uiState.isConnected) "Save" else "Save (offline)",
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+
+            // Delete button (only for existing tasks)
+            if (uiState.taskId != null) {
+                item(key = "offline_edit_delete_button") {
+                    Button(
+                        onClick = onDelete,
+                        enabled = !uiState.isSaving,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = MaterialTheme.colors.error,
+                            contentColor = MaterialTheme.colors.onError,
+                        )
+                    ) {
+                        Text(
+                            text = "Delete",
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Format a timestamp as a date string.
+ */
+private fun formatDate(timestamp: Long): String {
+    val formatter = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+    return formatter.format(Date(timestamp))
+}
+
+/**
+ * Format a timestamp as a time string.
+ */
+private fun formatTime(timestamp: Long): String {
+    val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
+    return formatter.format(Date(timestamp))
+}
+
+/**
+ * Wear OS Date Picker using Picker component with haptic feedback.
+ */
+@Composable
+fun WearDatePicker(
+    initialDate: Long?,
+    onDateSelected: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val haptic = LocalHapticFeedback.current
+    val calendar = remember {
+        Calendar.getInstance().apply {
+            initialDate?.let { timeInMillis = it }
+        }
+    }
+
+    val currentYear = calendar.get(Calendar.YEAR)
+    val currentMonth = calendar.get(Calendar.MONTH)
+    val currentDay = calendar.get(Calendar.DAY_OF_MONTH)
+
+    // Create picker states
+    val yearState = rememberPickerState(
+        initialNumberOfOptions = 10, // 10 years range
+        initiallySelectedOption = 0, // Current year
+    )
+    val monthState = rememberPickerState(
+        initialNumberOfOptions = 12,
+        initiallySelectedOption = currentMonth,
+    )
+    val dayState = rememberPickerState(
+        initialNumberOfOptions = 31,
+        initiallySelectedOption = currentDay - 1,
+    )
+
+    val years = (currentYear..currentYear + 9).toList()
+    val months = listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+    // Track previous values to trigger haptic on change
+    val prevDay = remember { androidx.compose.runtime.mutableIntStateOf(dayState.selectedOption) }
+    val prevMonth = remember { androidx.compose.runtime.mutableIntStateOf(monthState.selectedOption) }
+    val prevYear = remember { androidx.compose.runtime.mutableIntStateOf(yearState.selectedOption) }
+
+    // Trigger haptic feedback when selection changes
+    if (dayState.selectedOption != prevDay.intValue) {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        prevDay.intValue = dayState.selectedOption
+    }
+    if (monthState.selectedOption != prevMonth.intValue) {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        prevMonth.intValue = monthState.selectedOption
+    }
+    if (yearState.selectedOption != prevYear.intValue) {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        prevYear.intValue = yearState.selectedOption
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = "Select Date",
+                style = MaterialTheme.typography.title3,
+                color = MaterialTheme.colors.primary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Day picker
+                Picker(
+                    state = dayState,
+                    modifier = Modifier.size(width = 48.dp, height = 100.dp),
+                    contentDescription = "Day",
+                    readOnly = false,
+                    userScrollEnabled = true,
+                ) { index ->
+                    Text(
+                        text = "${index + 1}",
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Month picker
+                Picker(
+                    state = monthState,
+                    modifier = Modifier.size(width = 56.dp, height = 100.dp),
+                    contentDescription = "Month",
+                    readOnly = false,
+                    userScrollEnabled = true,
+                ) { index ->
+                    Text(
+                        text = months[index],
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Year picker
+                Picker(
+                    state = yearState,
+                    modifier = Modifier.size(width = 64.dp, height = 100.dp),
+                    contentDescription = "Year",
+                    readOnly = false,
+                    userScrollEnabled = true,
+                ) { index ->
+                    Text(
+                        text = years[index].toString(),
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.secondaryButtonColors(),
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = "Cancel",
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+
+                Button(
+                    onClick = {
+                        val selectedCalendar = Calendar.getInstance().apply {
+                            set(Calendar.YEAR, years[yearState.selectedOption])
+                            set(Calendar.MONTH, monthState.selectedOption)
+                            set(Calendar.DAY_OF_MONTH, dayState.selectedOption + 1)
+                            set(Calendar.HOUR_OF_DAY, 0)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0)
+                            set(Calendar.MILLISECOND, 0)
+                        }
+                        onDateSelected(selectedCalendar.timeInMillis)
+                    },
+                    colors = ButtonDefaults.primaryButtonColors(),
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Check,
+                        contentDescription = "Confirm",
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Wear OS Time Picker using Picker component with haptic feedback (24h format).
+ */
+@Composable
+fun WearTimePicker(
+    initialTime: Long?,
+    onTimeSelected: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val haptic = LocalHapticFeedback.current
+    val calendar = remember {
+        Calendar.getInstance().apply {
+            initialTime?.let { timeInMillis = it }
+        }
+    }
+
+    val currentHour = calendar.get(Calendar.HOUR_OF_DAY)
+    val currentMinute = calendar.get(Calendar.MINUTE)
+
+    val hourState = rememberPickerState(
+        initialNumberOfOptions = 24,
+        initiallySelectedOption = currentHour,
+    )
+    val minuteState = rememberPickerState(
+        initialNumberOfOptions = 60,
+        initiallySelectedOption = currentMinute,
+    )
+
+    // Track previous values to trigger haptic on change
+    val prevHour = remember { androidx.compose.runtime.mutableIntStateOf(hourState.selectedOption) }
+    val prevMinute = remember { androidx.compose.runtime.mutableIntStateOf(minuteState.selectedOption) }
+
+    // Trigger haptic feedback when selection changes
+    if (hourState.selectedOption != prevHour.intValue) {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        prevHour.intValue = hourState.selectedOption
+    }
+    if (minuteState.selectedOption != prevMinute.intValue) {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        prevMinute.intValue = minuteState.selectedOption
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = "Select Time (24h)",
+                style = MaterialTheme.typography.title3,
+                color = MaterialTheme.colors.primary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Hour picker (24h)
+                Picker(
+                    state = hourState,
+                    modifier = Modifier.size(width = 56.dp, height = 100.dp),
+                    contentDescription = "Hour",
+                    readOnly = false,
+                    userScrollEnabled = true,
+                ) { index ->
+                    Text(
+                        text = String.format(Locale.getDefault(), "%02d", index),
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+
+                Text(
+                    text = ":",
+                    style = MaterialTheme.typography.title2,
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                )
+
+                // Minute picker
+                Picker(
+                    state = minuteState,
+                    modifier = Modifier.size(width = 56.dp, height = 100.dp),
+                    contentDescription = "Minute",
+                    readOnly = false,
+                    userScrollEnabled = true,
+                ) { index ->
+                    Text(
+                        text = String.format(Locale.getDefault(), "%02d", index),
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.secondaryButtonColors(),
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = "Cancel",
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+
+                Button(
+                    onClick = {
+                        val selectedCalendar = Calendar.getInstance().apply {
+                            set(Calendar.HOUR_OF_DAY, hourState.selectedOption)
+                            set(Calendar.MINUTE, minuteState.selectedOption)
+                            set(Calendar.SECOND, 0)
+                            set(Calendar.MILLISECOND, 0)
+                        }
+                        onTimeSelected(selectedCalendar.timeInMillis)
+                    },
+                    colors = ButtonDefaults.primaryButtonColors(),
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Check,
+                        contentDescription = "Confirm",
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditScreen.kt
@@ -92,6 +92,7 @@ import java.util.Locale
  * Saves to local database and syncs when connected.
  */
 @OptIn(ExperimentalHorologistApi::class)
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 fun OfflineTaskEditScreen(
     uiState: OfflineEditUiState,
@@ -476,17 +477,11 @@ fun OfflineTaskEditScreen(
     }
 }
 
-/**
- * Format a timestamp as a date string.
- */
 private fun formatDate(timestamp: Long): String {
     val formatter = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
     return formatter.format(Date(timestamp))
 }
 
-/**
- * Format a timestamp as a time string.
- */
 private fun formatTime(timestamp: Long): String {
     val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
     return formatter.format(Date(timestamp))
@@ -495,6 +490,7 @@ private fun formatTime(timestamp: Long): String {
 /**
  * Wear OS Date Picker using Picker component with haptic feedback.
  */
+@Suppress("LongMethod")
 @Composable
 fun WearDatePicker(
     initialDate: Long?,
@@ -664,6 +660,7 @@ fun WearDatePicker(
 /**
  * Wear OS Time Picker using Picker component with haptic feedback (24h format).
  */
+@Suppress("LongMethod")
 @Composable
 fun WearTimePicker(
     initialTime: Long?,

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditViewModel.kt
@@ -1,0 +1,311 @@
+/**
+ * OfflineTaskEditViewModel.kt — ViewModel for creating and editing a single task.
+ *
+ * ## Lifecycle
+ * - Created by [OfflineTaskEditViewModelFactory] with an optional [taskId].
+ * - If [taskId] is non-null, loads the existing task from Room on init.
+ * - Otherwise initialises a blank [OfflineEditUiState] for a new task.
+ *
+ * ## State
+ * Exposes a single [uiState] ([StateFlow]) that drives [OfflineTaskEditScreen].
+ * All mutations go through dedicated setter methods ([setTitle], [setNotes],
+ * [setDueDate], etc.) which call `_uiState.update { … }`.
+ *
+ * ## Saving
+ * [save] writes the task to Room via [TaskRepository.saveTask].
+ * The repository handles creating the outbox operation for sync.
+ * After saving, the ViewModel calls the provided [onComplete] callback
+ * (which navigates back in [MainActivity]).
+ *
+ * ## Connectivity
+ * Polls [NodeClient] every 5 s so the edit screen can show "Connected"
+ * or "Save (offline)" on the save button.
+ *
+ * ## Factory
+ * [OfflineTaskEditViewModelFactory] is needed because the ViewModel
+ * takes a constructor parameter ([taskId]) in addition to [Application].
+ */
+package org.tasks.presentation.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.wearable.NodeClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.tasks.data.local.TaskRepository
+import org.tasks.data.sync.DataLayerSyncManager
+import timber.log.Timber
+
+/**
+ * UI state for the offline task edit screen.
+ */
+data class OfflineEditUiState(
+    val isLoading: Boolean = true,
+    val taskId: String? = null,
+    val title: String = "",
+    val notes: String = "",
+    val completed: Boolean = false,
+    val priority: Int = 0,
+    val repeating: Boolean = false,
+    val isSaving: Boolean = false,
+    val isConnected: Boolean = false,
+    // Due date and time
+    val dueDate: Long? = null,
+    val dueTime: Long? = null,
+    // Reminder
+    val reminder: Boolean = false,
+    val reminderTime: Long? = null,
+    // UI state for date/time pickers
+    val showDatePicker: Boolean = false,
+    val showTimePicker: Boolean = false,
+)
+
+/**
+ * ViewModel for task editing that works fully offline.
+ * Saves to local Room database and syncs when connected.
+ */
+class OfflineTaskEditViewModel(
+    application: Application,
+    private val taskId: String?,
+) : AndroidViewModel(application) {
+
+    private val taskRepository = TaskRepository.getInstance(application)
+    private val syncManager = DataLayerSyncManager.getInstance(application)
+    private val nodeClient: NodeClient = Wearable.getNodeClient(application)
+
+    private val _uiState = MutableStateFlow(OfflineEditUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        if (!taskId.isNullOrEmpty()) {
+            loadTask(taskId)
+        } else {
+            // New task mode
+            _uiState.update {
+                it.copy(isLoading = false, taskId = null)
+            }
+        }
+        checkConnectionStatus()
+    }
+
+    /**
+     * Load task from local database.
+     */
+    private fun loadTask(id: String) {
+        viewModelScope.launch {
+            val task = taskRepository.getTask(id)
+            _uiState.update { state ->
+                if (task != null) {
+                    state.copy(
+                        isLoading = false,
+                        taskId = id,
+                        title = task.title,
+                        notes = task.notes,
+                        completed = task.completed,
+                        priority = task.priority,
+                        repeating = task.repeating,
+                        dueDate = task.dueDate,
+                        dueTime = task.dueTime,
+                        reminder = task.reminder,
+                        reminderTime = task.reminderTime,
+                    )
+                } else {
+                    // Task not found, treat as new task
+                    state.copy(isLoading = false, taskId = null)
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if phone is connected using NodeClient.
+     */
+    private fun checkConnectionStatus() {
+        viewModelScope.launch {
+            try {
+                val connectedNodes = nodeClient.connectedNodes.await()
+                _uiState.update { it.copy(isConnected = connectedNodes.isNotEmpty()) }
+                Timber.d("Edit screen connection status: ${connectedNodes.isNotEmpty()}")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to check connection status")
+                _uiState.update { it.copy(isConnected = false) }
+            }
+        }
+    }
+
+    /**
+     * Update the title.
+     */
+    fun setTitle(title: String) {
+        _uiState.update { it.copy(title = title) }
+    }
+
+    /**
+     * Update the notes.
+     */
+    fun setNotes(notes: String) {
+        _uiState.update { it.copy(notes = notes) }
+    }
+
+    /**
+     * Toggle completion status.
+     */
+    fun toggleCompleted() {
+        _uiState.update { it.copy(completed = !it.completed) }
+    }
+
+    /**
+     * Set priority.
+     */
+    fun setPriority(priority: Int) {
+        _uiState.update { it.copy(priority = priority) }
+    }
+
+    /**
+     * Set due date.
+     */
+    fun setDueDate(dueDate: Long?) {
+        _uiState.update { it.copy(dueDate = dueDate) }
+    }
+
+    /**
+     * Set due time.
+     */
+    fun setDueTime(dueTime: Long?) {
+        _uiState.update { it.copy(dueTime = dueTime) }
+    }
+
+    /**
+     * Toggle reminder.
+     */
+    fun toggleReminder() {
+        _uiState.update { state ->
+            val newReminder = !state.reminder
+            state.copy(
+                reminder = newReminder,
+                // If reminder is enabled and no reminder time is set, use due date/time
+                reminderTime = if (newReminder && state.reminderTime == null) {
+                    state.dueDate ?: state.dueTime
+                } else state.reminderTime
+            )
+        }
+    }
+
+    /**
+     * Set reminder time.
+     */
+    fun setReminderTime(reminderTime: Long?) {
+        _uiState.update { it.copy(reminderTime = reminderTime) }
+    }
+
+    /**
+     * Show/hide date picker.
+     */
+    fun showDatePicker(show: Boolean) {
+        _uiState.update { it.copy(showDatePicker = show) }
+    }
+
+    /**
+     * Show/hide time picker.
+     */
+    fun showTimePicker(show: Boolean) {
+        _uiState.update { it.copy(showTimePicker = show) }
+    }
+
+    /**
+     * Clear due date.
+     */
+    fun clearDueDate() {
+        _uiState.update { it.copy(dueDate = null, dueTime = null) }
+    }
+
+    /**
+     * Save the task to local database.
+     * Syncs automatically when phone is connected.
+     * @param onComplete callback when save is complete
+     */
+    fun save(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+
+            val state = _uiState.value
+            val savedId = taskRepository.saveTask(
+                id = state.taskId,
+                title = state.title.ifEmpty { "Untitled Task" },
+                notes = state.notes,
+                dueDate = state.dueDate,
+                dueTime = state.dueTime,
+                reminder = state.reminder,
+                reminderTime = state.reminderTime,
+            )
+
+            // Update completion status if changed
+            if (state.taskId != null) {
+                taskRepository.toggleComplete(savedId, state.completed)
+            } else if (state.completed) {
+                taskRepository.toggleComplete(savedId, true)
+            }
+
+            // Try to sync if connected
+            if (_uiState.value.isConnected) {
+                try {
+                    syncManager.processPendingOps()
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to sync after save")
+                    // Task is saved locally, will sync later
+                }
+            }
+
+            _uiState.update { it.copy(isSaving = false) }
+            onComplete()
+        }
+    }
+
+    /**
+     * Delete the current task.
+     */
+    fun delete(onComplete: () -> Unit) {
+        val id = _uiState.value.taskId ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+
+            taskRepository.deleteTask(id)
+
+            // Try to sync if connected
+            if (_uiState.value.isConnected) {
+                try {
+                    syncManager.processPendingOps()
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to sync after delete")
+                }
+            }
+
+            _uiState.update { it.copy(isSaving = false) }
+            onComplete()
+        }
+    }
+}
+
+/**
+ * Factory for creating OfflineTaskEditViewModel with taskId parameter.
+ */
+class OfflineTaskEditViewModelFactory(
+    private val application: Application,
+    private val taskId: String?,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(OfflineTaskEditViewModel::class.java)) {
+            return OfflineTaskEditViewModel(application, taskId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}
+

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskEditViewModel.kt
@@ -71,6 +71,7 @@ data class OfflineEditUiState(
  * ViewModel for task editing that works fully offline.
  * Saves to local Room database and syncs when connected.
  */
+@Suppress("TooManyFunctions", "TooGenericExceptionCaught")
 class OfflineTaskEditViewModel(
     application: Application,
     private val taskId: String?,
@@ -95,9 +96,6 @@ class OfflineTaskEditViewModel(
         checkConnectionStatus()
     }
 
-    /**
-     * Load task from local database.
-     */
     private fun loadTask(id: String) {
         viewModelScope.launch {
             val task = taskRepository.getTask(id)
@@ -124,9 +122,6 @@ class OfflineTaskEditViewModel(
         }
     }
 
-    /**
-     * Check if phone is connected using NodeClient.
-     */
     private fun checkConnectionStatus() {
         viewModelScope.launch {
             try {

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListScreen.kt
@@ -1,0 +1,237 @@
+/**
+ * OfflineTaskListScreen.kt — Main task list screen for the Wear OS app.
+ *
+ * ## Layout (top → bottom inside a [ScalingLazyColumn]):
+ *
+ * 1. **Connection banner** — shows "Connected" / "Offline" / "Syncing…"
+ *    with a cloud icon and an optional manual-sync button.
+ * 2. **Task rows** — each task is rendered via [TaskRow] ([TaskCard] +
+ *    [Checkbox]). Tapping a row navigates to [OfflineTaskEditScreen];
+ *    tapping the checkbox toggles completion.
+ * 3. **Add button** — a prominent "Add task" chip at the bottom.
+ * 4. **Settings button** — opens [OfflineSettingsScreen].
+ *
+ * ## Offline-first
+ * Tasks are loaded from the local Room database via
+ * [OfflineTaskListViewModel]. The connection banner is purely
+ * informational — all features work without a phone connection.
+ *
+ * ## State
+ * The screen is fully stateless; all state lives in
+ * [OfflineTaskListViewState] which is collected from the ViewModel's
+ * [StateFlow] in [MainActivity].
+ */
+package org.tasks.presentation.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import org.jetbrains.compose.resources.stringResource
+import org.tasks.data.sync.SyncState
+import org.tasks.presentation.components.EmptyCard
+import org.tasks.presentation.components.TaskRow
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.add_task
+
+/**
+ * Task list screen that works fully offline.
+ * Shows tasks from local database and syncs when connected.
+ */
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun OfflineTaskListScreen(
+    viewState: OfflineTaskListState,
+    onTaskClick: (String) -> Unit,
+    onToggleComplete: (String, Boolean) -> Unit,
+    onAddTask: () -> Unit,
+    openSettings: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    val columnState = rememberResponsiveColumnState()
+    ScreenScaffold(
+        scrollState = columnState,
+    ) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            columnState = columnState,
+        ) {
+            // Header with buttons
+            item(key = "header_buttons") {
+                OfflineButtonHeader(
+                    addTask = onAddTask,
+                    openSettings = openSettings,
+                    onRefresh = onRefresh,
+                )
+            }
+
+            // Connection status indicator
+            item(key = "connection_status") {
+                ConnectionStatusRow(
+                    isConnected = viewState.isConnected,
+                    syncState = viewState.syncState,
+                    hasPendingSync = viewState.hasPendingSync,
+                )
+            }
+
+            if (viewState.isLoading) {
+                item(key = "loading_indicator") {
+                    CircularProgressIndicator(
+                        modifier = Modifier.padding(top = 16.dp)
+                    )
+                }
+            } else if (viewState.tasks.isEmpty()) {
+                item(key = "empty_card") { EmptyCard() }
+            } else {
+                // Display tasks - use stringId for unique keys
+                viewState.tasks.forEachIndexed { index, task ->
+                    item(key = "task_${task.stringId}_${task.completed}_$index") {
+                        TaskRow(
+                            task = task,
+                            onClick = { onTaskClick(task.stringId) },
+                            onToggleComplete = {
+                                onToggleComplete(task.stringId, !task.completed)
+                            },
+                            onToggleSubtasks = { /* no-op for now */ },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Header with action buttons for the offline task list.
+ */
+@Composable
+private fun OfflineButtonHeader(
+    addTask: () -> Unit,
+    openSettings: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        Button(
+            onClick = onRefresh,
+            colors = ButtonDefaults.iconButtonColors(
+                contentColor = MaterialTheme.colors.onSurface,
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Sync,
+                contentDescription = "Refresh",
+            )
+        }
+        Button(
+            onClick = addTask,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = MaterialTheme.colors.onPrimary,
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Add,
+                contentDescription = stringResource(Res.string.add_task),
+            )
+        }
+        Button(
+            onClick = openSettings,
+            colors = ButtonDefaults.iconButtonColors(
+                contentColor = MaterialTheme.colors.onSurface,
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Settings,
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+/**
+ * Row showing connection status.
+ */
+@Composable
+private fun ConnectionStatusRow(
+    isConnected: Boolean,
+    syncState: SyncState,
+    hasPendingSync: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when {
+            syncState == SyncState.SYNCING -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(12.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Syncing...",
+                    style = MaterialTheme.typography.caption3,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                )
+            }
+            isConnected -> {
+                Icon(
+                    imageVector = Icons.Outlined.Cloud,
+                    contentDescription = "Connected",
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colors.primary,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Connected",
+                    style = MaterialTheme.typography.caption3,
+                    color = MaterialTheme.colors.primary,
+                )
+            }
+            else -> {
+                Icon(
+                    imageVector = Icons.Outlined.CloudOff,
+                    contentDescription = "Offline",
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colors.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = if (hasPendingSync) "Offline (pending sync)" else "Offline",
+                    style = MaterialTheme.typography.caption3,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListScreen.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListScreen.kt
@@ -63,6 +63,7 @@ import tasks.kmp.generated.resources.add_task
  * Shows tasks from local database and syncs when connected.
  */
 @OptIn(ExperimentalHorologistApi::class)
+@Suppress("LongParameterList")
 @Composable
 fun OfflineTaskListScreen(
     viewState: OfflineTaskListState,
@@ -125,9 +126,6 @@ fun OfflineTaskListScreen(
     }
 }
 
-/**
- * Header with action buttons for the offline task list.
- */
 @Composable
 private fun OfflineButtonHeader(
     addTask: () -> Unit,
@@ -175,9 +173,6 @@ private fun OfflineButtonHeader(
     }
 }
 
-/**
- * Row showing connection status.
- */
 @Composable
 private fun ConnectionStatusRow(
     isConnected: Boolean,

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListViewModel.kt
@@ -1,0 +1,262 @@
+/**
+ * OfflineTaskListViewModel.kt — ViewModel for the main task list screen.
+ *
+ * ## Responsibilities
+ * - Loads tasks from the local Room database via [TaskRepository].
+ * - Polls phone connectivity every 5 seconds via [NodeClient].
+ * - Monitors [DataLayerSyncManager.syncState] for syncing progress.
+ * - Combines all flows into a single [OfflineTaskListState] exposed as [viewState].
+ * - Provides actions: [toggleComplete], [refresh].
+ *
+ * ## Data flow
+ * ```
+ * Room DB (Flow<List<TaskLite>>)  ─┐
+ * isConnected (MutableStateFlow)  ─┤── combine ──▶ OfflineTaskListState
+ * syncState (StateFlow<SyncState>) ─┘
+ * ```
+ *
+ * When [refresh] is called the ViewModel:
+ * 1. Sends pending outbox operations to the phone.
+ * 2. Requests a full snapshot from the phone.
+ */
+package org.tasks.presentation.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.wearable.NodeClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.tasks.data.local.SettingsEntity
+import org.tasks.data.local.SettingsRepository
+import org.tasks.data.local.TaskRepository
+import org.tasks.data.sync.DataLayerSyncManager
+import org.tasks.data.sync.SyncState
+import org.tasks.presentation.model.TaskLite
+import timber.log.Timber
+
+/**
+ * UI state for the offline-capable task list screen.
+ */
+data class OfflineTaskListState(
+    val isLoading: Boolean = true,
+    val tasks: List<TaskLite> = emptyList(),
+    val settings: SettingsEntity = SettingsEntity(),
+    val isConnected: Boolean = false,
+    val syncState: SyncState = SyncState.IDLE,
+    val hasPendingSync: Boolean = false,
+)
+
+/**
+ * ViewModel for task list that works fully offline.
+ * Reads tasks from local Room database and syncs when connected.
+ */
+class OfflineTaskListViewModel(
+    application: Application
+) : AndroidViewModel(application) {
+
+    private val taskRepository = TaskRepository.getInstance(application)
+    private val settingsRepository = SettingsRepository.getInstance(application)
+    private val syncManager = DataLayerSyncManager.getInstance(application)
+    private val nodeClient: NodeClient = Wearable.getNodeClient(application)
+
+    private val _isLoading = MutableStateFlow(true)
+    private val _isConnected = MutableStateFlow(false)
+    private val _hasPendingSync = MutableStateFlow(false)
+
+    val viewState: StateFlow<OfflineTaskListState> = combine(
+        taskRepository.getTasks(),
+        settingsRepository.getSettings(),
+        syncManager.syncState,
+        _isConnected,
+        _isLoading,
+    ) { tasks, settings, syncState, connected, loading ->
+        // Apply filters based on settings
+        val filteredTasks = filterTasks(tasks, settings)
+
+        OfflineTaskListState(
+            isLoading = loading,
+            tasks = filteredTasks,
+            settings = settings,
+            isConnected = connected,
+            syncState = syncState,
+            hasPendingSync = syncState == SyncState.SYNCING,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = OfflineTaskListState()
+    )
+
+    init {
+        viewModelScope.launch {
+            // Ensure settings and sample data exist
+            settingsRepository.ensureSettingsExist()
+            taskRepository.insertSampleDataIfEmpty()
+            _isLoading.value = false
+
+            // Try initial sync if connected
+            try {
+                val connectedNodes = nodeClient.connectedNodes.await()
+                if (connectedNodes.isNotEmpty()) {
+                    _isConnected.value = true
+                    Timber.d("Initial connection detected, requesting sync")
+                    syncManager.processPendingOps()
+                    syncManager.requestSync()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to check initial connection")
+            }
+        }
+
+        // Start listening for sync events
+        syncManager.startListening()
+
+        // Check connection status periodically
+        checkConnectionStatus()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        syncManager.stopListening()
+    }
+
+    /**
+     * Filter tasks based on current settings.
+     */
+    private fun filterTasks(tasks: List<TaskLite>, settings: SettingsEntity): List<TaskLite> {
+        return tasks.filter { task ->
+            // Filter by completion status
+            val showCompleted = settings.showCompleted || !task.completed
+
+            // Filter by hidden status
+            val showHidden = settings.showHidden || !task.hidden
+
+            showCompleted && showHidden
+        }
+    }
+
+    /**
+     * Check if phone is connected using NodeClient.
+     * This checks for any connected nodes (typically the paired phone).
+     */
+    private fun checkConnectionStatus() {
+        viewModelScope.launch {
+            // Check periodically
+            while (true) {
+                try {
+                    val connectedNodes = nodeClient.connectedNodes.await()
+                    val wasConnected = _isConnected.value
+                    _isConnected.value = connectedNodes.isNotEmpty()
+                    Timber.d("Phone connection status: ${_isConnected.value} (${connectedNodes.size} nodes)")
+
+                    // If just connected, sync pending operations and request full sync
+                    if (_isConnected.value && !wasConnected) {
+                        Timber.d("Connection restored, syncing with phone")
+                        syncManager.processPendingOps()
+                        syncManager.requestSync()
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to check connection status")
+                    _isConnected.value = false
+                }
+
+                // Check every 5 seconds
+                delay(5000)
+            }
+        }
+    }
+
+    /**
+     * Toggle task completion (works offline).
+     */
+    fun toggleComplete(taskId: String, completed: Boolean) {
+        viewModelScope.launch {
+            taskRepository.toggleComplete(taskId, completed)
+            trySyncPendingOps()
+        }
+    }
+
+    /**
+     * Delete a task (works offline).
+     */
+    fun deleteTask(taskId: String) {
+        viewModelScope.launch {
+            taskRepository.deleteTask(taskId)
+            trySyncPendingOps()
+        }
+    }
+
+    /**
+     * Toggle group collapsed state (works offline).
+     */
+    fun toggleGroup(groupId: Long, collapsed: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.toggleGroupCollapsed(groupId, collapsed)
+        }
+    }
+
+    /**
+     * Try to sync pending operations if connected.
+     */
+    private suspend fun trySyncPendingOps() {
+        if (_isConnected.value) {
+            try {
+                syncManager.processPendingOps()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to sync pending operations")
+            }
+        }
+    }
+
+    /**
+     * Force refresh: check connection, sync pending ops, and request full sync from phone.
+     */
+    fun refresh() {
+        viewModelScope.launch {
+            // First check connection status
+            try {
+                val connectedNodes = nodeClient.connectedNodes.await()
+                _isConnected.value = connectedNodes.isNotEmpty()
+                Timber.d("Refresh: connection status = ${_isConnected.value}")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to check connection status")
+                _isConnected.value = false
+            }
+
+            // If connected, sync pending ops and request full sync
+            if (_isConnected.value) {
+                try {
+                    // Process any pending outbox operations
+                    syncManager.processPendingOps()
+                    // Request full sync from phone
+                    syncManager.requestSync()
+                    Timber.d("Refresh: requested sync from phone")
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to sync")
+                }
+            }
+        }
+    }
+
+    /**
+     * Request a full sync from phone.
+     */
+    fun requestSync() {
+        viewModelScope.launch {
+            try {
+                syncManager.requestSync()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to request sync")
+            }
+        }
+    }
+}

--- a/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListViewModel.kt
+++ b/wear/src/main/java/org/tasks/presentation/screens/OfflineTaskListViewModel.kt
@@ -59,6 +59,7 @@ data class OfflineTaskListState(
  * ViewModel for task list that works fully offline.
  * Reads tasks from local Room database and syncs when connected.
  */
+@Suppress("TooGenericExceptionCaught")
 class OfflineTaskListViewModel(
     application: Application
 ) : AndroidViewModel(application) {
@@ -129,9 +130,6 @@ class OfflineTaskListViewModel(
         syncManager.stopListening()
     }
 
-    /**
-     * Filter tasks based on current settings.
-     */
     private fun filterTasks(tasks: List<TaskLite>, settings: SettingsEntity): List<TaskLite> {
         return tasks.filter { task ->
             // Filter by completion status
@@ -144,10 +142,6 @@ class OfflineTaskListViewModel(
         }
     }
 
-    /**
-     * Check if phone is connected using NodeClient.
-     * This checks for any connected nodes (typically the paired phone).
-     */
     private fun checkConnectionStatus() {
         viewModelScope.launch {
             // Check periodically
@@ -204,9 +198,6 @@ class OfflineTaskListViewModel(
         }
     }
 
-    /**
-     * Try to sync pending operations if connected.
-     */
     private suspend fun trySyncPendingOps() {
         if (_isConnected.value) {
             try {


### PR DESCRIPTION
# Pull Request: Standalone Offline Support and Bidirectional Sync for Wear OS

## Description

This PR introduces comprehensive offline support and real-time bidirectional synchronization for the **Wear OS module**. Prior to this change, the Wear app had limited offline capabilities and was highly dependent on constant connectivity with the phone app. 

With this update, the watch app gains a fully-functional local persistence layer, allowing users to view, create, edit, and complete tasks offline, with changes automatically queued and synced when the connection is restored.

---

## Key Features & Changes

### 1. Local Database & Persistence Layer (Wear Module)
*   Implemented a local SQLite database using **Room** ([WearDatabase.kt](wear/src/main/java/org/tasks/data/local/WearDatabase.kt)).
*   Added core entities and DAOs for local storage:
    *   `TaskEntity`: Local cache of tasks synced with the phone.
    *   `OutboxOpEntity`: Queue of watch-to-phone synchronization operations.
    *   `ProcessedOpEntity`: Tracking for incoming phone operations to guarantee message idempotency.
    *   `SettingsEntity`: Stores local user preferences.

### 2. Standalone Compose UI (Wear Module)
Added standalone screens and ViewModels built with Wear Compose for independent watch operation:
*   `OfflineTaskListScreen`: Displays task lists with status filters.
*   `OfflineTaskEditScreen`: Enables creating and editing tasks (title, notes, due date, reminders).
*   `OfflineSettingsScreen`: Local preferences and settings management.

### 3. Bidirectional Sync Architecture
*   **Watch-to-Phone Sync:** Mutations on the watch are written atomically to the local `tasks` table and the `outbox_ops` queue in a single transaction. The sync manager drains the queue to the phone over the Wearable Data Layer API.
*   **Phone-to-Watch Sync:** Hooked up a new `WearSyncNotifier` interface in the common KMP layer. Task saving, completion, and deletion events on the phone immediately notify the Wear OS data client to push updates to the watch.
*   **Conflict Resolution:** Implemented per-field last-write-wins (LWW) conflict resolution in both directions. Fields (title, notes, completed status) are merged independently based on update timestamps relative to the baseline modification dates, minimizing data loss.

### 4. Build & CI Stability
*   Modified signing configurations in both `app` and `wear` build files to gracefully fall back to debug signing when custom release keystores are not configured in local project properties.

---

## Files Modified / Added

### Wear OS Module
*   [WearDatabase.kt](wear/src/main/java/org/tasks/data/local/WearDatabase.kt) — Room database setup.
*   [SyncProtocol.kt](wear/src/main/java/org/tasks/data/sync/SyncProtocol.kt) — Data Layer paths and keys mapping.
*   [SyncRepository.kt](wear/src/main/java/org/tasks/data/sync/SyncRepository.kt) — Transactional sync and conflict resolution engine.
*   [MainActivity.kt (presentation)](wear/src/main/java/org/tasks/presentation/MainActivity.kt) — Root Compose UI.

### Common KMP Module
*   [WearSyncNotifier.kt](kmp/src/commonMain/kotlin/org/tasks/wear/WearSyncNotifier.kt) — Common interface for platform notifications.
*   [TaskSaver.kt](kmp/src/commonMain/kotlin/org/tasks/data/TaskSaver.kt) — Integrates change trigger events.
*   [TaskDeleter.kt](kmp/src/commonMain/kotlin/org/tasks/service/TaskDeleter.kt) — Integrates delete trigger events.

### Phone Module (App)
*   [PhoneSyncManager.kt](app/src/googleplay/java/org/tasks/wear/PhoneSyncManager.kt) — Processes watch ops and applies LWW conflict resolution.
*   [WearRefresherImpl.kt](app/src/googleplay/java/org/tasks/wear/WearRefresherImpl.kt) — Triggers single-task pushes.
*   [WearSyncNotifierImpl.kt](app/src/main/java/org/tasks/wear/WearSyncNotifierImpl.kt) — Lazy DI implementation to break dependency cycles.