### PR TITLE
Keep a usable change stamp when the sync state is unrecognized

### DIFF
--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -59,11 +59,7 @@ open class OpenTaskDao(
                         name = it.getString(TaskLists.LIST_NAME),
                         color = it.getInt(TaskLists.LIST_COLOR),
                         url = it.getString(CommonSyncColumns._SYNC_ID),
-                        ctag = it.getString(TaskLists.SYNC_VERSION)?.let { json ->
-                            runCatching { JSONObject(json).getString("value") }
-                                .onFailure { Logger.w("OpenTaskDao") { "Failed to parse ${TaskLists.SYNC_VERSION}: $json" } }
-                                .getOrNull()
-                        },
+                        ctag = it.getString(TaskLists.SYNC_VERSION)?.let(::toChangeStamp),
                         access = when (it.getInt(TaskLists.ACCESS_LEVEL)) {
                             TaskLists.ACCESS_LEVEL_OWNER -> CaldavCalendar.ACCESS_OWNER
                             TaskLists.ACCESS_LEVEL_READ -> CaldavCalendar.ACCESS_READ_ONLY
@@ -127,6 +123,27 @@ open class OpenTaskDao(
 
         private fun taskByUidArgs(listId: Long, uid: String) =
                 arrayOf(listId.toString(), uid)
+
+        private fun toChangeStamp(syncVersion: String): String =
+                // DAVx5 serializes a SyncState here, {"type":...,"value":...}. Anything else - an
+                // older DAVx5, a different OpenTasks backed provider, a format change - used to end
+                // up as a null ctag, and a null ctag never equals the stored one, so the up to date
+                // check never short circuited and every sync walked every etag in every list. The
+                // raw column works just as well as a change stamp, so keep it.
+                //
+                // The type is part of the stamp because CTAG and SYNC_TOKEN values live in separate
+                // namespaces: without it a collection switching between the two can report the same
+                // stamp for a different state.
+                runCatching {
+                    val syncState = JSONObject(syncVersion)
+                    "${syncState.optString("type")}:${syncState.getString("value")}"
+                }.getOrElse {
+                    Logger.d("OpenTaskDao") {
+                        "Unrecognized ${TaskLists.SYNC_VERSION}, using it verbatim: $syncVersion"
+                    }
+                    syncVersion
+                }
+
         val SUPPORTED_TYPES = OpenTaskProvider.SUPPORTED_TYPES
 
         suspend fun Map<String, List<CaldavCalendar>>.filterActive(caldavDao: CaldavDao) =

--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -60,11 +60,7 @@ open class OpenTaskDao(
                         name = it.getString(TaskLists.LIST_NAME),
                         color = it.getInt(TaskLists.LIST_COLOR),
                         url = it.getString(CommonSyncColumns._SYNC_ID),
-                        ctag = it.getString(TaskLists.SYNC_VERSION)?.let { json ->
-                            runCatching { JSONObject(json).getString("value") }
-                                .onFailure { Logger.w("OpenTaskDao") { "Failed to parse ${TaskLists.SYNC_VERSION}: $json" } }
-                                .getOrNull()
-                        },
+                        ctag = it.getString(TaskLists.SYNC_VERSION)?.let(::toChangeStamp),
                         access = when (it.getInt(TaskLists.ACCESS_LEVEL)) {
                             TaskLists.ACCESS_LEVEL_OWNER -> CaldavCalendar.ACCESS_OWNER
                             TaskLists.ACCESS_LEVEL_READ -> CaldavCalendar.ACCESS_READ_ONLY
@@ -128,6 +124,27 @@ open class OpenTaskDao(
 
         private fun taskByUidArgs(listId: Long, uid: String) =
                 arrayOf(listId.toString(), uid)
+
+        private fun toChangeStamp(syncVersion: String): String =
+                // DAVx5 serializes a SyncState here, {"type":...,"value":...}. Anything else - an
+                // older DAVx5, a different OpenTasks backed provider, a format change - used to end
+                // up as a null ctag, and a null ctag never equals the stored one, so the up to date
+                // check never short circuited and every sync walked every etag in every list. The
+                // raw column works just as well as a change stamp, so keep it.
+                //
+                // The type is part of the stamp because CTAG and SYNC_TOKEN values live in separate
+                // namespaces: without it a collection switching between the two can report the same
+                // stamp for a different state.
+                runCatching {
+                    val syncState = JSONObject(syncVersion)
+                    "${syncState.optString("type")}:${syncState.getString("value")}"
+                }.getOrElse {
+                    Logger.d("OpenTaskDao") {
+                        "Unrecognized ${TaskLists.SYNC_VERSION}, using it verbatim: $syncVersion"
+                    }
+                    syncVersion
+                }
+
         val SUPPORTED_TYPES = OpenTaskProvider.SUPPORTED_TYPES
 
         suspend fun Map<String, List<CaldavCalendar>>.filterActive(caldavDao: CaldavDao) =


### PR DESCRIPTION
`OpenTaskDao.getLists()` reads the per-list change stamp DAVx5 writes into `TaskLists.SYNC_VERSION`. It parses it as a serialized `SyncState` and drops to `null` if that fails.

A null ctag is never equal to the stored one:

```kotlin
if (calendar.ctag?.equals(ctag) == true) { return }
```

so the up-to-date check in `OpenTasksSynchronizer.fetchChanges` never short-circuits and **every sync walks every etag in every list, forever**. The only signal is a `Logger.w` nobody sees. The happy path is fine — current DAVx5 does write that JSON — it's the failure mode that is expensive, and it is silent.

This falls back to the raw column value instead. Any stable string works as a change stamp, so an older DAVx5, a different OpenTasks-backed provider, or a format change costs nothing instead of permanently disabling the check.

It also includes `SyncState.type` in the stamp. CTAG and SYNC_TOKEN values live in different namespaces, so comparing only `value` can report a collection as up to date after it switched between the two.

Note: including the type changes the stamp format, so the first sync after upgrading walks each list once and then settles.