### PR TITLE
Say why background syncs don't ask the providers to sync

### DIFF
--- a/app/src/main/java/org/tasks/jobs/SyncWork.kt
+++ b/app/src/main/java/org/tasks/jobs/SyncWork.kt
@@ -121,6 +121,12 @@ class SyncWork @AssistedInject constructor(
         if (openTaskDao.shouldSync()) {
             openTasksSynchronizer.get().sync(hasPro = inventory.hasPro)
 
+            // Only nudge the providers when the user asked for a sync. DAVx5 and the other
+            // OpenTasks backed providers run their own schedules, and a background worker
+            // requesting a sync every time would fight that. The sync above reads whatever the
+            // provider last wrote, so a background sync reporting success does not mean anything
+            // was pulled from the server - that is deliberate, this has been tied to a user
+            // gesture since it was added.
             if (source == SyncSource.USER_INITIATED) {
                 AccountManager
                     .get(context)


### PR DESCRIPTION
Comment only, no behaviour change — but I'd like it confirmed rather than assumed.

`SyncWork.doSync()` only calls `ContentResolver.requestSync` for the OpenTasks providers when the sync was user-initiated. For every other trigger — the periodic background sync, sync-on-app-start, sync-after-change — Tasks.org reads whatever DAVx5 last wrote to the provider and never asks it to talk to the server. So a background sync can report success having pulled nothing new.

I went looking for whether that was deliberate. It appears to be: the call arrived in ca49ca642e (*"Request davx5/etesync sync on swipe gesture"*) already gated on `EXTRA_IMMEDIATE`, and 677dec5170 carried that gate over to `SyncSource.USER_INITIATED` unchanged. It has never been unconditional. The reasoning that fits is that DAVx5 owns its own schedule and a background worker requesting a sync on every run would fight it.

This just writes that down so the next person doesn't have to do the archaeology. If I've read the intent wrong, I'd rather know — happy to close this or turn it into a real change instead.

(For the record the extras are right: `SYNC_EXTRAS_MANUAL` bypasses the auto-sync setting and `SYNC_EXTRAS_EXPEDITED` skips the queue; neither forces a full resync in DAVx5.)