### PR TITLE
Refresh the task list only when a list or tag looks different

### DIFF
--- a/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/chips/ChipDataProvider.kt
@@ -15,6 +15,7 @@ import org.tasks.data.dao.TagDataDao
 import org.tasks.data.entity.TagData
 import org.tasks.filters.CaldavFilter
 import org.tasks.filters.CaldavListCache
+import org.tasks.filters.appearances
 import org.tasks.filters.TagFilter
 
 class ChipDataProvider(
@@ -39,10 +40,16 @@ class ChipDataProvider(
     fun getTag(tag: String?): TagFilter? = tagDatas[tag]
 
     private fun updateTags(updated: List<TagData>) {
-        Logger.d("ChipDataProvider") { "Updating tags" }
-        tagDatas = updated.associateBy({ it.remoteId }) { TagFilter(it) }
-        tagsVersion++
-        refreshBroadcaster.broadcastRefresh()
+        val tags = updated.associateBy({ it.remoteId }) { TagFilter(it) }
+        // Same gate as the one in CaldavListCache: the tag tables are written on every
+        // sync, and only a change to what a chip draws needs to reach the task list.
+        val changed = tags.appearances() != tagDatas.appearances()
+        tagDatas = tags
+        if (changed) {
+            Logger.d("ChipDataProvider") { "Updating tags" }
+            tagsVersion++
+            refreshBroadcaster.broadcastRefresh()
+        }
     }
 
     init {

--- a/kmp/src/commonMain/kotlin/org/tasks/filters/CaldavListCache.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/filters/CaldavListCache.kt
@@ -46,9 +46,15 @@ class CaldavListCache(
                     val account = accounts.find { it.uuid == list.account } ?: return@mapNotNull null
                     CaldavFilter(calendar = list, account = account)
                 }
-                byUuid = filters.associateBy { it.uuid }
+                val updated: Map<String?, CaldavFilter> = filters.associateBy { it.uuid }
+                // Only a rebuild that changes what a list draws is worth refreshing the
+                // task list for. See [appearances].
+                val changed = updated.appearances() != byUuid.appearances()
+                byUuid = updated
                 byId = filters.associateBy { it.calendar.id }
-                _version.value++
+                if (changed) {
+                    _version.value++
+                }
             }
             .launchIn(scope)
     }

--- a/kmp/src/commonMain/kotlin/org/tasks/filters/FilterAppearance.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/filters/FilterAppearance.kt
@@ -1,0 +1,19 @@
+package org.tasks.filters
+
+/**
+ * The parts of a [Filter] that a chip or a group header actually draws.
+ *
+ * Syncing writes to the calendar, account and tag tables constantly, and for things
+ * nothing renders: ctags, sync tokens, error state, last-sync timestamps. The caches over
+ * those tables rebuild on every one of those writes. Comparing this rather than the
+ * filters themselves is how they tell a rebuild that changes the task list apart from one
+ * that doesn't.
+ */
+data class FilterAppearance(
+    val title: String,
+    val icon: String?,
+    val tint: Int,
+)
+
+fun <K> Map<K, Filter>.appearances(): Map<K, FilterAppearance> =
+    mapValues { (_, filter) -> FilterAppearance(filter.title, filter.icon, filter.tint) }

--- a/kmp/src/jvmTest/kotlin/org/tasks/filters/FilterAppearanceTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/filters/FilterAppearanceTest.kt
@@ -1,0 +1,76 @@
+package org.tasks.filters
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.tasks.data.entity.CaldavAccount
+import org.tasks.data.entity.CaldavCalendar
+import org.tasks.data.entity.TagData
+
+class FilterAppearanceTest {
+    private fun lists(
+        name: String = "Personal",
+        color: Int = 0xff0000,
+        icon: String? = "list",
+        ctag: String? = "ctag-1",
+        lastSync: Long = 0,
+        error: String? = "",
+    ) = mapOf(
+        "uuid-1" to CaldavFilter(
+            calendar = CaldavCalendar(
+                uuid = "uuid-1",
+                name = name,
+                color = color,
+                icon = icon,
+                ctag = ctag,
+                lastSync = lastSync,
+            ),
+            account = CaldavAccount(uuid = "account-1", error = error, lastSync = lastSync),
+        )
+    )
+
+    private fun tags(name: String = "home", color: Int? = 0, icon: String? = "label") = mapOf(
+        "tag-1" to TagFilter(TagData(remoteId = "tag-1", name = name, color = color, icon = icon))
+    )
+
+    @Test
+    fun aSyncThatOnlyMovesTheCtagChangesNothing() {
+        assertEquals(
+            lists().appearances(),
+            lists(ctag = "ctag-2", lastSync = 1234, error = "unreachable").appearances(),
+        )
+    }
+
+    @Test
+    fun aRenamedListLooksDifferent() {
+        assertNotEquals(lists().appearances(), lists(name = "Work").appearances())
+    }
+
+    @Test
+    fun aRecolouredListLooksDifferent() {
+        assertNotEquals(lists().appearances(), lists(color = 0x00ff00).appearances())
+    }
+
+    @Test
+    fun aRelabelledListLooksDifferent() {
+        assertNotEquals(lists().appearances(), lists(icon = "star").appearances())
+    }
+
+    @Test
+    fun anAddedListLooksDifferent() {
+        val second = mapOf(
+            "uuid-2" to CaldavFilter(
+                calendar = CaldavCalendar(uuid = "uuid-2", name = "Work"),
+                account = CaldavAccount(uuid = "account-1"),
+            )
+        )
+
+        assertNotEquals(lists().appearances(), (lists() + second).appearances())
+    }
+
+    @Test
+    fun aRenamedTagLooksDifferent() {
+        assertEquals(tags().appearances(), tags().appearances())
+        assertNotEquals(tags().appearances(), tags(name = "work").appearances())
+    }
+}


### PR DESCRIPTION
Fixes the other half of #4568. Independent of #4569, which fixes the half that decides
whether a requery is *visible*; this one is about requeries that shouldn't happen at all.
Either can go first.

`CaldavListCache` watches the calendar and account tables and bumps its version on every
emission:

```kotlin
byUuid = filters.associateBy { it.uuid }
byId = filters.associateBy { it.calendar.id }
_version.value++
```

`ChipDataProvider` turns each bump into a `broadcastRefresh()`, which reaches
`TaskListViewModel.invalidate()`:

```kotlin
fun invalidate() {
    _state.update { it.copy(now = currentTimeMillis()) }
}
```

`now` is always a new value, so the `distinctUntilChanged()` guarding the query pipeline
never absorbs it. Every bump is a full `fetchTasks`, a fresh `SectionedDataSource` and a
`DiffUtil` pass.

The trouble is what writes to those tables. Syncing writes to them constantly and for
things nothing draws: ctags, sync tokens, error state, last-sync timestamps.
`OpenTasksSynchronizer.fetchChanges` does `caldavDao.update(calendar)` for the ctag and
then broadcasts directly, once per list; `setError` does the same per account; `SyncWork`
broadcasts three more times around each run. With several lists that is a rebuild of the
whole task list once per throttle window, continuously, for as long as the sync lasts.

`ChipDataProvider.updateTags` has the same shape and the same problem.

### The change

Both now compare what a chip or a group header actually draws — title, icon, tint — and
skip the version bump when that is unchanged. The caches themselves are still refreshed
either way, so `getListTitle` and `getCaldavList` keep returning current data; only the
subscribers are spared.

The projection is shared between the two call sites rather than written twice, since
"what does this filter draw" is one idea and both caches need it.

b1f79f9c26 already skipped the broadcast for an empty cache, so this is the same
reasoning applied to the contents rather than the size.

### Tests

`FilterAppearanceTest` covers the distinction the gate rests on: a sync that only moves
the ctag, the last-sync timestamp and the account error compares equal, while a rename, a
recolour, an icon change and an added list all compare different. It covers the tag path
too, since `updateTags` uses the same projection.

I tested the projection rather than the caches themselves deliberately — `CaldavListCache`
does its work in an `init` block on a `throttleLatest(1000)`, so driving it from a test
means either second-long sleeps or restructuring the class. The projection is the part
this PR adds and the part that can be wrong; the plumbing around it is untouched.

`:kmp:jvmTest` (902), `:data:jvmTest` (67), `:app:testGenericDebugUnitTest` (511) and
`:composeApp:desktopTest` are green.

### What this does not do

The frequency is only half of it. Even a legitimate requery currently repaints every
bound subtask row, which is #4569 — without that one, this change reduces how often the
list flickers but not whether it does.

Two smaller triggers are in #4533 and not here: `TaskListViewModel` derives its query
trigger from the whole `State`, so flipping the sync indicator re-runs the query, and
`TaskListFragment` re-submits identical results on unrelated state changes. Happy to
split those out too if you'd rather take them separately.
