### PR TITLE
Batch the OpenTasks sync queries instead of one per task

### DIFF
--- a/app/src/androidTest/java/org/tasks/opentasks/TestOpenTaskDao.kt
+++ b/app/src/androidTest/java/org/tasks/opentasks/TestOpenTaskDao.kt
@@ -79,7 +79,9 @@ class TestOpenTaskDao @Inject constructor(
                 null,
                 null,
                 null,
-                null)?.use {
+                // MyAndroidTask reads a task and its properties as one contiguous run of rows, and
+                // the default sort is by due date, which does not keep a run together
+                TaskContract.Tasks._ID)?.use {
             while (it.moveToNext()) {
                 MyAndroidTask(it).task?.let { task -> result.add(task) }
             }

--- a/kmp/src/androidMain/kotlin/org/tasks/data/MyAndroidTask.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/MyAndroidTask.kt
@@ -24,7 +24,8 @@ class MyAndroidTask() : DmfsTask(null) {
 
     constructor(cursor: Cursor) : this() {
         val values = cursor.toValues()
-        id = cursor.getLong(TaskContract.Tasks._ID)
+        val taskId = cursor.getLong(TaskContract.Tasks._ID)
+        id = taskId
         task = Task()
         populateTask(values)
         if (values.containsKey(TaskContract.Properties.PROPERTY_ID)) {
@@ -32,6 +33,15 @@ class MyAndroidTask() : DmfsTask(null) {
             populateProperty(values)
 
             while (cursor.moveToNext()) {
+                if (cursor.getLong(TaskContract.Tasks._ID) != taskId) {
+                    // The property view repeats the task row once per property, so a cursor holding
+                    // more than one task is a run of rows per task. Stop at the start of the next
+                    // run, and leave the cursor on the last row of this one so the caller's
+                    // moveToNext lands there. Ordering the query by _ID is what makes a run
+                    // contiguous; the provider's default sort is by due date.
+                    cursor.moveToPrevious()
+                    break
+                }
                 // process the other properties
                 populateProperty(cursor.toValues(true))
             }

--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -122,7 +122,8 @@ open class OpenTaskDao(
     }
 
     /**
-     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids.
+     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids - one
+     * selection argument short of [OPENTASK_BATCH_LIMIT], since the list id takes one.
      *
      * Callers used to ask for one uid at a time, which is a binder round trip and a cursor window
      * per task on every sync that saw a change.
@@ -152,7 +153,6 @@ open class OpenTaskDao(
     companion object {
         private const val OPENTASK_BATCH_LIMIT = 499
 
-        /** One selection argument of the batch is spent on the list id. */
         private const val UID_BATCH_LIMIT = OPENTASK_BATCH_LIMIT - 1
 
         private val TASK_BY_UID = "${Tasks.LIST_ID} = ? AND ${Tasks._UID} = ?"

--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -122,9 +122,43 @@ open class OpenTaskDao(
         }
     }
 
+    /**
+     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids.
+     *
+     * Callers used to ask for one uid at a time, which is a binder round trip and a cursor window
+     * per task on every sync that saw a change.
+     */
+    suspend fun getTasks(listId: Long, uids: List<String>): Map<String, MyAndroidTask> =
+            withContext(Dispatchers.IO) {
+                val result = HashMap<String, MyAndroidTask>(uids.size)
+                uids.chunked(UID_BATCH_LIMIT).forEach { chunk ->
+                    cr.query(
+                            tasks.buildUpon().appendQueryParameter(LOAD_PROPERTIES, "1").build(),
+                            null,
+                            "${Tasks.LIST_ID} = ? AND ${Tasks._UID} IN (${chunk.placeholders()})",
+                            arrayOf(listId.toString()) + chunk,
+                            // MyAndroidTask reads a task and its properties as one contiguous run
+                            // of rows. The property view returns a row per property and sorts by
+                            // due date by default, which does not keep a run together.
+                            Tasks._ID)?.use { cursor ->
+                        while (cursor.moveToNext()) {
+                            val uid = cursor.getString(Tasks._UID) ?: continue
+                            result[uid] = MyAndroidTask(cursor)
+                        }
+                    }
+                }
+                result
+            }
+
     companion object {
         private const val OPENTASK_BATCH_LIMIT = 499
+
+        /** One selection argument of the batch is spent on the list id. */
+        private const val UID_BATCH_LIMIT = OPENTASK_BATCH_LIMIT - 1
+
         private val TASK_BY_UID = "${Tasks.LIST_ID} = ? AND ${Tasks._UID} = ?"
+
+        private fun List<String>.placeholders() = joinToString(",") { "?" }
 
         private fun taskByUidArgs(listId: Long, uid: String) =
                 arrayOf(listId.toString(), uid)

--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -121,9 +121,43 @@ open class OpenTaskDao(
         }
     }
 
+    /**
+     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids.
+     *
+     * Callers used to ask for one uid at a time, which is a binder round trip and a cursor window
+     * per task on every sync that saw a change.
+     */
+    suspend fun getTasks(listId: Long, uids: List<String>): Map<String, MyAndroidTask> =
+            withContext(Dispatchers.IO) {
+                val result = HashMap<String, MyAndroidTask>(uids.size)
+                uids.chunked(UID_BATCH_LIMIT).forEach { chunk ->
+                    cr.query(
+                            tasks.buildUpon().appendQueryParameter(LOAD_PROPERTIES, "1").build(),
+                            null,
+                            "${Tasks.LIST_ID} = ? AND ${Tasks._UID} IN (${chunk.placeholders()})",
+                            arrayOf(listId.toString()) + chunk,
+                            // MyAndroidTask reads a task and its properties as one contiguous run
+                            // of rows. The property view returns a row per property and sorts by
+                            // due date by default, which does not keep a run together.
+                            Tasks._ID)?.use { cursor ->
+                        while (cursor.moveToNext()) {
+                            val uid = cursor.getString(Tasks._UID) ?: continue
+                            result[uid] = MyAndroidTask(cursor)
+                        }
+                    }
+                }
+                result
+            }
+
     companion object {
         private const val OPENTASK_BATCH_LIMIT = 499
+
+        /** One selection argument of the batch is spent on the list id. */
+        private const val UID_BATCH_LIMIT = OPENTASK_BATCH_LIMIT - 1
+
         private val TASK_BY_UID = "${Tasks.LIST_ID} = ? AND ${Tasks._UID} = ?"
+
+        private fun List<String>.placeholders() = joinToString(",") { "?" }
 
         private fun taskByUidArgs(listId: Long, uid: String) =
                 arrayOf(listId.toString(), uid)

--- a/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/data/OpenTaskDao.kt
@@ -123,7 +123,8 @@ open class OpenTaskDao(
     }
 
     /**
-     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids.
+     * Loads several tasks, with their properties, in one query per [UID_BATCH_LIMIT] uids - one
+     * selection argument short of [OPENTASK_BATCH_LIMIT], since the list id takes one.
      *
      * Callers used to ask for one uid at a time, which is a binder round trip and a cursor window
      * per task on every sync that saw a change.
@@ -153,7 +154,6 @@ open class OpenTaskDao(
     companion object {
         private const val OPENTASK_BATCH_LIMIT = 499
 
-        /** One selection argument of the batch is spent on the list id. */
         private const val UID_BATCH_LIMIT = OPENTASK_BATCH_LIMIT - 1
 
         private val TASK_BY_UID = "${Tasks.LIST_ID} = ? AND ${Tasks._UID} = ?"

--- a/kmp/src/androidMain/kotlin/org/tasks/opentasks/OpenTasksSynchronizer.kt
+++ b/kmp/src/androidMain/kotlin/org/tasks/opentasks/OpenTasksSynchronizer.kt
@@ -171,14 +171,31 @@ class OpenTasksSynchronizer(
         Logger.d("OpenTasksSynchronizer") { "SYNC $calendar" }
 
         val etags = openTaskDao.getEtags(listId)
-        etags.forEach { (uid, sync1, version) ->
-            val caldavTask = caldavDao.getTaskByRemoteId(calendar.uuid!!, uid)
+        val uids = etags.map { it.first }
+        // One query for the whole list rather than one per task. This runs for every task in the
+        // list whenever anything in it changed, so on a few thousand tasks it was the bulk of the
+        // sync.
+        val local = caldavDao
+                .getTasksByRemoteId(calendar.uuid!!, uids)
+                .associateBy { it.remoteId }
+        val changed = etags.mapNotNull { (uid, sync1, version) ->
             val etag = if (account.isEteSync || account.isDecSync) version else sync1
+            val caldavTask = local[uid]
             if (caldavTask?.etag == null || caldavTask.etag != etag) {
-                applyChanges(account, calendar, listId, uid, etag, caldavTask)
+                Triple(uid, etag, caldavTask)
+            } else {
+                null
             }
         }
-        removeDeleted(calendar.uuid!!, etags.map { it.first })
+        if (changed.isNotEmpty()) {
+            Logger.d("OpenTasksSynchronizer") { "CHANGED ${changed.size} of ${etags.size}" }
+            // Likewise, one cross process query for the changed set instead of one per task.
+            val remote = openTaskDao.getTasks(listId, changed.map { it.first })
+            changed.forEach { (uid, etag, caldavTask) ->
+                remote[uid]?.let { applyChanges(account, calendar, it, uid, etag, caldavTask) }
+            }
+        }
+        removeDeleted(calendar.uuid!!, uids)
 
         calendar.ctag = ctag
         Logger.d("OpenTasksSynchronizer") { "UPDATE $calendar" }
@@ -252,16 +269,14 @@ class OpenTasksSynchronizer(
     private suspend fun applyChanges(
         account: CaldavAccount,
         calendar: CaldavCalendar,
-        listId: Long,
+        androidTask: MyAndroidTask,
         uid: String,
         etag: String?,
         existing: CaldavTask?
     ) {
-        openTaskDao.getTask(listId, uid)?.let { androidTask ->
-            val adapted = Ical4androidTaskAdapter(androidTask.task!!)
-            val vtodo = adapted.serialize()
-            iCalendar.fromVtodo(account, calendar, existing, adapted, vtodo, CaldavTask.objectName(uid), etag)
-        }
+        val adapted = Ical4androidTaskAdapter(androidTask.task!!)
+        val vtodo = adapted.serialize()
+        iCalendar.fromVtodo(account, calendar, existing, adapted, vtodo, CaldavTask.objectName(uid), etag)
     }
 
     companion object {


### PR DESCRIPTION
Found while looking at slow DAVx5 syncs. `OpenTasksSynchronizer.fetchChanges` walks every task in a list whenever the list's ctag moves, with two nested N+1s:

```kotlin
val etags = openTaskDao.getEtags(listId)        // one provider query, fine
etags.forEach { (uid, sync1, version) ->
    val caldavTask = caldavDao.getTaskByRemoteId(calendar.uuid!!, uid)   // one Room query PER TASK
    val etag = if (account.isEteSync || account.isDecSync) version else sync1
    if (caldavTask?.etag == null || caldavTask.etag != etag) {
        applyChanges(account, calendar, listId, uid, etag, caldavTask)   // cross-process CP query PER CHANGED TASK
    }
}
```

1. `getTaskByRemoteId()` — one Room query per task in the list, on every sync where anything changed.
2. `applyChanges` → `openTaskDao.getTask()` — one `ContentResolver.query` with `LOAD_PROPERTIES` per changed task. Cross-process, so a binder round trip plus a cursor window each.

DAVx5 syncs on its own schedule, so with a few thousand tasks across a dozen lists this runs constantly, and any single remote change re-walks that whole list.

### What this does

- Uses the existing `caldavDao.getTasksByRemoteId()` (which already chunks) for the local rows, into a map keyed by remote id.
- Adds `OpenTaskDao.getTasks(listId, uids)` to fetch the changed set from the provider in batches. Batch size is 498 — one argument of the 499 convention already in this file is spent on the list id.

### The MyAndroidTask part

`MyAndroidTask(cursor)` consumed *every* remaining row as a property of the task it started on. That's correct for a single-task query and wrong for a batched one, so it now stops when the task id changes and leaves the cursor on the last row of the run.

Runs are only contiguous if the query is ordered by `_ID` — `Task_Property_View` is `tasks JOIN lists LEFT JOIN properties` and `Tasks.DEFAULT_SORT_ORDER` is `DUE`, which doesn't group a task's rows. Both batched callers now ask for `_ID` explicitly.

That includes `TestOpenTaskDao.getTasks()`, which is already a multi-task `LOAD_PROPERTIES` query and has been collapsing every task after the first into the first one's property list. Worth a look if you have an emulator handy — I've compiled the instrumented sources but not run them.

No behaviour change intended beyond doing the same work in far fewer round trips.