### PR TITLE
Allow persistent notifications on Android 14+ depending on appops

### DIFF
--- a/app/src/main/java/com/todoroo/andlib/utility/AndroidUtilities.kt
+++ b/app/src/main/java/com/todoroo/andlib/utility/AndroidUtilities.kt
@@ -5,6 +5,8 @@
  */
 package com.todoroo.andlib.utility
 
+import android.app.AppOpsManager
+import android.content.Context
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Looper
@@ -37,6 +39,19 @@ object AndroidUtilities {
     fun convertDpToPixels(displayMetrics: DisplayMetrics, dp: Int): Int {
         // developer.android.com/guide/practices/screens_support.html#dips-pels
         return (dp * displayMetrics.density + 0.5f).toInt()
+    }
+
+    fun allowsNonDismissibleNotifications(context: Context?): Boolean {
+        if (preUpsideDownCake()) return true
+        return context?.let {
+            val appOps = it.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+            val mode = appOps.checkOpNoThrow(
+                "android:system_exempt_from_dismissible_notifications",
+                it.applicationInfo.uid,
+                it.applicationInfo.packageName
+            )
+            return mode == AppOpsManager.MODE_ALLOWED
+        } ?: false
     }
 
     fun preS(): Boolean {

--- a/app/src/main/java/org/tasks/compose/settings/NotificationsScreen.kt
+++ b/app/src/main/java/org/tasks/compose/settings/NotificationsScreen.kt
@@ -27,6 +27,7 @@ fun NotificationsScreen(
     showBatteryOptimization: Boolean,
     completionSoundName: String,
     showPreUpsideDownCake: Boolean,
+    showPersistentReminders: Boolean,
     persistentEnabled: Boolean,
     wearableEnabled: Boolean,
     bundleEnabled: Boolean,
@@ -108,7 +109,9 @@ fun NotificationsScreen(
             modifier = Modifier.padding(horizontal = SettingsContentPadding),
             verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
         ) {
-            val total = 3 + (if (showPreUpsideDownCake) 2 else 0)
+            var total = 3
+            if (showPreUpsideDownCake) total += 1
+            if (showPersistentReminders) total += 1
             var i = 0
 
             SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
@@ -118,7 +121,7 @@ fun NotificationsScreen(
                     onClick = onCompletionSound,
                 )
             }
-            if (showPreUpsideDownCake) {
+            if (showPersistentReminders) {
                 SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
                     SwitchPreferenceRow(
                         title = stringResource(R.string.persistent_notifications),
@@ -127,6 +130,8 @@ fun NotificationsScreen(
                         onCheckedChange = onPersistent,
                     )
                 }
+            }
+            if (showPreUpsideDownCake) {
                 SettingsItemCard(position = CardPosition.forIndex(i++, total)) {
                     SwitchPreferenceRow(
                         title = stringResource(R.string.wearable_notifications),

--- a/app/src/main/java/org/tasks/notifications/NotificationManager.kt
+++ b/app/src/main/java/org/tasks/notifications/NotificationManager.kt
@@ -245,7 +245,7 @@ class NotificationManager @Inject constructor(
             notification.flags = notification.flags or NotificationCompat.FLAG_INSISTENT
             ringTimes = 1
         }
-        if (preferences.usePersistentReminders()) {
+        if (preferences.usePersistentReminders(context)) {
             notification.flags = notification.flags or
                     NotificationCompat.FLAG_NO_CLEAR or
                     NotificationCompat.FLAG_ONGOING_EVENT

--- a/app/src/main/java/org/tasks/preferences/Preferences.kt
+++ b/app/src/main/java/org/tasks/preferences/Preferences.kt
@@ -481,8 +481,8 @@ class Preferences @JvmOverloads constructor(
 
     fun bundleNotifications(): Boolean = getBoolean(R.string.p_bundle_notifications, true)
 
-    fun usePersistentReminders(): Boolean =
-            AndroidUtilities.preUpsideDownCake() && getBoolean(R.string.p_rmd_persistent, true)
+    fun usePersistentReminders(context: Context): Boolean =
+            AndroidUtilities.allowsNonDismissibleNotifications(context) && getBoolean(R.string.p_rmd_persistent, true)
 
     fun useSwipeToSnooze(): Boolean =
             getBoolean(R.string.p_rmd_swipe_to_snooze_enabled, false)

--- a/app/src/main/java/org/tasks/preferences/fragments/Notifications.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/Notifications.kt
@@ -100,6 +100,7 @@ class Notifications : Fragment() {
                 showBatteryOptimization = viewModel.showBatteryOptimization,
                 completionSoundName = viewModel.completionSoundName,
                 showPreUpsideDownCake = AndroidUtilities.preUpsideDownCake(),
+                showPersistentReminders = AndroidUtilities.allowsNonDismissibleNotifications(context),
                 persistentEnabled = viewModel.persistentEnabled,
                 wearableEnabled = viewModel.wearableEnabled,
                 bundleEnabled = viewModel.bundleEnabled,


### PR DESCRIPTION
This is related to #2753: I've been using this patch for a few months after upgrading from Android 10 to Android 16 and thought it could be useful to others. Although it _should_ not break anything, it's very specific so feel free to reject it, that would be totally understandable!

Android 14 doesn't allow non-dismissable notifications, but there's an appops flag that can be set to restore the permission: `appops set --uid org.tasks SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow`

I personally set the flag from `adb`, but apparently it's also doable as a normal app using Shizuku (I saw [NotiFixer](https://github.com/dkajan19/NotiFixer) but haven't tested it).

I think setting the flag from the app if Shizuku is available is completely out of scope here, but checking if it's set is quite easy so that's what this patch sticks to.

Sadly there's no well-known constant provided by the Android SDK which means we have to use [the string from the framework constant `OPSTR_SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/core/java/android/app/AppOpsManager.java#2362) directly. I think that's acceptable? If for some reason a future Android version removes the permission, the check should silently fall back to `false`, which would be just like the current behavior.

If accepted, I can also prepare another PR to update the docs and point users to this (advanced) solution.

---

_Note for more context as to why I initially decided to patch this: I know about the option of setting the swipe to snooze option to bring back the notification immediately, but one thing I really love about persistent notifications is that they enable keeping track of how long the notification has been sitting there in my notification tray._

_In a way this allows me to quickly know for how long I've been avoiding a given task. The "swipe" option recreates a brand new notification, which means an accidental swipe resets that "counter" (unavoidable of course)_