### PR TITLE
Stop re-importing OpenTasks tasks that have no etag

### DIFF
--- a/kmp/src/androidMain/kotlin/org/tasks/opentasks/OpenTasksSynchronizer.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/opentasks/OpenTasksSynchronizer.kt
@@ -173,7 +173,14 @@ class OpenTasksSynchronizer(
         val etags = openTaskDao.getEtags(listId)
         etags.forEach { (uid, sync1, version) ->
             val caldavTask = caldavDao.getTaskByRemoteId(calendar.uuid!!, uid)
-            val etag = if (account.isEteSync || account.isDecSync) version else sync1
+            // Fall back to the row version when there is no sync1. A null etag makes the check below
+            // permanently true, so a task DAVx5 has not assigned an etag to yet - anything created
+            // locally and not uploaded, or written while AccountSettingsMigration8 had the etag
+            // parked in SYNC_VERSION - is re-read, re-parsed and re-written on every sync for the
+            // life of the install. The version is the provider's own revision counter, so it is a
+            // usable stamp: at worst a push we made ourselves bumps it and costs one extra pass,
+            // instead of never converging.
+            val etag = if (account.isEteSync || account.isDecSync) version else (sync1 ?: version)
             if (caldavTask?.etag == null || caldavTask.etag != etag) {
                 applyChanges(account, calendar, listId, uid, etag, caldavTask)
             }


### PR DESCRIPTION
In `OpenTasksSynchronizer.fetchChanges`:

```kotlin
val etag = if (account.isEteSync || account.isDecSync) version else sync1
if (caldavTask?.etag == null || caldavTask.etag != etag) {
    applyChanges(account, calendar, listId, uid, etag, caldavTask)
}
```

The first clause makes a null stored etag permanently "changed". For DAVx5 accounts the etag comes from `Tasks.SYNC1`, which is null for any row DAVx5 has not assigned one to yet — notably tasks created locally and not yet uploaded. Those never converge: re-read from the provider, re-parsed from iCalendar and re-written to the database on every single sync, for the life of the install.

(DAVx5's `AccountSettingsMigration8` also moved the etag to `SYNC_VERSION` and explicitly nulled `SYNC1` before moving it back, so rows written in that window can be in the same state.)

`getEtags` already selects the provider's `version` column and then throws it away for anything that isn't EteSync/DecSync. It's the row revision counter — it changes on every modification regardless of who wrote it — so it's a usable stamp on its own. Using it when `sync1` is null makes the comparison converge.

The tradeoff: a push we make ourselves bumps `version`, so an affected task can cost one extra pass, which then settles. That is strictly better than never settling at all.

I don't have a DAVx5 account with enough history to prove the `version` column never moves for non-content reasons, so a second opinion on that would be welcome.