### PR TITLE
Bind the UID in OpenTasks provider selections

### DIFF
--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -96,9 +96,7 @@ open class OpenTaskDao(
 
     fun delete(listId: Long, uid: String): ContentProviderOperation =
             newDelete(tasks)
-                    .withSelection(
-                            "${Tasks.LIST_ID} = $listId AND ${Tasks._UID} = '$uid'",
-                            null)
+                    .withSelection(TASK_BY_UID, taskByUidArgs(listId, uid))
                     .build()
 
 
@@ -112,8 +110,8 @@ open class OpenTaskDao(
         cr.query(
                 tasks.buildUpon().appendQueryParameter(LOAD_PROPERTIES, "1").build(),
                 null,
-                "${Tasks.LIST_ID} = $listId AND ${Tasks._UID} = '$uid'",
-                null,
+                TASK_BY_UID,
+                taskByUidArgs(listId, uid),
                 null)?.use {
             if (it.moveToFirst()) {
                 MyAndroidTask(it)
@@ -125,6 +123,14 @@ open class OpenTaskDao(
 
     companion object {
         private const val OPENTASK_BATCH_LIMIT = 499
+        private val TASK_BY_UID = "${Tasks.LIST_ID} = ? AND ${Tasks._UID} = ?"
+
+        private fun taskByUidArgs(listId: Long, uid: String) =
+                // Bound rather than interpolated: a UID is server supplied, and CalDAV places no
+                // restriction on quotes. A single apostrophe used to turn the selection into
+                // invalid SQL, which the provider answers with "no such task" - the task is then
+                // re-imported on every sync and local edits to it are never sent back.
+                arrayOf(listId.toString(), uid)
         val SUPPORTED_TYPES = OpenTaskProvider.SUPPORTED_TYPES
 
         suspend fun Map<String, List<CaldavCalendar>>.filterActive(caldavDao: CaldavDao) =


### PR DESCRIPTION
`OpenTaskDao.delete()` and `OpenTaskDao.getTask()` both build their selection like this:

```kotlin
"${Tasks.LIST_ID} = $listId AND ${Tasks._UID} = '$uid'"
```

The UID comes from the server. CalDAV doesn't restrict what can be in it, and plenty of servers hand out UIDs that aren't plain alphanumerics — anything containing an apostrophe closes the quote early and the selection stops being valid SQL.

What makes this worth fixing rather than shrugging at is the failure mode. The provider doesn't throw anything you'd notice; the query just matches nothing. `getTask()` then returns null, the task looks brand new, so it gets imported again on the next sync — and every sync after that. Local edits to it never make it back to the server, because the code never finds the row it's supposed to update. Silent, permanent, and it looks like a server problem from the user's side.

`listId` is a `Long` so it was never a real risk, but it's in the same string so it's bound too.

No behaviour change for UIDs that were already fine — same query, just without hand-rolled quoting.

I don't have a server handing out awkward UIDs to reproduce against, so this is a fix by inspection rather than one I've watched fail and then watched recover.