### PR TITLE
chore: gitleaks baseline for upstream artifacts

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,48 @@
+# gitleaks baseline — known-benign UPSTREAM tasks.org artifacts (2026-07-19).
+#
+# Provenance: this repo is a fork of the open-source tasks.org Android app.
+# Every entry below is upstream content, not ours, and not a live Gomu secret:
+#   - google-services.json `gcp-api-key` hits: Firebase Android config files.
+#     These API keys are client-side identifiers upstream ships in the public
+#     repo (standard for google-services.json; not private credentials).
+#   - InventoryTest.kt `generic-api-key` hits: hardcoded fake purchase-token
+#     test fixtures in upstream billing unit tests.
+# Scoped per finding as path:rule:line fingerprints (never blanket paths), so
+# any NEW secret — even in these same files — still fires.
+#
+# Entry format: gitleaks matches the finding fingerprint EXACTLY as computed
+# for the scan invocation:
+#   - `gitleaks dir <path>` fingerprints are prefixed with <path> as given, so
+#     each finding appears twice below: once repo-relative (for in-repo scans,
+#     `gitleaks dir .`) and once with the canonical checkout path used by the
+#     weekly security sweep (`gitleaks dir /Users/gomu/gomu/code/tasks-org`).
+#   - `gitleaks git` fingerprints are commit:path:rule:line (checkout-independent).
+
+# --- dir scan, repo-relative form ---
+app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:111
+app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:112
+app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:113
+app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:114
+app/src/debug/google-services.json:gcp-api-key:24
+app/src/generic/google-services.json:gcp-api-key:24
+app/src/release/google-services.json:gcp-api-key:24
+composeApp/src/debug/google-services.json:gcp-api-key:24
+composeApp/src/release/google-services.json:gcp-api-key:24
+wear/src/debug/google-services.json:gcp-api-key:24
+wear/src/release/google-services.json:gcp-api-key:24
+
+# --- dir scan, canonical gomu-trailer checkout form (weekly sweep invocation) ---
+/Users/gomu/gomu/code/tasks-org/app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:111
+/Users/gomu/gomu/code/tasks-org/app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:112
+/Users/gomu/gomu/code/tasks-org/app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:113
+/Users/gomu/gomu/code/tasks-org/app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:114
+/Users/gomu/gomu/code/tasks-org/app/src/debug/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/app/src/generic/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/app/src/release/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/composeApp/src/debug/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/composeApp/src/release/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/wear/src/debug/google-services.json:gcp-api-key:24
+/Users/gomu/gomu/code/tasks-org/wear/src/release/google-services.json:gcp-api-key:24
+
+# --- git scan (commit-pinned; upstream sync commit touching a Firebase config) ---
+2a886ad43d4216d41ea6affdb9ac2349f60a6d2c:app/src/generic/google-services.json:gcp-api-key:24


### PR DESCRIPTION
The weekly security sweep (gomu `ops/security-sweep.sh` STEP 3b) cried CRITICAL on this repo every run over 11 known-benign upstream tasks.org artifacts. This adds a `.gitleaksignore` baselining exactly those findings — path:rule:line fingerprints, never blanket paths, so any NEW secret (even in these same files) still fires.

## The 11 findings (fingerprints; secrets redacted by policy)

Firebase client config `gcp-api-key` (upstream ships these in the public repo; client-side identifiers, not private creds) — 7:
- `app/src/debug/google-services.json:gcp-api-key:24`
- `app/src/generic/google-services.json:gcp-api-key:24` (in the geo-marker checkout tree; also commit-pinned `2a886ad4…` for the git-mode scan)
- `app/src/release/google-services.json:gcp-api-key:24`
- `composeApp/src/debug/google-services.json:gcp-api-key:24`
- `composeApp/src/release/google-services.json:gcp-api-key:24`
- `wear/src/debug/google-services.json:gcp-api-key:24`
- `wear/src/release/google-services.json:gcp-api-key:24`

Upstream billing test fixtures `generic-api-key` (fake purchase tokens in `InventoryTest.kt`) — 4:
- `app/src/androidTestGoogleplay/java/org/tasks/billing/InventoryTest.kt:generic-api-key:111` … `:114`

## Why each finding appears twice

gitleaks matches `.gitleaksignore` fingerprints VERBATIM as computed for the scan invocation: `gitleaks dir <path>` prefixes fingerprints with `<path>` as given (verified empirically on 8.30.1). So each dir finding is listed repo-relative (in-repo scans) AND with the canonical `/Users/gomu/gomu/code/tasks-org` prefix (the sweep's invocation). git-mode fingerprints are commit-pinned and checkout-independent.

## Verification (gitleaks 8.30.1)

- Sweep-replica `gitleaks dir -i <this branch> /Users/gomu/gomu/code/tasks-org` → no unignored leaks, rc=0
- Sweep-replica `gitleaks git --log-opts=--since=8.days -i <this branch> /Users/gomu/gomu/code/tasks-org` → no leaks, rc=0
- In-repo `gitleaks dir .` and `gitleaks git --log-opts=--since=8.days .` on this branch → rc=0

Note: the sweep reads the ignore file from the LIVE checkout (`-i <repo>`), so it stays red until this lands on the checked-out branch (`geo-marker-promote-worker` — merge main into it or rebase after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Rt6LGEXvovCab3Vw63e9P