### PR TITLE
Add a benchmark for the colour costs the task list pays per row

### DIFF
--- a/kmp/src/jvmTest/kotlin/org/tasks/themes/ColorSchemeBenchmark.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/themes/ColorSchemeBenchmark.kt
@@ -1,0 +1,52 @@
+package org.tasks.themes
+
+import androidx.compose.ui.graphics.Color
+import com.materialkolor.dynamicColorScheme
+import com.materialkolor.palettes.TonalPalette
+import org.junit.Ignore
+import org.junit.Test
+import org.tasks.kmp.org.tasks.themes.ColorProvider
+
+/**
+ * Not a correctness test and not part of CI - it measures wall clock time, which is exactly the
+ * kind of thing that makes a build flaky. Run it explicitly:
+ *
+ *     ./gradlew :kmp:jvmTest --tests '*ColorSchemeBenchmark*' -i
+ *
+ * These are the pure-Kotlin colour costs the task list pays while scrolling. Every row hosts its
+ * own composition for the chip row and gets a fresh setContent lambda, so TasksTheme cannot skip
+ * recomposition and calls dynamicColorScheme once per row; every chip resolves a tone through HCT.
+ *
+ * Device frame timing is a separate exercise - this only shows how expensive the underlying calls
+ * are, so the claim that they are worth avoiding can be checked rather than assumed.
+ */
+@Ignore("Timing benchmark - run explicitly, see class doc")
+class ColorSchemeBenchmark {
+
+    @Test
+    fun colorCosts() {
+        val seed = ColorProvider.BLUE_500
+        val chipColor = 0xFF3F51B5.toInt()
+
+        report("dynamicColorScheme (once per row)") {
+            dynamicColorScheme(seedColor = Color(seed), isDark = false)
+        }
+        report("TonalPalette.fromInt().tone() (once per chip)") {
+            TonalPalette.fromInt(chipColor).tone(30)
+        }
+        report("contentColor (once per chip)") { contentColor(chipColor) }
+    }
+
+    private fun report(label: String, block: () -> Any?) {
+        repeat(WARMUP) { block() }
+        val start = System.nanoTime()
+        repeat(ITERATIONS) { block() }
+        val perCallMicros = (System.nanoTime() - start).toDouble() / ITERATIONS / 1_000.0
+        println("BENCH | $label: ${"%.2f".format(perCallMicros)} us/call")
+    }
+
+    private companion object {
+        const val WARMUP = 2_000
+        const val ITERATIONS = 20_000
+    }
+}


### PR DESCRIPTION
Rebased onto current main — it no longer sits on top of #4533, and measures the calls as they are on main today.

`TasksTheme` calls `dynamicColorScheme` once per task row (every row hosts its own composition for the chip row and gets a fresh `setContent` lambda, so it can never skip recomposition), and every chip resolves a tone through HCT. That those calls are expensive enough to matter was reasoned from the code, not measured. This measures them.

`@Ignore`d by default — it times wall clock, which has no place in CI. Run it with:

```
./gradlew :kmp:jvmTest --tests "*ColorSchemeBenchmark*" -i
```

On current main, desktop JVM, 20k iterations after 2k warmup:

```
BENCH | dynamicColorScheme (once per row):              917.03 us/call
BENCH | TonalPalette.fromInt().tone() (once per chip):    3.35 us/call
BENCH | contentColor (once per chip):                    15.59 us/call
```

A frame is 16.6 ms at 60 fps, so a screen of ten rows spends most of a frame budget on the first line alone, on the main thread. This is the evidence for #4533; it stands on its own if you would rather take the measurement without the fix.
