### PR TITLE
Keep drag state out of task list row equality

### DIFF
--- a/app/src/test/java/org/tasks/tasklist/DiffCallbackTest.kt
+++ b/app/src/test/java/org/tasks/tasklist/DiffCallbackTest.kt
@@ -1,0 +1,58 @@
+package org.tasks.tasklist
+
+import com.todoroo.astrid.adapter.TaskAdapter
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito
+import org.tasks.data.TaskContainer
+import org.tasks.data.entity.Task
+
+class DiffCallbackTest {
+    private inline fun <reified T> stub(): T = Mockito.mock(T::class.java)
+
+    private val adapter = TaskAdapter(
+        newTasksOnTop = false,
+        googleTaskDao = stub(),
+        caldavDao = stub(),
+        taskDao = stub(),
+        taskSaver = stub(),
+        dirtyDao = stub(),
+        refreshBroadcaster = stub(),
+        taskMover = stub(),
+    )
+
+    private val task = Task(id = 1, title = "child")
+
+    /** A query result: a new container every time, over equal copies of the same row. */
+    private fun rows(task: Task = this.task, indent: Int = 1) = SectionedDataSource(
+        tasks = listOf(TaskContainer(task = task.copy(), indent = indent))
+    )
+
+    /** The indent writes [TaskListRecyclerAdapter.onBindViewHolder] makes on every bind. */
+    private fun SectionedDataSource.bound() = also {
+        for (position in 0 until size) {
+            val row = getItem(position)
+            row.indent = adapter.getIndent(row)
+            row.targetIndent = row.indent
+        }
+    }
+
+    private fun unchanged(old: SectionedDataSource, new: SectionedDataSource) =
+        DiffCallback(old, new, adapter).areContentsTheSame(0, 0)
+
+    @Test
+    fun requeryingLeavesABoundSubtaskAlone() {
+        assertTrue(unchanged(old = rows().bound(), new = rows()))
+    }
+
+    @Test
+    fun requeryingLeavesABoundTopLevelTaskAlone() {
+        assertTrue(unchanged(old = rows(indent = 0).bound(), new = rows(indent = 0)))
+    }
+
+    @Test
+    fun anEditedTitleIsStillReportedAsAChange() {
+        assertFalse(unchanged(old = rows().bound(), new = rows(task = task.copy(title = "new"))))
+    }
+}

--- a/data/src/commonMain/kotlin/org/tasks/data/TaskContainer.kt
+++ b/data/src/commonMain/kotlin/org/tasks/data/TaskContainer.kt
@@ -21,8 +21,14 @@ data class TaskContainer(
     @ColumnInfo(name = "primary_sort") val primarySort: Long = 0,
     @ColumnInfo(name = "secondary_sort") val secondarySort: Long = 0,
     var indent: Int = 0,
-    var targetIndent: Int = 0,
 ){
+    /**
+     * Where a drag would drop this row. Written on every bind and while dragging, never
+     * selected by the query, so it is kept off the primary constructor to stay out of
+     * [equals]: a bound row and a freshly queried one must still compare equal.
+     */
+    var targetIndent: Int = 0
+
     val isGoogleTask: Boolean
         get() = accountType == TYPE_GOOGLE_TASKS
 


### PR DESCRIPTION
Fixes half of #4568, and I think the half that explains why this has been so hard to
reproduce on purpose.

`DiffCallback.areContentsTheSame` decides a row is unchanged by comparing the containers:

```kotlin
val oldItem = old.getItem(oldPosition)
val newItem = new.getItem(newPosition)
!refreshDates && oldItem == newItem && oldItem.indent == adapter.getIndent(newItem)
```

`TaskContainer` is a `data class`, so that `==` covered every primary-constructor
property — including `targetIndent`.

`targetIndent` is drag scratch state. It is never selected by the query, but
`TaskListRecyclerAdapter.onBindViewHolder` writes it on every single bind:

```kotlin
val indent = adapter.getIndent(task)
task.indent = indent
task.targetIndent = indent
```

So a row that has been bound and sits at indent > 0 carries `targetIndent = indent`,
while the container the next query produces for the same task carries the default `0`.
They compare unequal, the row is dispatched as a change, and since `DiffCallback` has no
`getChangePayload` it arrives at `notifyItemRangeChanged(position, count, null)` and
`DefaultItemAnimator` cross-fades it.

The effect is that **every visible subtask row re-animates on every requery, whether or
not anything in the database changed.** Top-level rows are unaffected — `targetIndent` is
0 on both sides — which fits the shape of the reports in #4087: the more nesting on
screen, the worse it looks. Only the recursive query selects `indent`, so this is scoped
to lists showing subtasks.

### The change

Move `targetIndent` off the primary constructor and into the class body, which takes it
out of the generated `equals()`. `indent` stays exactly where it is — it is a real
column, and `DiffCallback` already compares it explicitly against the adapter, which
reads to me like the deliberate handling `targetIndent` never got.

Nothing constructs a `TaskContainer` with a `targetIndent` argument, and nothing calls
`.copy()` on one, so this is a compile-safe move.

### Tests

`DiffCallbackTest` covers a bound subtask surviving a requery, a bound top-level task
surviving a requery, and — so the fix can't quietly over-suppress — an edited title still
being reported as a change.

I checked the test actually pins the defect rather than just passing: reverting the
`TaskContainer` change fails `requeryingLeavesABoundSubtaskAlone` and leaves the
top-level case passing, which is the scoping above, executable.

`:app:testGenericDebugUnitTest`, `:data:jvmTest` and `:kmp:jvmTest` are green (1477 tests).
This is a JVM-verified change; I haven't watched it on a device, so if you want a
before/after screen recording before taking it, say so and I'll get one.

### What I left out

`AstridTaskAdapter.getIndent` returns `updater.getIndentForTask(task.uuid)` rather than
`task.indent`, so on the Astrid-sort path `indent` itself mismatches between a bound row
and a queried one — the same bug, second instance, and there the raw `==` defeats the
explicit indent check that was put there to handle it. Different fix, different risk, so
I kept it out of this diff. Happy to follow up if you want it.

The other half of #4568 — the refresh storm that decides *when* these requeries happen —
is unrelated to this change and still open.
