### PR TITLE
Only log task list query text when the query is slow

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
+++ b/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
@@ -434,10 +434,17 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
                         }
                     }
                 }
+                var submitted: SectionedDataSource? = null
                 listViewModel.state.collect {
                     val results = it.tasks
                     if (results is TasksResults.Results) {
-                        submitList(results.tasks)
+                        // State also changes for things the list doesn't depend on, such as the
+                        // sync indicator. Resubmitting the same results would diff the list
+                        // against itself on every one of those.
+                        if (results.tasks !== submitted) {
+                            submitted = results.tasks
+                            submitList(results.tasks)
+                        }
                         if (results.tasks.isEmpty()) {
                             swipeRefreshLayout.visibility = View.GONE
                             emptyRefreshLayout.visibility = View.VISIBLE

--- a/app/src/main/java/org/tasks/tasklist/TaskViewHolder.kt
+++ b/app/src/main/java/org/tasks/tasklist/TaskViewHolder.kt
@@ -85,6 +85,24 @@ class TaskViewHolder internal constructor(
     private val debugDirty: View = binding.debugDirty
     private val alwaysDisplayFullDate: Boolean = preferences.alwaysDisplayFullDate
 
+    // Resolved once per view holder rather than on every bind - theme attribute lookups allocate a
+    // TypedArray, and preference reads go through a string resource lookup. Preference changes
+    // restart the activity, which recreates these view holders.
+    private val onSurface: Int =
+        MaterialColors.getColor(context, com.google.android.material.R.attr.colorOnSurface, 0)
+    private val onSurfaceDim: Int = ColorUtils.setAlphaComponent(onSurface, 0x61)
+    private val onSurfaceVariant: Int =
+        MaterialColors.getColor(context, com.google.android.material.R.attr.colorOnSurfaceVariant, 0)
+    private val chipAppearance: Int = preferences.getIntegerFromString(R.string.p_chip_appearance, 0)
+    private val showDescription: Boolean = preferences.getBoolean(R.string.p_show_description, true)
+    private val linkifyTaskList: Boolean = preferences.getBoolean(R.string.p_linkify_task_list, false)
+    private val showListChip: Boolean = preferences.showListChip
+    private val showSubtaskChip: Boolean = preferences.showSubtaskChip
+    private val showStartDateChip: Boolean = preferences.showStartDateChip
+    private val showPlaceChip: Boolean = preferences.showPlaceChip
+    private val showTagChip: Boolean = preferences.showTagChip
+    private val is24HourFormat: Boolean = context.is24HourFormat
+
     lateinit var task: TaskContainer
 
     var indent = 0
@@ -167,11 +185,11 @@ class TaskViewHolder internal constructor(
             sortByStartDate = sortMode == SORT_START,
             sortByList = sortMode == SORT_LIST
         )
-        if (preferences.getBoolean(R.string.p_show_description, true)) {
+        if (showDescription) {
             markdown.setMarkdown(description, task.notes)
             description.visibility = if (task.task.hasNotes()) View.VISIBLE else View.GONE
         }
-        if (markdown.enabled || preferences.getBoolean(R.string.p_linkify_task_list, false)) {
+        if (markdown.enabled || linkifyTaskList) {
             if (!markdown.enabled) {
                 Linkify.safeLinkify(nameView)
                 Linkify.safeLinkify(description)
@@ -204,8 +222,6 @@ class TaskViewHolder internal constructor(
     }
 
     private fun setupTitleAndCheckbox() {
-        val onSurface = MaterialColors.getColor(context, com.google.android.material.R.attr.colorOnSurface, 0)
-        val onSurfaceDim = ColorUtils.setAlphaComponent(onSurface, 0x61)
         if (task.isCompleted) {
             nameView.setTextColor(onSurfaceDim)
             nameView.paintFlags = nameView.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
@@ -223,19 +239,19 @@ class TaskViewHolder internal constructor(
             if (task.task.isOverdue) {
                 dueDate.setTextColor(textColorOverdue)
             } else {
-                dueDate.setTextColor(MaterialColors.getColor(context, com.google.android.material.R.attr.colorOnSurfaceVariant, 0))
+                dueDate.setTextColor(onSurfaceVariant)
             }
             val dateValue: String? = if (sortByDueDate
                     && (task.sortGroup ?: 0) >= currentTimeMillis().startOfDay()
             ) {
                 task.takeIf { it.hasDueTime() }?.let {
-                    formatTime(task.dueDate, context.is24HourFormat)
+                    formatTime(task.dueDate, is24HourFormat)
                 }
             } else {
                 runBlocking {
                     getRelativeDateTime(
                         task.dueDate,
-                        context.is24HourFormat,
+                        is24HourFormat,
                         alwaysDisplayFullDate = alwaysDisplayFullDate
                     )
                 }
@@ -257,11 +273,26 @@ class TaskViewHolder internal constructor(
         val place = task.location?.place
         val list = task.caldav
         val tagsString = task.tagsString
-        val appearance = preferences.getIntegerFromString(R.string.p_chip_appearance, 0)
-        val showText = appearance != 2
-        val showIcon = appearance != 1
+        val showText = chipAppearance != 2
+        val showIcon = chipAppearance != 1
         val toggleSubtasks = { task: Long, collapsed: Boolean -> callback.toggleSubtasks(task, collapsed) }
         val onClick = { it: Filter -> callback.onClick(it) }
+        // Deliberately conservative: `indent` is not assigned until after bindView returns, and the
+        // list and tag chips can still resolve to nothing. Over-reporting only costs an empty
+        // chip row, which is what every task rendered before.
+        val hasChips =
+            (children > 0 && showSubtaskChip) ||
+                    (isHidden && showStartDateChip) ||
+                    (place != null && filter !is PlaceFilter && showPlaceChip) ||
+                    (!sortByList && showListChip && filter !is CaldavFilter) ||
+                    (!tagsString.isNullOrBlank() && showTagChip)
+        if (!hasChips) {
+            // Composing a themed, empty chip row for every chipless task is pure overhead on the
+            // scroll path. The view still measures to zero height either way, so clearing the
+            // content leaves the layout unchanged.
+            chipGroup.setContent {}
+            return
+        }
         chipGroup.setContent {
             TasksTheme(
                 theme = theme.themeBase.index,
@@ -273,7 +304,7 @@ class TaskViewHolder internal constructor(
                         bottom = rowPaddingDp.dp
                     )
                 ) {
-                    if (children > 0 && remember { preferences.showSubtaskChip }) {
+                    if (children > 0 && showSubtaskChip) {
                         SubtaskChip(
                             collapsed = collapsed,
                             children = children,
@@ -282,7 +313,7 @@ class TaskViewHolder internal constructor(
                     }
                     if (
                         isHidden &&
-                        remember { preferences.showStartDateChip } &&
+                        showStartDateChip &&
                         startDate != task.dueDate &&
                         startDate != task.dueDate.startOfDay()
                     ) {
@@ -294,7 +325,7 @@ class TaskViewHolder internal constructor(
                             colorProvider = { chipProvider.getColor(it) },
                         )
                     }
-                    if (place != null && filter !is PlaceFilter && remember { preferences.showPlaceChip }) {
+                    if (place != null && filter !is PlaceFilter && showPlaceChip) {
                         FilterChip(
                             filter = PlaceFilter(place),
                             defaultIcon = TasksIcons.PLACE,
@@ -308,7 +339,7 @@ class TaskViewHolder internal constructor(
                     if (
                         indent == 0 &&
                         !sortByList &&
-                        preferences.showListChip &&
+                        showListChip &&
                         filter !is CaldavFilter
                     ) {
                         remember(list, chipProvider.lists.listsCount) {
@@ -324,7 +355,7 @@ class TaskViewHolder internal constructor(
                             )
                         }
                     }
-                    if (!tagsString.isNullOrBlank() && remember { preferences.showTagChip }) {
+                    if (!tagsString.isNullOrBlank() && showTagChip) {
                         remember(tagsString, filter, chipProvider.lists.tagsVersion) {
                             val tags = tagsString.split(",").toHashSet()
                             if (filter is TagFilter) {

--- a/app/src/main/java/org/tasks/ui/CheckBoxProvider.kt
+++ b/app/src/main/java/org/tasks/ui/CheckBoxProvider.kt
@@ -14,13 +14,13 @@ class CheckBoxProvider @Inject constructor(
     @param:ActivityContext private val context: Context,
     private val colorProvider: ColorProvider
 ) {
+    private val cache = mutableMapOf<Long, Drawable>()
+
     /**
      * Inflating and mutating a vector drawable is expensive, and the task list asks for one on
      * every row bind. There are only a handful of (icon, priority) combinations, so tinted
      * drawables are cached and shared via their constant state.
      */
-    private val cache = mutableMapOf<Long, Drawable>()
-
     fun getCheckBox(task: Task) = getDrawable(task.getCheckboxRes(), task.priority)
 
     private fun getDrawable(@DrawableRes resId: Int, priority: Int): Drawable =

--- a/app/src/main/java/org/tasks/ui/CheckBoxProvider.kt
+++ b/app/src/main/java/org/tasks/ui/CheckBoxProvider.kt
@@ -14,14 +14,24 @@ class CheckBoxProvider @Inject constructor(
     @param:ActivityContext private val context: Context,
     private val colorProvider: ColorProvider
 ) {
+    /**
+     * Inflating and mutating a vector drawable is expensive, and the task list asks for one on
+     * every row bind. There are only a handful of (icon, priority) combinations, so tinted
+     * drawables are cached and shared via their constant state.
+     */
+    private val cache = mutableMapOf<Long, Drawable>()
+
     fun getCheckBox(task: Task) = getDrawable(task.getCheckboxRes(), task.priority)
 
-    private fun getDrawable(@DrawableRes resId: Int, priority: Int): Drawable {
-        val original = AppCompatResources.getDrawable(context, resId)
-        val wrapped = original!!.mutate()
-        wrapped.setTint(colorProvider.getPriorityColor(priority))
-        return wrapped
-    }
+    private fun getDrawable(@DrawableRes resId: Int, priority: Int): Drawable =
+        cache
+            .getOrPut((resId.toLong() shl 32) or (priority.toLong() and 0xFFFFFFFFL)) {
+                val original = AppCompatResources.getDrawable(context, resId)
+                val wrapped = original!!.mutate()
+                wrapped.setTint(colorProvider.getPriorityColor(priority))
+                wrapped
+            }
+            .let { it.constantState?.newDrawable(context.resources) ?: it }
 
     companion object {
         fun Task.getCheckboxRes() = getCheckboxRes(isCompleted, isRecurring)

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
@@ -23,9 +23,23 @@ import org.tasks.time.DateTimeUtils2
 
 private const val MAX_TIME = 9999999999999
 
-// Kermit defaults to verbose, so the query logging below runs in release builds too - don't
-// recompile this on every query.
 private val WHITESPACE = Regex("\\s+")
+
+/**
+ * Kermit's minimum severity defaults to verbose and the release build never raises it, so this
+ * runs in production. Collapsing several KB of SQL into one line is far too costly to do on every
+ * query, and the timing alone answers the usual question. The query text is only worth the cost
+ * when it is the slow one.
+ */
+private const val LOG_QUERY_TEXT_ABOVE_MS = 100
+
+private fun logQuery(query: String, durationMs: Long) = Logger.v("TaskDao") {
+    if (durationMs >= LOG_QUERY_TEXT_ABOVE_MS) {
+        "${durationMs}ms: ${query.replace(WHITESPACE, " ").trim()}"
+    } else {
+        "${durationMs}ms"
+    }
+}
 
 @Dao
 abstract class TaskDao(private val database: Database) {
@@ -113,8 +127,7 @@ FROM (
     suspend fun fetchTasks(query: String): List<TaskContainer> {
         val start = DateTimeUtils2.currentTimeMillis()
         val result = fetchRaw(RoomRawQuery(query))
-        val end = DateTimeUtils2.currentTimeMillis()
-        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(WHITESPACE, " ").trim()}" }
+        logQuery(query, DateTimeUtils2.currentTimeMillis() - start)
         return result
     }
 
@@ -124,8 +137,7 @@ FROM (
     suspend fun count(query: String): Int {
         val start = DateTimeUtils2.currentTimeMillis()
         val result = countRaw(RoomRawQuery(query))
-        val end = DateTimeUtils2.currentTimeMillis()
-        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(WHITESPACE, " ").trim()}" }
+        logQuery(query, DateTimeUtils2.currentTimeMillis() - start)
         return result
     }
 

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
@@ -27,13 +27,11 @@ private val WHITESPACE = Regex("\\s+")
 
 private const val LOG_QUERY_TEXT_ABOVE_MS = 100
 
-/**
- * Kermit's minimum severity defaults to verbose and the release build never raises it, so this
- * runs in production. Collapsing several KB of SQL into one line is far too costly to do on every
- * query, and the timing alone answers the usual question. The query text is only worth the cost
- * when it is the slow one.
- */
 private fun logQuery(query: String, durationMs: Long) = Logger.v("TaskDao") {
+    // Kermit's minimum severity defaults to verbose and the release build never raises it, so
+    // this runs in production. Collapsing several KB of SQL into one line is far too costly to do
+    // on every query, and the timing alone answers the usual question. The query text is only
+    // worth the cost when it is the slow one.
     if (durationMs >= LOG_QUERY_TEXT_ABOVE_MS) {
         "${durationMs}ms: ${query.replace(WHITESPACE, " ").trim()}"
     } else {

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
@@ -23,6 +23,10 @@ import org.tasks.time.DateTimeUtils2
 
 private const val MAX_TIME = 9999999999999
 
+// Kermit defaults to verbose, so the query logging below runs in release builds too - don't
+// recompile this on every query.
+private val WHITESPACE = Regex("\\s+")
+
 @Dao
 abstract class TaskDao(private val database: Database) {
 
@@ -110,7 +114,7 @@ FROM (
         val start = DateTimeUtils2.currentTimeMillis()
         val result = fetchRaw(RoomRawQuery(query))
         val end = DateTimeUtils2.currentTimeMillis()
-        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(Regex("\\s+"), " ").trim()}" }
+        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(WHITESPACE, " ").trim()}" }
         return result
     }
 
@@ -121,7 +125,7 @@ FROM (
         val start = DateTimeUtils2.currentTimeMillis()
         val result = countRaw(RoomRawQuery(query))
         val end = DateTimeUtils2.currentTimeMillis()
-        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(Regex("\\s+"), " ").trim()}" }
+        Logger.v("TaskDao") { "${end - start}ms: ${query.replace(WHITESPACE, " ").trim()}" }
         return result
     }
 

--- a/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/dao/TaskDao.kt
@@ -25,14 +25,14 @@ private const val MAX_TIME = 9999999999999
 
 private val WHITESPACE = Regex("\\s+")
 
+private const val LOG_QUERY_TEXT_ABOVE_MS = 100
+
 /**
  * Kermit's minimum severity defaults to verbose and the release build never raises it, so this
  * runs in production. Collapsing several KB of SQL into one line is far too costly to do on every
  * query, and the timing alone answers the usual question. The query text is only worth the cost
  * when it is the slow one.
  */
-private const val LOG_QUERY_TEXT_ABOVE_MS = 100
-
 private fun logQuery(query: String, durationMs: Long) = Logger.v("TaskDao") {
     if (durationMs >= LOG_QUERY_TEXT_ABOVE_MS) {
         "${durationMs}ms: ${query.replace(WHITESPACE, " ").trim()}"

--- a/kmp/src/androidMain/kotlin/Platform.android.kt
+++ b/kmp/src/androidMain/kotlin/Platform.android.kt
@@ -13,6 +13,7 @@ import org.tasks.kmp.org.tasks.time.toFormatStyle
 import org.tasks.kmp.org.tasks.time.toLocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 actual fun formatNumber(number: Int) = Locale.getDefault().formatNumber(number)
 
@@ -24,11 +25,15 @@ actual val PROD_ID = "+//IDN tasks.org//android-${BuildConfig.VERSION_CODE}//EN"
 
 actual val DEV_URL: String = BuildConfig.DEV_URL
 
-actual fun formatDate(timestamp: Long, style: DateStyle): String =
-    DateTimeFormatter
-        .ofLocalizedDate(style.toFormatStyle())
-        .withLocale(Locale.getDefault())
-        .format(timestamp.toLocalDateTime().toLocalDate())
+private val dateFormatters = ConcurrentHashMap<String, DateTimeFormatter>()
+
+actual fun formatDate(timestamp: Long, style: DateStyle): String {
+    val locale = Locale.getDefault()
+    val formatter = dateFormatters.getOrPut("$locale|$style") {
+        DateTimeFormatter.ofLocalizedDate(style.toFormatStyle()).withLocale(locale)
+    }
+    return formatter.format(timestamp.toLocalDateTime().toLocalDate())
+}
 
 actual fun formatTime(timestamp: Long, is24HourFormat: Boolean): String =
     formatTimeString(timestamp.toLocalDateTime(), is24HourFormat)

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
@@ -55,6 +55,10 @@ class ChipDataProvider(
                 CaldavFilter(calendar = list, account = account)
             }
             .associateBy { filter -> filter.uuid }
+        // Syncing writes to the calendar and account tables constantly - sync tokens, ctags, error
+        // state - and every write emits here. Broadcasting a refresh on each one re-ran the task
+        // list query and rebuilt the whole list repeatedly for the duration of a sync. Only a
+        // change to what a chip actually renders needs to reach the list.
         val changed = updated.chipAppearance() != lists.chipAppearance()
         lists = updated
         listsCount = updated.size
@@ -66,6 +70,7 @@ class ChipDataProvider(
 
     private fun updateTags(updated: List<TagData>) {
         val tags = updated.associateBy({ it.remoteId }) { TagFilter(it) }
+        // As above: only refresh the list when a tag chip would actually look different.
         val changed = tags.chipAppearance() != tagDatas.chipAppearance()
         tagDatas = tags
         if (changed) {
@@ -75,12 +80,6 @@ class ChipDataProvider(
         }
     }
 
-    /**
-     * Syncing writes to these tables constantly - sync tokens, ctags, error state, ordering - and
-     * every write emits here. Broadcasting a refresh on each one re-ran the task list query and
-     * rebuilt the whole list repeatedly for the duration of a sync. Only a change to what a chip
-     * actually renders needs to reach the list.
-     */
     private fun <K> Map<K, Filter>.chipAppearance() =
         mapValues { (_, filter) -> Triple(filter.title, filter.icon, filter.tint) }
 

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
@@ -18,6 +18,7 @@ import org.tasks.data.entity.CaldavAccount
 import org.tasks.data.entity.CaldavCalendar
 import org.tasks.data.entity.TagData
 import org.tasks.filters.CaldavFilter
+import org.tasks.filters.Filter
 import org.tasks.filters.TagFilter
 
 class ChipDataProvider(
@@ -48,23 +49,40 @@ class ChipDataProvider(
         accounts: List<CaldavAccount>,
         calendars: List<CaldavCalendar>,
     ) {
-        Logger.d("ChipDataProvider") { "Updating lists" }
-        lists = calendars
+        val updated: Map<String?, CaldavFilter> = calendars
             .mapNotNull { list ->
                 val account = accounts.find { it.uuid == list.account } ?: return@mapNotNull null
                 CaldavFilter(calendar = list, account = account)
             }
             .associateBy { filter -> filter.uuid }
-        listsCount = lists.size
-        refreshBroadcaster.broadcastRefresh()
+        val changed = updated.chipAppearance() != lists.chipAppearance()
+        lists = updated
+        listsCount = updated.size
+        if (changed) {
+            Logger.d("ChipDataProvider") { "Updating lists" }
+            refreshBroadcaster.broadcastRefresh()
+        }
     }
 
     private fun updateTags(updated: List<TagData>) {
-        Logger.d("ChipDataProvider") { "Updating tags" }
-        tagDatas = updated.associateBy({ it.remoteId }) { TagFilter(it) }
-        tagsVersion++
-        refreshBroadcaster.broadcastRefresh()
+        val tags = updated.associateBy({ it.remoteId }) { TagFilter(it) }
+        val changed = tags.chipAppearance() != tagDatas.chipAppearance()
+        tagDatas = tags
+        if (changed) {
+            Logger.d("ChipDataProvider") { "Updating tags" }
+            tagsVersion++
+            refreshBroadcaster.broadcastRefresh()
+        }
     }
+
+    /**
+     * Syncing writes to these tables constantly - sync tokens, ctags, error state, ordering - and
+     * every write emits here. Broadcasting a refresh on each one re-ran the task list query and
+     * rebuilt the whole list repeatedly for the duration of a sync. Only a change to what a chip
+     * actually renders needs to reach the list.
+     */
+    private fun <K> Map<K, Filter>.chipAppearance() =
+        mapValues { (_, filter) -> Triple(filter.title, filter.icon, filter.tint) }
 
     init {
         combine(caldavDao.watchAccounts(), caldavDao.subscribeToCalendars()) { accounts, calendars ->

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/components/IconByLabel.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/components/IconByLabel.kt
@@ -41,14 +41,14 @@ fun TasksIcon(
     }
 }
 
+private val iconCache = ConcurrentHashMap<String, Optional<ImageVector>>()
+
 /**
  * Resolving an icon means a [Class.forName] plus reflective invocation, and a miss additionally
  * costs a thrown [ClassNotFoundException]. Chips call this during composition on the main thread,
  * so results (including misses) are memoized for the lifetime of the process. The icon set is
  * static, so entries never need invalidating.
  */
-private val iconCache = ConcurrentHashMap<String, Optional<ImageVector>>()
-
 fun imageVectorByName(label: String?): ImageVector? {
     if (label == null) {
         return null

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/components/IconByLabel.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/components/IconByLabel.kt
@@ -16,6 +16,8 @@ import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.tasks.compose.pickers.label
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
 
 @Composable
 fun TasksIcon(
@@ -39,10 +41,30 @@ fun TasksIcon(
     }
 }
 
-fun imageVectorByName(label: String?): ImageVector? = label?.let {
-    val iconName = it.label
-    loadIcon("androidx.compose.material.icons.outlined.${iconName}Kt", Icons.Outlined)
-        ?: loadIcon("androidx.compose.material.icons.automirrored.outlined.${iconName}Kt", Icons.AutoMirrored.Outlined)
+/**
+ * Resolving an icon means a [Class.forName] plus reflective invocation, and a miss additionally
+ * costs a thrown [ClassNotFoundException]. Chips call this during composition on the main thread,
+ * so results (including misses) are memoized for the lifetime of the process. The icon set is
+ * static, so entries never need invalidating.
+ */
+private val iconCache = ConcurrentHashMap<String, Optional<ImageVector>>()
+
+fun imageVectorByName(label: String?): ImageVector? {
+    if (label == null) {
+        return null
+    }
+    return iconCache
+        .getOrPut(label) {
+            val iconName = label.label
+            Optional.ofNullable(
+                loadIcon("androidx.compose.material.icons.outlined.${iconName}Kt", Icons.Outlined)
+                    ?: loadIcon(
+                        "androidx.compose.material.icons.automirrored.outlined.${iconName}Kt",
+                        Icons.AutoMirrored.Outlined
+                    )
+            )
+        }
+        .orElse(null)
 }
 
 private fun loadIcon(className: String, receiver: Any): ImageVector? =

--- a/kmp/src/commonMain/kotlin/org/tasks/tasklist/HeaderFormatter.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/tasklist/HeaderFormatter.kt
@@ -6,6 +6,10 @@ import org.jetbrains.compose.resources.getString
 import org.tasks.data.dao.CaldavDao
 import org.tasks.kmp.org.tasks.time.DateStyle
 import org.tasks.kmp.org.tasks.time.getRelativeDay
+import org.tasks.time.DateTimeUtils2.currentTimeMillis
+import org.tasks.time.startOfDay
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.Volatile
 import tasks.kmp.generated.resources.Res
 import tasks.kmp.generated.resources.completed
 import tasks.kmp.generated.resources.filter_high_priority
@@ -24,7 +28,16 @@ import tasks.kmp.generated.resources.sort_start_group
 class HeaderFormatter(
     private val caldavDao: CaldavDao,
 ) {
-    private val listCache = HashMap<Long, String?>()
+    /**
+     * [headerStringBlocking] is called from view binding on the main thread, and resolving a header
+     * means a string resource load or - when grouping by list - a database query. Headers repeat
+     * constantly while scrolling, so results are memoized. Relative dates ("today", "tomorrow") are
+     * only valid for the current day, so the cache is dropped when the day rolls over. This is also
+     * what eventually picks up a renamed list.
+     */
+    @Volatile
+    private var cacheDay = Long.MIN_VALUE
+    private val headerCache = ConcurrentHashMap<String, String>()
 
     fun headerStringBlocking(
         value: Long,
@@ -32,8 +45,17 @@ class HeaderFormatter(
         alwaysDisplayFullDate: Boolean = false,
         style: DateStyle = DateStyle.FULL,
         compact: Boolean = false,
-    ) = runBlocking {
-        headerString(value, groupMode, alwaysDisplayFullDate, style, compact)
+    ): String {
+        val today = currentTimeMillis().startOfDay()
+        if (today != cacheDay) {
+            cacheDay = today
+            headerCache.clear()
+        }
+        val key = "$value|$groupMode|$alwaysDisplayFullDate|$style|$compact"
+        headerCache[key]?.let { return it }
+        return runBlocking {
+            headerString(value, groupMode, alwaysDisplayFullDate, style, compact)
+        }.also { headerCache[key] = it }
     }
 
     suspend fun headerString(
@@ -49,9 +71,7 @@ class HeaderFormatter(
             groupMode == SortHelper.SORT_IMPORTANCE ->
                 getString(priorityToString(value))
             groupMode == SortHelper.SORT_LIST ->
-                listCache.getOrPut(value) {
-                    caldavDao.getCalendarById(value)?.name
-                } ?: "list: $value"
+                caldavDao.getCalendarById(value)?.name ?: "list: $value"
             value == SectionedDataSource.HEADER_OVERDUE ->
                 getString(Res.string.filter_overdue)
             value == 0L -> getString(

--- a/kmp/src/commonMain/kotlin/org/tasks/tasklist/HeaderFormatter.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/tasklist/HeaderFormatter.kt
@@ -28,17 +28,17 @@ import tasks.kmp.generated.resources.sort_start_group
 class HeaderFormatter(
     private val caldavDao: CaldavDao,
 ) {
-    /**
-     * [headerStringBlocking] is called from view binding on the main thread, and resolving a header
-     * means a string resource load or - when grouping by list - a database query. Headers repeat
-     * constantly while scrolling, so results are memoized. Relative dates ("today", "tomorrow") are
-     * only valid for the current day, so the cache is dropped when the day rolls over. This is also
-     * what eventually picks up a renamed list.
-     */
     @Volatile
     private var cacheDay = Long.MIN_VALUE
     private val headerCache = ConcurrentHashMap<String, String>()
 
+    /**
+     * Called from view binding on the main thread, and resolving a header means a string resource
+     * load or - when grouping by list - a database query. Headers repeat constantly while
+     * scrolling, so results are memoized. Relative dates ("today", "tomorrow") are only valid for
+     * the current day, so the cache is dropped when the day rolls over. That is also what
+     * eventually picks up a renamed list.
+     */
     fun headerStringBlocking(
         value: Long,
         groupMode: Int,

--- a/kmp/src/commonMain/kotlin/org/tasks/tasklist/SectionedDataSource.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/tasklist/SectionedDataSource.kt
@@ -36,10 +36,12 @@ class SectionedDataSource(
             return getSection(sectionedPosition).firstPosition
         }
 
+        // `sections` is sorted by position, so stop at the first one past the target rather than
+        // walking the whole map. This runs for every item lookup, including inside the diff.
         var offset = 0
-        sections.forEach { (_, section) ->
+        for ((_, section) in sections) {
             if (section.sectionedPosition > sectionedPosition) {
-                return@forEach
+                break
             }
             --offset
         }

--- a/kmp/src/commonMain/kotlin/org/tasks/themes/ChipColors.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/themes/ChipColors.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import com.materialkolor.contrast.Contrast
 import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
+import java.util.concurrent.ConcurrentHashMap
 
 object ColorTone {
     const val LIGHT_CHIP = -1
@@ -22,10 +23,20 @@ object ColorTone {
     const val DARK_APPBAR = 80
 }
 
+/**
+ * Solving a tone or a content color runs HCT/CAM16 conversions, which are expensive relative to
+ * how often they're asked for: every chip on every task list row resolves both. Both functions are
+ * pure over a small set of inputs, so results are cached for the lifetime of the process.
+ */
+private val tonalColorCache = ConcurrentHashMap<Long, Int>()
+private val contentColorCache = ConcurrentHashMap<Int, Int>()
+
 fun tonalColor(seedColor: Int, tone: Int): Int =
     when {
         tone < 0 -> seedColor
-        else -> TonalPalette.fromInt(seedColor).tone(tone)
+        else -> tonalColorCache.getOrPut((seedColor.toLong() shl 32) or tone.toLong()) {
+            TonalPalette.fromInt(seedColor).tone(tone)
+        }
     }
 
 data class ChipColors(val backgroundColor: Int, val contentColor: Int)
@@ -46,7 +57,10 @@ private const val MIN_CONTRAST_RATIO = 4.5
 private const val WHITE = -1         // 0xFFFFFFFF
 private const val BLACK = -16777216  // 0xFF000000
 
-fun contentColor(backgroundColor: Int): Int {
+fun contentColor(backgroundColor: Int): Int =
+    contentColorCache.getOrPut(backgroundColor) { computeContentColor(backgroundColor) }
+
+private fun computeContentColor(backgroundColor: Int): Int {
     val bgTone = Hct.fromInt(backgroundColor).tone
     val palette = TonalPalette.fromInt(backgroundColor)
     val lightRatio = Contrast.ratioOfTones(bgTone, ColorTone.LIGHT_CONTENT.toDouble())

--- a/kmp/src/commonMain/kotlin/org/tasks/themes/ChipColors.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/themes/ChipColors.kt
@@ -23,14 +23,14 @@ object ColorTone {
     const val DARK_APPBAR = 80
 }
 
-/**
- * Solving a tone or a content color runs HCT/CAM16 conversions, which are expensive relative to
- * how often they're asked for: every chip on every task list row resolves both. Both functions are
- * pure over a small set of inputs, so results are cached for the lifetime of the process.
- */
 private val tonalColorCache = ConcurrentHashMap<Long, Int>()
 private val contentColorCache = ConcurrentHashMap<Int, Int>()
 
+/**
+ * Solving a tone runs HCT/CAM16 conversions, which are expensive relative to how often they're
+ * asked for: every chip on every task list row resolves one. This is pure over a small set of
+ * inputs, so results are cached for the lifetime of the process.
+ */
 fun tonalColor(seedColor: Int, tone: Int): Int =
     when {
         tone < 0 -> seedColor
@@ -57,6 +57,7 @@ private const val MIN_CONTRAST_RATIO = 4.5
 private const val WHITE = -1         // 0xFFFFFFFF
 private const val BLACK = -16777216  // 0xFF000000
 
+/** Cached for the same reason as [tonalColor] - every chip resolves one per composition. */
 fun contentColor(backgroundColor: Int): Int =
     contentColorCache.getOrPut(backgroundColor) { computeContentColor(backgroundColor) }
 

--- a/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
@@ -15,16 +15,13 @@ import java.util.concurrent.ConcurrentHashMap
 
 const val BLUE = -14575885
 
-/**
- * Generating a scheme runs the full HCT tonal palette derivation, which is far too expensive to
- * repeat per composition. There are only a handful of (theme, seed) combinations in practice, and
- * the schemes are immutable, so they're cached for the lifetime of the process.
- *
- * This matters most on the task list, where every row hosts its own composition for the chip row.
- */
 private val colorSchemeCache = ConcurrentHashMap<Triple<Int, Int, Boolean>, ColorScheme>()
 
 private fun getColorScheme(theme: Int, seedColor: Int, isDark: Boolean): ColorScheme =
+    // Generating a scheme runs the full HCT tonal palette derivation, which is far too expensive
+    // to repeat per composition. There are only a handful of (theme, seed) combinations in
+    // practice, and the schemes are immutable, so they're cached for the lifetime of the process.
+    // This matters most on the task list, where every row hosts its own composition for the chips.
     colorSchemeCache.getOrPut(Triple(theme, seedColor, isDark)) {
         generateColorScheme(theme, seedColor, isDark)
     }

--- a/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/themes/TasksTheme.kt
@@ -1,6 +1,7 @@
 package org.tasks.themes
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -10,8 +11,23 @@ import androidx.compose.ui.graphics.toArgb
 import com.materialkolor.dynamicColorScheme
 import org.tasks.kmp.org.tasks.themes.ColorProvider.BLACK
 import org.tasks.kmp.org.tasks.themes.ColorProvider.WHITE
+import java.util.concurrent.ConcurrentHashMap
 
 const val BLUE = -14575885
+
+/**
+ * Generating a scheme runs the full HCT tonal palette derivation, which is far too expensive to
+ * repeat per composition. There are only a handful of (theme, seed) combinations in practice, and
+ * the schemes are immutable, so they're cached for the lifetime of the process.
+ *
+ * This matters most on the task list, where every row hosts its own composition for the chip row.
+ */
+private val colorSchemeCache = ConcurrentHashMap<Triple<Int, Int, Boolean>, ColorScheme>()
+
+private fun getColorScheme(theme: Int, seedColor: Int, isDark: Boolean): ColorScheme =
+    colorSchemeCache.getOrPut(Triple(theme, seedColor, isDark)) {
+        generateColorScheme(theme, seedColor, isDark)
+    }
 
 @Composable
 fun colorOn(color: Color) = colorOn(color.toArgb())
@@ -31,11 +47,20 @@ fun TasksTheme(
         else -> isSystemInDarkTheme()
     }
     val seedColor = if (primary == WHITE) BLACK else primary
+    val colorScheme = remember(theme, seedColor, isDark) {
+        getColorScheme(theme, seedColor, isDark)
+    }
+    MaterialTheme(colorScheme = colorScheme) {
+        content()
+    }
+}
+
+private fun generateColorScheme(theme: Int, seedColor: Int, isDark: Boolean): ColorScheme {
     val generated = dynamicColorScheme(
         seedColor = Color(seedColor),
         isDark = isDark,
     )
-    val colorScheme = when (theme) {
+    return when (theme) {
         0 -> generated.copy(
             surface = Color(0xFFF0F0F0),
             background = Color.White,
@@ -64,9 +89,6 @@ fun TasksTheme(
             background = Color.White,
             surfaceContainerLowest = Color.White,
         )
-    }
-    MaterialTheme(colorScheme = colorScheme) {
-        content()
     }
 }
 

--- a/kmp/src/commonMain/kotlin/org/tasks/time/DateUtilities.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/time/DateUtilities.kt
@@ -22,6 +22,7 @@ import tasks.kmp.generated.resources.yest
 import tasks.kmp.generated.resources.yesterday
 import tasks.kmp.generated.resources.yesterday_abbrev_lowercase
 import tasks.kmp.generated.resources.yesterday_lowercase
+import kotlin.concurrent.Volatile
 import kotlin.math.abs
 
 suspend fun getRelativeDateTime(
@@ -76,8 +77,22 @@ fun getFullDateTime(
 private fun isAbbreviated(style: DateStyle): Boolean =
     style == DateStyle.SHORT || style == DateStyle.MEDIUM
 
-private fun stripYear(date: String, year: Int): String =
-    date.replace("(?: de |, |/| |\\u00a0)?$year(?:年|년 |[\\s\\u00a0]г\\.)?".toRegex(), "")
+// Compiling this pattern costs more than the replace itself, and the task list strips the year
+// from a date string for every visible row. The pattern only varies by year.
+@Volatile
+private var yearRegex: Pair<Int, Regex>? = null
+
+private fun stripYear(date: String, year: Int): String {
+    val cached = yearRegex
+    val regex = if (cached != null && cached.first == year) {
+        cached.second
+    } else {
+        "(?: de |, |/| |\\u00a0)?$year(?:年|년 |[\\s\\u00a0]г\\.)?"
+            .toRegex()
+            .also { yearRegex = year to it }
+    }
+    return date.replace(regex, "")
+}
 
 private suspend fun getRelativeDay(
     date: Long,

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/time/TimeFormatter.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/time/TimeFormatter.kt
@@ -6,18 +6,32 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 // Languages where AM/PM is conventionally placed before the time
 private val AM_PM_BEFORE_TIME = setOf("zh", "ja", "ko", "vi", "as", "brx", "ee", "ta", "yue")
 
-fun formatTimeString(dateTime: LocalDateTime, is24HourFormat: Boolean): String {
-    val locale = Locale.getDefault()
+private val AM_PM_MARKER = Regex("[\\s\\u202F]*a[\\s\\u202F]*")
+private val MINUTES = Regex("[:.]mm")
+
+/**
+ * Building the pattern and compiling a [DateTimeFormatter] costs more than the formatting itself,
+ * and the task list formats a time for every visible row. The result depends only on the locale
+ * and the two booleans, so formatters are cached.
+ */
+private val timeFormatters = ConcurrentHashMap<String, DateTimeFormatter>()
+
+private fun timeFormatter(
+    locale: Locale,
+    is24HourFormat: Boolean,
+    omitMinutes: Boolean,
+): DateTimeFormatter = timeFormatters.getOrPut("$locale|$is24HourFormat|$omitMinutes") {
     var pattern = DateTimeFormatterBuilder
         .getLocalizedDateTimePattern(null, FormatStyle.SHORT, IsoChronology.INSTANCE, locale)
     if (is24HourFormat && !pattern.contains("H")) {
         pattern = pattern
             .replace("hh", "HH").replace("h", "HH")
-            .replace(Regex("[\\s\\u202F]*a[\\s\\u202F]*"), "")
+            .replace(AM_PM_MARKER, "")
             .trim()
     } else if (!is24HourFormat && pattern.contains("H")) {
         pattern = pattern.replace("HH", "h").replace("H", "h")
@@ -27,12 +41,29 @@ fun formatTimeString(dateTime: LocalDateTime, is24HourFormat: Boolean): String {
             "$pattern a"
         }
     }
-    if (!is24HourFormat && dateTime.minute == 0) {
-        pattern = pattern.replace(Regex("[:.]mm"), "")
+    if (omitMinutes) {
+        pattern = pattern.replace(MINUTES, "")
     }
-    return dateTime.toLocalTime()
-        .format(DateTimeFormatter.ofPattern(pattern, locale))
+    DateTimeFormatter.ofPattern(pattern, locale)
 }
+
+fun formatTimeString(dateTime: LocalDateTime, is24HourFormat: Boolean): String {
+    val locale = Locale.getDefault()
+    val omitMinutes = !is24HourFormat && dateTime.minute == 0
+    return dateTime.toLocalTime().format(timeFormatter(locale, is24HourFormat, omitMinutes))
+}
+
+private val localizedFormatters = ConcurrentHashMap<String, DateTimeFormatter>()
+
+private fun localizedDateTimeFormatter(locale: Locale, dateStyle: FormatStyle): DateTimeFormatter =
+    localizedFormatters.getOrPut("datetime|$locale|$dateStyle") {
+        DateTimeFormatter.ofLocalizedDateTime(dateStyle, FormatStyle.SHORT).withLocale(locale)
+    }
+
+private fun localizedTimeFormatter(locale: Locale): DateTimeFormatter =
+    localizedFormatters.getOrPut("time|$locale") {
+        DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
+    }
 
 fun formatFullDateTimeString(
     dateTime: LocalDateTime,
@@ -40,12 +71,8 @@ fun formatFullDateTimeString(
     dateStyle: FormatStyle,
 ): String {
     val locale = Locale.getDefault()
-    val fullFormatted = DateTimeFormatter
-        .ofLocalizedDateTime(dateStyle, FormatStyle.SHORT)
-        .withLocale(locale)
-        .format(dateTime)
-    val localeTime = dateTime.toLocalTime()
-        .format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale))
+    val fullFormatted = localizedDateTimeFormatter(locale, dateStyle).format(dateTime)
+    val localeTime = dateTime.toLocalTime().format(localizedTimeFormatter(locale))
     val correctTime = formatTimeString(dateTime, is24HourFormat)
     return fullFormatted.replace(localeTime, correctTime)
 }

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/time/TimeFormatter.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/time/TimeFormatter.kt
@@ -14,18 +14,17 @@ private val AM_PM_BEFORE_TIME = setOf("zh", "ja", "ko", "vi", "as", "brx", "ee",
 private val AM_PM_MARKER = Regex("[\\s\\u202F]*a[\\s\\u202F]*")
 private val MINUTES = Regex("[:.]mm")
 
-/**
- * Building the pattern and compiling a [DateTimeFormatter] costs more than the formatting itself,
- * and the task list formats a time for every visible row. The result depends only on the locale
- * and the two booleans, so formatters are cached.
- */
 private val timeFormatters = ConcurrentHashMap<String, DateTimeFormatter>()
 
 private fun timeFormatter(
     locale: Locale,
     is24HourFormat: Boolean,
     omitMinutes: Boolean,
-): DateTimeFormatter = timeFormatters.getOrPut("$locale|$is24HourFormat|$omitMinutes") {
+): DateTimeFormatter =
+    // Building the pattern and compiling a DateTimeFormatter costs more than the formatting
+    // itself, and the task list formats a time for every visible row. The result depends only on
+    // the locale and the two booleans, so formatters are cached.
+    timeFormatters.getOrPut("$locale|$is24HourFormat|$omitMinutes") {
     var pattern = DateTimeFormatterBuilder
         .getLocalizedDateTimePattern(null, FormatStyle.SHORT, IsoChronology.INSTANCE, locale)
     if (is24HourFormat && !pattern.contains("H")) {

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/viewmodel/TaskListViewModel.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/viewmodel/TaskListViewModel.kt
@@ -65,6 +65,14 @@ open class TaskListViewModel(
         val collapsed: Set<Long> = setOf(SectionedDataSource.HEADER_COMPLETED),
     )
 
+    /** The subset of [State] that the task list query depends on. */
+    private data class QueryKey(
+        val filter: Filter,
+        val now: Long,
+        val searchQuery: String?,
+        val collapsed: Set<Long>,
+    )
+
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
 
@@ -147,7 +155,10 @@ open class TaskListViewModel(
             .launchIn(viewModelScope)
 
         _state
-            .map { it.copy(tasks = TasksResults.Loading) }
+            // Only the fields the query actually depends on may trigger a refetch. Deriving this
+            // from the whole state meant that flipping the sync indicator re-ran the query and
+            // rebuilt the entire list.
+            .map { QueryKey(it.filter, it.now, it.searchQuery, it.collapsed) }
             .distinctUntilChanged()
             .throttleLatest(333)
             .map {


### PR DESCRIPTION
Follow-up to #4533, where I noticed this while looking at what runs on a list refresh.

`app/src/release/java/org/tasks/BuildSetup.kt` replaces Kermit's log writers but never sets `minSeverity`. Kermit's default is `Severity.Verbose` — `BaseLoggerKt.DEFAULT_MIN_SEVERITY` in the 2.1.0 bytecode — so `Logger.v` runs in release, through Timber into `FileLogger` and onto disk.

The one that costs real work is `TaskDao.fetchTasks`:

```kotlin
Logger.v("TaskDao") { "${end - start}ms: ${query.replace(WHITESPACE, " ").trim()}" }
```

The recursive task list query is several KB of SQL. That rewrites the whole string and writes it out on every fetch, and the list refetches on every refresh. When the query took 8ms, nobody is reading the SQL.

This keeps the timing on every query and only pays for the query text when the query took ≥100ms — which is the case you'd actually be diagnosing.

### What I did not do

I left `minSeverity` alone. `FileLogger.getZipFile()` exists specifically to attach logs to bug reports, so verbose file logging in release looks deliberate and silencing it would quietly degrade the reports you get. If it isn't deliberate, `Logger.mutableConfig.minSeverity = Severity.Info` in the release `BuildSetup` is a one-liner — happy to add it, just didn't want to make that call on your behalf.

Worth knowing either way: Timber's `DebugTree.getTag()` does `new Throwable().getStackTrace()` when no explicit tag is set. `TimberLogWriter` always sets one so Kermit calls avoid it, but direct `Timber.d(...)` calls elsewhere in the app don't.

### Note

Branched off #4533 because that PR also touches `TaskDao` (it hoisted the `WHITESPACE` regex out of the per-call path). Merge that one first, or I can rebase this onto main if you'd rather take it standalone.
