### PR TITLE
Add AI task creation via OpenRouter

### DIFF
--- a/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
+++ b/app/src/main/java/com/todoroo/astrid/activity/TaskListFragment.kt
@@ -83,6 +83,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -176,6 +178,9 @@ import org.tasks.time.DateTimeUtils2.currentTimeMillis
 import org.tasks.ui.Banner
 import org.tasks.ui.TaskListEvent
 import org.tasks.ui.TaskListEventBus
+import org.tasks.ai.AiGate
+import org.tasks.compose.ai.AiCaptureSheet
+import org.tasks.ui.AiCaptureViewModel
 import org.tasks.ui.TaskListViewModel
 import tasks.kmp.generated.resources.Res
 import tasks.kmp.generated.resources.action_open
@@ -200,6 +205,7 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
     @Inject lateinit var viewHolderFactory: ViewHolderFactory
     @Inject lateinit var localBroadcastManager: LocalBroadcastManager
     @Inject lateinit var device: Device
+    @Inject lateinit var aiGate: AiGate
     @Inject lateinit var taskMover: TaskMover
     @Inject lateinit var taskAdapterProvider: TaskAdapterProvider
     @Inject lateinit var taskDao: TaskDao
@@ -221,6 +227,11 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
 
     private val listViewModel: TaskListViewModel by viewModels()
     private val mainViewModel: MainActivityViewModel by activityViewModels()
+    private val aiCaptureViewModel: AiCaptureViewModel by viewModels()
+    private val showAiSheetState: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private var showAiSheet: Boolean
+        get() = showAiSheetState.value
+        set(value) { showAiSheetState.value = value }
     private lateinit var taskAdapter: TaskAdapter
     private var recyclerAdapter: DragAndDropRecyclerAdapter? = null
     private var dirtyTaskIds: Set<Long> = emptySet()
@@ -675,6 +686,42 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
                 }
             }
         }
+        binding.aiCaptureCompose.setContent {
+            TasksTheme(
+                theme = theme.themeBase.index,
+                primary = theme.themeColor.primaryColor,
+            ) {
+                val visible = showAiSheetState.collectAsStateWithLifecycle().value
+                if (visible) {
+                    val captureState = aiCaptureViewModel.state.collectAsStateWithLifecycle().value
+                    val captureInput = aiCaptureViewModel.input.collectAsStateWithLifecycle().value
+                    AiCaptureSheet(
+                        state = captureState,
+                        input = captureInput,
+                        onInputChange = { aiCaptureViewModel.onInputChange(it) },
+                        onSubmit = { aiCaptureViewModel.submit() },
+                        onToggle = { aiCaptureViewModel.toggle(it) },
+                        onOpenInEditor = { index ->
+                            val task = aiCaptureViewModel.openInEditor(index)
+                            showAiSheet = false
+                            onTaskListItemClicked(task)
+                        },
+                        onConfirm = {
+                            lifecycleScope.launch {
+                                val created = aiCaptureViewModel.confirm()
+                                showAiSheet = false
+                                aiCaptureViewModel.reset()
+                                onTaskCreated(created)
+                            }
+                        },
+                        onDismiss = {
+                            showAiSheet = false
+                            aiCaptureViewModel.reset()
+                        },
+                    )
+                }
+            }
+        }
         ViewCompat.requestApplyInsets(binding.toolbar)
         return binding.root
     }
@@ -745,6 +792,7 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
             menu.findItem(R.id.menu_expand_subtasks).isVisible = false
         }
         menu.findItem(R.id.menu_voice_add).isVisible = device.voiceInputAvailable() && filter.isWritable
+        menu.findItem(R.id.menu_ai_add).isVisible = filter.isWritable
         menu.findItem(R.id.menu_clear_completed).isVisible = filter.isWritable
     }
 
@@ -760,6 +808,11 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
                     search.isVisible = true
                     search.expandActionView()
                 }
+                true
+            }
+            R.id.menu_ai_add -> {
+                aiCaptureViewModel.reset()
+                showAiSheet = true
                 true
             }
             R.id.menu_voice_add -> {
@@ -987,7 +1040,13 @@ class TaskListFragment : Fragment(), OnRefreshListener, Toolbar.OnMenuItemClickL
                         recognizedSpeech = (recognizedSpeech.substring(0, 1)
                             .uppercase(Locale.getDefault())
                                 + recognizedSpeech.substring(1).lowercase(Locale.getDefault()))
-                        onTaskListItemClicked(addTask(recognizedSpeech))
+                        if (aiGate.canCall()) {
+                            aiCaptureViewModel.reset()
+                            showAiSheet = true
+                            aiCaptureViewModel.submit(recognizedSpeech)
+                        } else {
+                            onTaskListItemClicked(addTask(recognizedSpeech))
+                        }
                         firebase.addTask("voice")
                     }
                 }

--- a/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
+++ b/app/src/main/java/com/todoroo/astrid/service/TaskCreator.kt
@@ -51,8 +51,14 @@ class TaskCreator @Inject constructor(
     private val locationDao: LocationDao,
     private val alarmDao: AlarmDao,
 ) {
-    suspend fun basicQuickAddTask(title: String, filter: Filter? = null): Task {
-        val task = createWithValues(filter, title.trim { it <= ' ' })
+    suspend fun basicQuickAddTask(title: String, filter: Filter? = null): Task =
+        persistNewTask(createWithValues(filter, title.trim { it <= ' ' }))
+
+    /**
+     * Persists an already-built, unsaved [task]. Split out of [basicQuickAddTask] so callers can
+     * build several tasks in memory, show them for review, and persist only the confirmed ones.
+     */
+    suspend fun persistNewTask(task: Task): Task {
         taskDao.createNew(task)
         val gcalCreateEventEnabled = preferences.isDefaultCalendarSet && task.hasDueDate() // $NON-NLS-1$
         if (!isNullOrEmpty(task.title)

--- a/app/src/main/java/org/tasks/ai/AndroidOpenRouterClientProvider.kt
+++ b/app/src/main/java/org/tasks/ai/AndroidOpenRouterClientProvider.kt
@@ -1,0 +1,34 @@
+package org.tasks.ai
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.logging.LogLevel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.tasks.BuildConfig
+import timber.log.Timber
+import javax.inject.Inject
+
+class AndroidOpenRouterClientProvider @Inject constructor(
+    private val gate: AiGate,
+    private val credentials: AiCredentialStore,
+) : OpenRouterClientProvider {
+
+    override suspend fun getService(): OpenRouterService? = withContext(Dispatchers.IO) {
+        if (!gate.canCall()) return@withContext null
+        val apiKey = credentials.getApiKey() ?: return@withContext null
+        OpenRouterService(newClient(apiKey))
+    }
+
+    override suspend fun validateKey(rawKey: String): List<ModelInfo> = withContext(Dispatchers.IO) {
+        OpenRouterService(newClient(rawKey.trim())).listModels()
+    }
+
+    private fun newClient(apiKey: String) = HttpClient(Android) {
+        installOpenRouter(
+            apiKey = apiKey,
+            logLevel = if (BuildConfig.DEBUG) LogLevel.ALL else LogLevel.HEADERS,
+            log = { Timber.d(it) },
+        )
+    }
+}

--- a/app/src/main/java/org/tasks/compose/ai/AiCaptureSheet.kt
+++ b/app/src/main/java/org/tasks/compose/ai/AiCaptureSheet.kt
@@ -1,0 +1,239 @@
+package org.tasks.compose.ai
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.tasks.ui.AiCaptureState
+import org.tasks.ui.ReviewItem
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_add_n
+import tasks.kmp.generated.resources.ai_input_hint
+import tasks.kmp.generated.resources.ai_thinking
+import tasks.kmp.generated.resources.cancel
+import tasks.kmp.generated.resources.done
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AiCaptureSheet(
+    state: AiCaptureState,
+    input: String,
+    onInputChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onToggle: (Int) -> Unit,
+    onOpenInEditor: (Int) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+        ) {
+            when (state) {
+                AiCaptureState.Input -> InputState(
+                    input = input,
+                    onInputChange = onInputChange,
+                    onSubmit = onSubmit,
+                )
+
+                AiCaptureState.Loading -> LoadingState(onCancel = onDismiss)
+
+                is AiCaptureState.Review -> ReviewState(
+                    items = state.items,
+                    onToggle = onToggle,
+                    onOpenInEditor = onOpenInEditor,
+                    onConfirm = onConfirm,
+                    onCancel = onDismiss,
+                )
+
+                is AiCaptureState.Error -> ErrorState(
+                    message = stringResource(state.messageRes),
+                    onDismiss = onDismiss,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InputState(
+    input: String,
+    onInputChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    // Requesting focus on composition is what raises the keyboard, which puts the GBoard mic
+    // one tap away. No speech API or RECORD_AUDIO permission is involved.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    OutlinedTextField(
+        value = input,
+        onValueChange = onInputChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        label = { Text(stringResource(Res.string.ai_input_hint)) },
+        singleLine = false,
+        maxLines = 4,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Sentences,
+            imeAction = ImeAction.Done,
+        ),
+        keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        Button(onClick = onSubmit, enabled = input.isNotBlank()) {
+            Text(stringResource(Res.string.done))
+        }
+    }
+}
+
+@Composable
+private fun LoadingState(onCancel: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        CircularProgressIndicator()
+        Text(
+            text = stringResource(Res.string.ai_thinking),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onCancel) {
+            Text(stringResource(Res.string.cancel))
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ReviewState(
+    items: List<ReviewItem>,
+    onToggle: (Int) -> Unit,
+    onOpenInEditor: (Int) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val checked = items.count { it.checked }
+
+    LazyColumn(
+        modifier = Modifier.heightIn(max = 420.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        itemsIndexed(items) { index, item ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onOpenInEditor(index) },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Checkbox(
+                        checked = item.checked,
+                        onCheckedChange = { onToggle(index) },
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = item.task.title.orEmpty(),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        if (item.chips.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                item.chips.forEach { chip ->
+                                    AssistChip(onClick = { }, label = { Text(chip) })
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        TextButton(onClick = onCancel) {
+            Text(stringResource(Res.string.cancel))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onConfirm, enabled = checked > 0) {
+            Text(stringResource(Res.string.ai_add_n, checked))
+        }
+    }
+}
+
+@Composable
+private fun ErrorState(message: String, onDismiss: () -> Unit) {
+    Box(modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp)) {
+        Text(text = message, style = MaterialTheme.typography.bodyLarge)
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        TextButton(onClick = onDismiss) {
+            Text(stringResource(Res.string.cancel))
+        }
+    }
+}

--- a/app/src/main/java/org/tasks/injection/ApplicationModule.kt
+++ b/app/src/main/java/org/tasks/injection/ApplicationModule.kt
@@ -20,6 +20,11 @@ import org.tasks.LocalBroadcastManager
 import com.todoroo.astrid.gcal.GCalHelper
 import com.todoroo.astrid.repeats.RepeatTaskHelper
 import org.tasks.analytics.Firebase
+import org.tasks.ai.AiCredentialStore
+import org.tasks.ai.AiTaskParser
+import org.tasks.ai.AiGate
+import org.tasks.ai.AndroidOpenRouterClientProvider
+import org.tasks.ai.OpenRouterClientProvider
 import org.tasks.audio.SoundPlayer
 import org.tasks.calendars.CalendarHelper
 import org.tasks.filters.CaldavListCache
@@ -282,6 +287,48 @@ class ApplicationModule {
     @Provides
     @Singleton
     fun providesKeyStoreEncryption(): KeyStoreEncryption = AndroidKeyStoreEncryption()
+
+    @Provides
+    @Singleton
+    fun providesAiCredentialStore(
+        tasksPreferences: TasksPreferences,
+        encryption: KeyStoreEncryption,
+    ) = AiCredentialStore(
+        tasksPreferences = tasksPreferences,
+        encryption = encryption,
+    )
+
+    @Provides
+    @Singleton
+    fun providesAiGate(
+        tasksPreferences: TasksPreferences,
+        credentials: AiCredentialStore,
+    ) = AiGate(
+        tasksPreferences = tasksPreferences,
+        credentials = credentials,
+    )
+
+    @Provides
+    @Singleton
+    fun providesOpenRouterClientProvider(
+        provider: AndroidOpenRouterClientProvider,
+    ): OpenRouterClientProvider = provider
+
+    @Provides
+    @Singleton
+    fun providesAiTaskParser(
+        clientProvider: OpenRouterClientProvider,
+        filterProvider: FilterProvider,
+        tagDataDao: TagDataDao,
+        tasksPreferences: TasksPreferences,
+        json: Json,
+    ) = AiTaskParser(
+        clientProvider = clientProvider,
+        filterProvider = filterProvider,
+        tagDataDao = tagDataDao,
+        tasksPreferences = tasksPreferences,
+        json = json,
+    )
 
     @Provides
     fun providesBroadcastRefresh(localBroadcastManager: LocalBroadcastManager): RefreshBroadcaster =

--- a/app/src/main/java/org/tasks/preferences/fragments/AiTaskCreation.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/AiTaskCreation.kt
@@ -1,0 +1,90 @@
+package org.tasks.preferences.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
+import dagger.hilt.android.AndroidEntryPoint
+import org.jetbrains.compose.resources.getString
+import org.tasks.R
+import org.tasks.TasksUrls
+import org.tasks.compose.AiDisclosureDialog
+import org.tasks.compose.settings.AiTaskCreationScreen
+import org.tasks.extensions.Context.openUri
+import org.tasks.extensions.Context.toast
+import org.tasks.preferences.BasePreferences
+import org.tasks.themes.TasksSettingsTheme
+import org.tasks.themes.Theme
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class AiTaskCreation : Fragment() {
+
+    @Inject lateinit var theme: Theme
+
+    private val viewModel: AiTaskCreationViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = content {
+        TasksSettingsTheme(
+            theme = theme.themeBase.index,
+            primary = theme.themeColor.primaryColor,
+        ) {
+            val state by viewModel.state.collectAsState()
+            val showDisclosure by viewModel.showDisclosure.collectAsState()
+            val message by viewModel.message.collectAsState()
+
+            AiTaskCreationScreen(
+                state = state,
+                onEnabledChange = { viewModel.onEnabledChange(it) },
+                onKeyChange = { viewModel.onKeyChange(it) },
+                onKeySubmit = { viewModel.onKeySubmit() },
+                onModelSelected = { viewModel.onModelSelected(it) },
+                onPrivacyPolicy = { context?.openUri(TasksUrls.OPENROUTER_PRIVACY) },
+            )
+
+            if (showDisclosure) {
+                AiDisclosureDialog(
+                    onAccept = { viewModel.onDisclosureAccepted() },
+                    onDismiss = { viewModel.onDisclosureDismissed() },
+                    openUrl = { context?.openUri(it) },
+                )
+            }
+
+            message?.let { resource ->
+                androidx.compose.runtime.LaunchedEffect(resource) {
+                    context?.toast(getString(resource))
+                    viewModel.messageShown()
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refresh()
+        val surfaceColor = theme.themeBase.getSettingsSurfaceColor(requireActivity())
+        (activity as? BasePreferences)?.toolbar?.let { toolbar ->
+            toolbar.setBackgroundColor(surfaceColor)
+            (toolbar.parent as? View)?.setBackgroundColor(surfaceColor)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        val defaultColor = ContextCompat.getColor(requireContext(), R.color.content_background)
+        (activity as? BasePreferences)?.toolbar?.let { toolbar ->
+            toolbar.setBackgroundColor(defaultColor)
+            (toolbar.parent as? View)?.setBackgroundColor(defaultColor)
+        }
+    }
+}

--- a/app/src/main/java/org/tasks/preferences/fragments/AiTaskCreationViewModel.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/AiTaskCreationViewModel.kt
@@ -1,0 +1,156 @@
+package org.tasks.preferences.fragments
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
+import org.tasks.ai.AiCredentialStore
+import org.tasks.ai.AiGate
+import org.tasks.ai.ModelInfo
+import org.tasks.ai.OpenRouterClientProvider
+import org.tasks.compose.settings.AiModelOption
+import org.tasks.compose.settings.AiTaskCreationState
+import org.tasks.http.UnauthorizedException
+import org.tasks.preferences.TasksPreferences
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_key_invalid
+import tasks.kmp.generated.resources.ai_no_compatible_models
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class AiTaskCreationViewModel @Inject constructor(
+    private val gate: AiGate,
+    private val credentials: AiCredentialStore,
+    private val tasksPreferences: TasksPreferences,
+    private val clientProvider: OpenRouterClientProvider,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AiTaskCreationState())
+    val state: StateFlow<AiTaskCreationState> = _state.asStateFlow()
+
+    private val _showDisclosure = MutableStateFlow(false)
+    val showDisclosure: StateFlow<Boolean> = _showDisclosure.asStateFlow()
+
+    /** Non-blocking message (e.g. no compatible models), consumed by the fragment as a toast. */
+    private val _message = MutableStateFlow<StringResource?>(null)
+    val message: StateFlow<StringResource?> = _message.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() = viewModelScope.launch {
+        _state.update {
+            it.copy(
+                enabled = gate.isEnabled(),
+                hasStoredKey = credentials.hasApiKey(),
+                selectedModel = tasksPreferences
+                    .get(TasksPreferences.aiModel, "")
+                    .takeIf { model -> model.isNotBlank() },
+            )
+        }
+    }
+
+    fun onKeyChange(key: String) {
+        _state.update { it.copy(keyInput = key, keyError = null) }
+    }
+
+    /**
+     * Verifies [AiTaskCreationState.keyInput] against OpenRouter before storing it. Nothing is
+     * written when the key is rejected, so [AiGate.canCall] cannot be satisfied by a bad key.
+     */
+    fun onKeySubmit() = viewModelScope.launch {
+        val key = _state.value.keyInput.trim()
+        if (key.isBlank()) return@launch
+        _state.update { it.copy(loadingModels = true, keyError = null) }
+        val models = try {
+            clientProvider.validateKey(key)
+        } catch (e: UnauthorizedException) {
+            Timber.d(e)
+            _state.update {
+                it.copy(loadingModels = false, keyError = Res.string.ai_key_invalid)
+            }
+            return@launch
+        } catch (e: Exception) {
+            Timber.e(e)
+            _state.update {
+                it.copy(loadingModels = false, keyError = Res.string.ai_key_invalid)
+            }
+            return@launch
+        }
+
+        val compatible = models
+            .filter { it.supportsStructuredOutputs }
+            .sortedWith(compareByDescending<ModelInfo> { it.isFree }.thenBy { it.id })
+
+        if (compatible.isEmpty()) {
+            _message.value = Res.string.ai_no_compatible_models
+            _state.update { it.copy(loadingModels = false) }
+            return@launch
+        }
+
+        credentials.setApiKey(key)
+
+        val selected = _state.value.selectedModel
+            ?.takeIf { current -> compatible.any { it.id == current } }
+            ?: compatible.firstOrNull { it.isFree }?.id
+            ?: compatible.first().id
+        tasksPreferences.set(TasksPreferences.aiModel, selected)
+
+        _state.update {
+            it.copy(
+                loadingModels = false,
+                keyInput = "",
+                hasStoredKey = true,
+                models = compatible.map { model ->
+                    AiModelOption(id = model.id, label = model.name ?: model.id)
+                },
+                selectedModel = selected,
+            )
+        }
+    }
+
+    /**
+     * Toggling on while unconsented raises the disclosure instead of enabling, so consent
+     * cannot be bypassed from this screen.
+     */
+    fun onEnabledChange(enabled: Boolean) = viewModelScope.launch {
+        if (!enabled) {
+            tasksPreferences.set(TasksPreferences.aiTaskCreationEnabled, false)
+            _state.update { it.copy(enabled = false) }
+            return@launch
+        }
+        if (!gate.hasConsent()) {
+            _showDisclosure.value = true
+            return@launch
+        }
+        tasksPreferences.set(TasksPreferences.aiTaskCreationEnabled, true)
+        _state.update { it.copy(enabled = true) }
+    }
+
+    fun onDisclosureAccepted() = viewModelScope.launch {
+        gate.acceptConsent()
+        tasksPreferences.set(TasksPreferences.aiTaskCreationEnabled, true)
+        _showDisclosure.value = false
+        _state.update { it.copy(enabled = true) }
+    }
+
+    fun onDisclosureDismissed() {
+        _showDisclosure.value = false
+    }
+
+    fun onModelSelected(id: String) = viewModelScope.launch {
+        tasksPreferences.set(TasksPreferences.aiModel, id)
+        _state.update { it.copy(selectedModel = id) }
+    }
+
+    fun messageShown() {
+        _message.value = null
+    }
+}

--- a/app/src/main/java/org/tasks/preferences/fragments/MainSettingsComposeFragment.kt
+++ b/app/src/main/java/org/tasks/preferences/fragments/MainSettingsComposeFragment.kt
@@ -288,6 +288,7 @@ class MainSettingsComposeFragment : Fragment() {
             SettingsDestination.TaskDefaults -> TaskDefaults()
             SettingsDestination.TaskList -> TaskListPreferences()
             SettingsDestination.TaskEdit -> TaskEditPreferences()
+            SettingsDestination.AiTaskCreation -> AiTaskCreation()
             SettingsDestination.DateAndTime -> DateAndTime()
             SettingsDestination.NavigationDrawer -> NavigationDrawer()
             SettingsDestination.Backups -> Backups()

--- a/app/src/main/java/org/tasks/ui/AiCaptureViewModel.kt
+++ b/app/src/main/java/org/tasks/ui/AiCaptureViewModel.kt
@@ -1,0 +1,162 @@
+package org.tasks.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.todoroo.astrid.service.TaskCreator
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
+import org.tasks.ai.AiFailure
+import org.tasks.ai.AiParseResult
+import org.tasks.ai.AiTaskParser
+import org.tasks.ai.ParsedTask
+import org.tasks.ai.applyTo
+import org.tasks.data.GoogleTask
+import org.tasks.data.entity.CaldavTask
+import org.tasks.data.entity.Tag
+import org.tasks.data.entity.Task
+import org.tasks.filters.CaldavFilter
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_error_bad_response
+import tasks.kmp.generated.resources.ai_error_network
+import tasks.kmp.generated.resources.ai_error_no_tasks
+import tasks.kmp.generated.resources.ai_error_rate_limited
+import tasks.kmp.generated.resources.ai_error_unauthorized
+import tasks.kmp.generated.resources.ai_error_unavailable
+import tasks.kmp.generated.resources.ai_not_configured
+import javax.inject.Inject
+
+sealed interface AiCaptureState {
+    data object Input : AiCaptureState
+    data object Loading : AiCaptureState
+    data class Review(val items: List<ReviewItem>) : AiCaptureState
+    data class Error(val messageRes: StringResource) : AiCaptureState
+}
+
+/** One parsed task awaiting confirmation. [task] is built but deliberately unsaved. */
+data class ReviewItem(
+    val task: Task,
+    val parsed: ParsedTask,
+    val checked: Boolean = true,
+    val chips: List<String> = emptyList(),
+)
+
+@HiltViewModel
+class AiCaptureViewModel @Inject constructor(
+    private val parser: AiTaskParser,
+    private val taskCreator: TaskCreator,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<AiCaptureState>(AiCaptureState.Input)
+    val state: StateFlow<AiCaptureState> = _state.asStateFlow()
+
+    private val _input = MutableStateFlow("")
+    val input: StateFlow<String> = _input.asStateFlow()
+
+    private var parseJob: Job? = null
+
+    fun onInputChange(text: String) {
+        _input.value = text
+    }
+
+    fun reset() {
+        parseJob?.cancel()
+        parseJob = null
+        _input.value = ""
+        _state.value = AiCaptureState.Input
+    }
+
+    fun submit(text: String = _input.value) {
+        parseJob?.cancel()
+        _input.value = text
+        parseJob = viewModelScope.launch {
+            _state.value = AiCaptureState.Loading
+            when (val result = parser.parse(text)) {
+                is AiParseResult.NotConfigured ->
+                    _state.value = AiCaptureState.Error(Res.string.ai_not_configured)
+
+                is AiParseResult.Failure ->
+                    _state.value = AiCaptureState.Error(result.reason.messageRes())
+
+                is AiParseResult.Success -> {
+                    val lists = parser.writableLists()
+                    val knownTags = parser.knownTags()
+                    val items = result.tasks.map { parsed ->
+                        // createWithValues still runs TitleParser on the AI-produced title. That
+                        // is harmless: the prompt strips scheduling language from the title, and
+                        // applyTo runs afterward and wins on any field the model did set.
+                        val task = taskCreator.createWithValues(null, parsed.title)
+                        parsed.applyTo(task, lists, knownTags)
+                        ReviewItem(
+                            task = task,
+                            parsed = parsed,
+                            chips = chipsFor(task, parsed, lists),
+                        )
+                    }
+                    _state.value = AiCaptureState.Review(items)
+                }
+            }
+        }
+    }
+
+    fun toggle(index: Int) {
+        val current = _state.value as? AiCaptureState.Review ?: return
+        _state.value = AiCaptureState.Review(
+            current.items.mapIndexed { i, item ->
+                if (i == index) item.copy(checked = !item.checked) else item
+            }
+        )
+    }
+
+    fun openInEditor(index: Int): Task? =
+        (_state.value as? AiCaptureState.Review)?.items?.getOrNull(index)?.task
+
+    /** Persists only the checked items. Nothing reaches the database before this runs. */
+    suspend fun confirm(): List<Task> {
+        val current = _state.value as? AiCaptureState.Review ?: return emptyList()
+        return current.items
+            .filter { it.checked }
+            .map { taskCreator.persistNewTask(it.task) }
+    }
+
+    private fun AiFailure.messageRes(): StringResource = when (this) {
+        AiFailure.UNAUTHORIZED -> Res.string.ai_error_unauthorized
+        AiFailure.RATE_LIMITED -> Res.string.ai_error_rate_limited
+        AiFailure.UNAVAILABLE -> Res.string.ai_error_unavailable
+        AiFailure.BAD_RESPONSE -> Res.string.ai_error_bad_response
+        AiFailure.NO_TASKS -> Res.string.ai_error_no_tasks
+        AiFailure.NETWORK -> Res.string.ai_error_network
+    }
+}
+
+/**
+ * Chips describe what was actually applied to [task], not what the model asked for: an
+ * unmatched list or tag is dropped by [applyTo], and showing it here would mislead.
+ */
+private fun chipsFor(
+    task: Task,
+    parsed: ParsedTask,
+    lists: List<CaldavFilter>,
+): List<String> = buildList {
+    val listUuid = task.getTransitory<String>(CaldavTask.KEY)
+        ?: task.getTransitory<String>(GoogleTask.KEY)
+    listUuid?.let { uuid -> lists.firstOrNull { it.uuid == uuid }?.let { add(it.title) } }
+
+    if (task.hasDueDate()) {
+        parsed.due?.takeIf { it.isNotBlank() }?.let { add(it.replace('T', ' ')) }
+    }
+
+    when (task.priority) {
+        Task.Priority.HIGH -> add("!!!")
+        Task.Priority.MEDIUM -> add("!!")
+        Task.Priority.LOW -> add("!")
+        else -> {}
+    }
+
+    task.getTransitory<ArrayList<String>>(Tag.KEY)?.let { addAll(it) }
+}

--- a/app/src/main/res/drawable/outline_auto_awesome_24.xml
+++ b/app/src/main/res/drawable/outline_auto_awesome_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M19,9l1.25,-2.75L23,5l-2.75,-1.25L19,1l-1.25,2.75L15,5l2.75,1.25L19,9zM11.5,9.5L9,4L6.5,9.5L1,12l5.5,2.5L9,20l2.5,-5.5L17,12L11.5,9.5zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15z"/>
+
+</vector>

--- a/app/src/main/res/layout/fragment_task_list.xml
+++ b/app/src/main/res/layout/fragment_task_list.xml
@@ -89,4 +89,10 @@
       app:layout_anchorGravity="top|end"
       app:srcCompat="@drawable/ic_outline_add_24px"/>
 
+  <androidx.compose.ui.platform.ComposeView
+      android:id="@+id/ai_capture_compose"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="bottom" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/menu_task_list_fragment_bottom.xml
+++ b/app/src/main/res/menu/menu_task_list_fragment_bottom.xml
@@ -29,6 +29,11 @@
         android:title="@string/TLA_menu_sort"
         app:showAsAction="always" />
     <item
+        android:id="@+id/menu_ai_add"
+        android:icon="@drawable/outline_auto_awesome_24"
+        android:title="@string/ai_add_task"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/menu_voice_add"
         android:icon="@drawable/ic_outline_mic_none_24px"
         android:title="@string/EPr_voiceInputEnabled_title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,4 +457,6 @@ File %1$s contained %2$s.\n\n
   <string name="button_learn_more">Learn more</string>
   <string name="widget_view_more_tasks">View more tasks</string>
   <string name="read_more">Read more</string>
+    <!-- Task list overflow menu entry for AI task creation -->
+    <string name="ai_add_task">AI task</string>
 </resources>

--- a/app/src/test/java/org/tasks/ai/AiCaptureViewModelTest.kt
+++ b/app/src/test/java/org/tasks/ai/AiCaptureViewModelTest.kt
@@ -1,0 +1,207 @@
+package org.tasks.ai
+
+import com.todoroo.astrid.service.TaskCreator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.tasks.data.entity.Task
+import org.tasks.ui.AiCaptureState
+import org.tasks.ui.AiCaptureViewModel
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_error_bad_response
+import tasks.kmp.generated.resources.ai_error_network
+import tasks.kmp.generated.resources.ai_error_no_tasks
+import tasks.kmp.generated.resources.ai_error_rate_limited
+import tasks.kmp.generated.resources.ai_error_unauthorized
+import tasks.kmp.generated.resources.ai_error_unavailable
+import tasks.kmp.generated.resources.ai_not_configured
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AiCaptureViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun parsed(title: String, priority: String? = null) = ParsedTask(
+        title = title,
+        priority = priority,
+    )
+
+    private fun taskCreator(): TaskCreator = mock {
+        onBlocking { createWithValues(anyFilter(), any()) } doAnswer { invocation ->
+            Task(title = invocation.getArgument<String?>(1))
+        }
+        onBlocking { persistNewTask(any()) } doAnswer { invocation ->
+            invocation.getArgument(0)
+        }
+    }
+
+    private fun anyFilter() = org.mockito.kotlin.anyOrNull<org.tasks.filters.Filter>()
+
+    private fun parser(result: AiParseResult): AiTaskParser = mock {
+        onBlocking { parse(any()) } doReturn result
+        onBlocking { writableLists() } doReturn emptyList()
+        onBlocking { knownTags() } doReturn emptyList()
+    }
+
+    private fun viewModel(
+        result: AiParseResult,
+        creator: TaskCreator = taskCreator(),
+    ) = AiCaptureViewModel(parser(result), creator)
+
+    @Test
+    fun startsInInputState() = runTest(dispatcher) {
+        assertEquals(AiCaptureState.Input, viewModel(AiParseResult.NotConfigured).state.value)
+    }
+
+    @Test
+    fun multiTaskParseProducesOneCheckedItemPerTask() = runTest(dispatcher) {
+        val vm = viewModel(
+            AiParseResult.Success(listOf(parsed("Call dentist"), parsed("Buy milk")))
+        )
+        vm.submit("dentist and milk")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue(state is AiCaptureState.Review)
+        val items = (state as AiCaptureState.Review).items
+        assertEquals(2, items.size)
+        assertEquals(listOf("Call dentist", "Buy milk"), items.map { it.task.title })
+        assertTrue(items.all { it.checked })
+    }
+
+    @Test
+    fun confirmPersistsOnlyCheckedItems() = runTest(dispatcher) {
+        val creator = taskCreator()
+        val vm = viewModel(
+            AiParseResult.Success(listOf(parsed("Call dentist"), parsed("Buy milk"))),
+            creator,
+        )
+        vm.submit("dentist and milk")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.toggle(1)
+        val created = vm.confirm()
+
+        assertEquals(listOf("Call dentist"), created.map { it.title })
+        verify(creator).persistNewTask(any())
+    }
+
+    @Test
+    fun confirmPersistsNothingWhenAllUnchecked() = runTest(dispatcher) {
+        val creator = taskCreator()
+        val vm = viewModel(AiParseResult.Success(listOf(parsed("Call dentist"))), creator)
+        vm.submit("dentist")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.toggle(0)
+        val created = vm.confirm()
+
+        assertTrue(created.isEmpty())
+        verify(creator, never()).persistNewTask(any())
+    }
+
+    @Test
+    fun confirmOutsideReviewPersistsNothing() = runTest(dispatcher) {
+        val creator = taskCreator()
+        val vm = viewModel(AiParseResult.NotConfigured, creator)
+
+        assertTrue(vm.confirm().isEmpty())
+        verify(creator, never()).persistNewTask(any())
+    }
+
+    @Test
+    fun notConfiguredYieldsSettingsPointer() = runTest(dispatcher) {
+        val vm = viewModel(AiParseResult.NotConfigured)
+        vm.submit("anything")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            AiCaptureState.Error(Res.string.ai_not_configured),
+            vm.state.value,
+        )
+    }
+
+    @Test
+    fun everyFailureMapsToItsOwnMessage() = runTest(dispatcher) {
+        val expected = mapOf(
+            AiFailure.UNAUTHORIZED to Res.string.ai_error_unauthorized,
+            AiFailure.RATE_LIMITED to Res.string.ai_error_rate_limited,
+            AiFailure.UNAVAILABLE to Res.string.ai_error_unavailable,
+            AiFailure.BAD_RESPONSE to Res.string.ai_error_bad_response,
+            AiFailure.NO_TASKS to Res.string.ai_error_no_tasks,
+            AiFailure.NETWORK to Res.string.ai_error_network,
+        )
+        for ((failure, resource) in expected) {
+            val vm = viewModel(AiParseResult.Failure(failure))
+            vm.submit("anything")
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(failure.name, AiCaptureState.Error(resource), vm.state.value)
+        }
+    }
+
+    @Test
+    fun parsingNeverPersistsAnything() = runTest(dispatcher) {
+        val creator = taskCreator()
+        val vm = viewModel(AiParseResult.Success(listOf(parsed("Call dentist"))), creator)
+        vm.submit("dentist")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(creator, never()).persistNewTask(any())
+    }
+
+    @Test
+    fun openInEditorReturnsTheUnsavedTask() = runTest(dispatcher) {
+        val creator = taskCreator()
+        val vm = viewModel(AiParseResult.Success(listOf(parsed("Call dentist"))), creator)
+        vm.submit("dentist")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("Call dentist", vm.openInEditor(0)?.title)
+        assertNull(vm.openInEditor(5))
+        verify(creator, never()).persistNewTask(any())
+    }
+
+    @Test
+    fun resetReturnsToInputAndClearsText() = runTest(dispatcher) {
+        val vm = viewModel(AiParseResult.Success(listOf(parsed("Call dentist"))))
+        vm.onInputChange("dentist")
+        vm.submit()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.reset()
+
+        assertEquals(AiCaptureState.Input, vm.state.value)
+        assertEquals("", vm.input.value)
+    }
+
+    @Test
+    fun toggleOutsideReviewIsANoop() = runTest(dispatcher) {
+        val vm = viewModel(AiParseResult.NotConfigured)
+        vm.toggle(0)
+
+        assertEquals(AiCaptureState.Input, vm.state.value)
+    }
+}

--- a/app/src/test/java/org/tasks/ai/AiTaskCreationViewModelTest.kt
+++ b/app/src/test/java/org/tasks/ai/AiTaskCreationViewModelTest.kt
@@ -1,0 +1,249 @@
+package org.tasks.ai
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.tasks.http.UnauthorizedException
+import org.tasks.preferences.TasksPreferences
+import org.tasks.preferences.fragments.AiTaskCreationViewModel
+import org.tasks.security.KeyProvider
+import org.tasks.security.KeyStoreEncryption
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_key_invalid
+import tasks.kmp.generated.resources.ai_no_compatible_models
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AiTaskCreationViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private class InMemoryDataStore : DataStore<Preferences> {
+        private val state = MutableStateFlow(emptyPreferences())
+        override val data: Flow<Preferences> = state
+        override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences {
+            val updated = transform(state.value)
+            state.value = updated
+            return updated
+        }
+    }
+
+    private class FakeProvider(
+        var models: List<ModelInfo> = emptyList(),
+        var error: Throwable? = null,
+    ) : OpenRouterClientProvider {
+        var validateCalls = 0
+        override suspend fun getService(): OpenRouterService? = null
+        override suspend fun validateKey(rawKey: String): List<ModelInfo> {
+            validateCalls++
+            error?.let { throw it }
+            return models
+        }
+    }
+
+    private lateinit var preferences: TasksPreferences
+    private lateinit var credentials: AiCredentialStore
+    private lateinit var gate: AiGate
+    private lateinit var provider: FakeProvider
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        preferences = TasksPreferences(InMemoryDataStore())
+        credentials = AiCredentialStore(
+            preferences,
+            KeyStoreEncryption(object : KeyProvider {
+                private val key: SecretKey =
+                    KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+                override fun getKey() = key
+            })
+        )
+        gate = AiGate(preferences, credentials)
+        provider = FakeProvider()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() =
+        AiTaskCreationViewModel(gate, credentials, preferences, provider)
+
+    /**
+     * [KeyStoreEncryption] hops to [Dispatchers.Default], which the test scheduler does not
+     * control, so draining the test dispatcher alone is not enough to observe a stored key.
+     */
+    private fun awaitUntil(timeoutMs: Long = 5_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            dispatcher.scheduler.advanceUntilIdle()
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        dispatcher.scheduler.advanceUntilIdle()
+        if (!condition()) throw AssertionError("Timed out waiting for view model state")
+    }
+
+    private fun model(id: String, structured: Boolean) = ModelInfo(
+        id = id,
+        name = id,
+        supportedParameters = if (structured) listOf("structured_outputs") else emptyList(),
+    )
+
+    @Test
+    fun togglingOnWhileUnconsentedRaisesDialogAndDoesNotEnable() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onEnabledChange(true)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(vm.showDisclosure.value)
+        assertFalse(vm.state.value.enabled)
+        assertFalse(preferences.get(TasksPreferences.aiTaskCreationEnabled, false))
+    }
+
+    @Test
+    fun acceptingDisclosureSetsConsentAndEnables() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onEnabledChange(true)
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onDisclosureAccepted()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(vm.showDisclosure.value)
+        assertTrue(vm.state.value.enabled)
+        assertTrue(gate.hasConsent())
+        assertTrue(preferences.get(TasksPreferences.aiTaskCreationEnabled, false))
+    }
+
+    @Test
+    fun dismissingDisclosureLeavesFeatureOff() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onEnabledChange(true)
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onDisclosureDismissed()
+
+        assertFalse(vm.showDisclosure.value)
+        assertFalse(vm.state.value.enabled)
+        assertFalse(gate.hasConsent())
+        assertFalse(preferences.get(TasksPreferences.aiTaskCreationEnabled, false))
+    }
+
+    @Test
+    fun invalidKeySetsErrorAndStoresNothing() = runTest(dispatcher) {
+        provider.error = UnauthorizedException("nope")
+        val vm = viewModel()
+        vm.onKeyChange("sk-bad")
+        vm.onKeySubmit()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(Res.string.ai_key_invalid, vm.state.value.keyError)
+        assertFalse(credentials.hasApiKey())
+        assertTrue(vm.state.value.models.isEmpty())
+    }
+
+    @Test
+    fun validKeyStoresKeyAndFiltersToStructuredOutputModels() = runTest(dispatcher) {
+        provider.models = listOf(
+            model("vendor/plain", structured = false),
+            model("vendor/structured:free", structured = true),
+        )
+        val vm = viewModel()
+        vm.onKeyChange("sk-good")
+        vm.onKeySubmit()
+        awaitUntil { vm.state.value.selectedModel != null }
+
+        assertNull(vm.state.value.keyError)
+        assertEquals("sk-good", credentials.getApiKey())
+        assertEquals(
+            listOf("vendor/structured:free"),
+            vm.state.value.models.map { it.id },
+        )
+        assertEquals("vendor/structured:free", vm.state.value.selectedModel)
+        assertEquals(
+            "vendor/structured:free",
+            preferences.get(TasksPreferences.aiModel, ""),
+        )
+        assertTrue(vm.state.value.hasStoredKey)
+    }
+
+    @Test
+    fun noCompatibleModelsSurfacesMessageAndStoresNothing() = runTest(dispatcher) {
+        provider.models = listOf(model("vendor/plain", structured = false))
+        val vm = viewModel()
+        vm.onKeyChange("sk-good")
+        vm.onKeySubmit()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(Res.string.ai_no_compatible_models, vm.message.value)
+        assertFalse(credentials.hasApiKey())
+        assertFalse(preferences.get(TasksPreferences.aiTaskCreationEnabled, false))
+    }
+
+    @Test
+    fun freeModelIsPreferredWhenAutoSelecting() = runTest(dispatcher) {
+        provider.models = listOf(
+            model("aaa/paid", structured = true),
+            model("zzz/free:free", structured = true),
+        )
+        val vm = viewModel()
+        vm.onKeyChange("sk-good")
+        vm.onKeySubmit()
+        awaitUntil { vm.state.value.selectedModel != null }
+
+        assertEquals("zzz/free:free", vm.state.value.selectedModel)
+    }
+
+    @Test
+    fun blankKeyIsNotSubmitted() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onKeyChange("   ")
+        vm.onKeySubmit()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0, provider.validateCalls)
+    }
+
+    @Test
+    fun disablingClearsThePreferenceWithoutTouchingConsent() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onEnabledChange(true)
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onDisclosureAccepted()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.onEnabledChange(false)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(vm.state.value.enabled)
+        assertFalse(preferences.get(TasksPreferences.aiTaskCreationEnabled, false))
+        assertTrue(gate.hasConsent())
+    }
+
+    @Test
+    fun selectingAModelPersistsIt() = runTest(dispatcher) {
+        val vm = viewModel()
+        vm.onModelSelected("vendor/other:free")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("vendor/other:free", vm.state.value.selectedModel)
+        assertEquals("vendor/other:free", preferences.get(TasksPreferences.aiModel, ""))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -179,6 +179,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 locale = { module = "com.twofortyfouram:android-plugin-api-for-locale", version.ref = "locale" }
 make-it-easy = { module = "com.natpryce:make-it-easy", version.ref = "make-it-easy" }
 markwon = { module = "io.noties.markwon:core", version.ref = "markwon" }

--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -65,6 +65,9 @@ kotlin {
                 implementation(libs.mockito.kotlin)
                 implementation(libs.androidx.room)
                 implementation(libs.androidx.sqlite)
+                implementation(libs.ktor.client.mock)
+                implementation(libs.ktor.content.negotiation)
+                implementation(libs.ktor.serialization)
             }
         }
         jvmCommonMain.dependencies {

--- a/kmp/src/commonMain/composeResources/values/strings.xml
+++ b/kmp/src/commonMain/composeResources/values/strings.xml
@@ -598,4 +598,26 @@
     <string name="subtasks_multilevel_microsoft">Multi-level subtasks not supported by Microsoft To Do</string>
     <string name="subtasks_will_be_flattened">This list doesn't support nested subtasks. Saving will move them all to the top level.</string>
     <string name="subtask_list_locked">New subtasks use the parent's list</string>
+    <string name="ai_task_creation">AI task creation</string>
+    <string name="ai_task_creation_enable">Enable AI task creation</string>
+    <string name="ai_api_key">OpenRouter API key</string>
+    <string name="ai_model">Model</string>
+    <string name="ai_model_none">Enter an API key to load models</string>
+    <string name="ai_disclosure_title">Your task text is sent to OpenRouter</string>
+    <string name="ai_disclosure_body">When you use AI task creation, what you type or dictate — along with the names of your lists and tags — is sent to OpenRouter and the model provider you select. Free models may retain and train on what you send, according to each provider's own policy. Nothing is sent unless you start an AI task.</string>
+    <string name="ai_disclosure_accept">I understand</string>
+    <string name="ai_privacy_policy">OpenRouter privacy policy</string>
+    <string name="ai_key_invalid">Couldn't verify that key</string>
+    <string name="ai_no_compatible_models">No models on your account support structured output</string>
+    <string name="ai_add_task">AI task</string>
+    <string name="ai_input_hint">Describe your tasks…</string>
+    <string name="ai_thinking">Thinking…</string>
+    <string name="ai_add_n">Add %1$d</string>
+    <string name="ai_error_unauthorized">Your OpenRouter key was rejected. Check it in Settings.</string>
+    <string name="ai_error_rate_limited">OpenRouter rate limit reached. Try again shortly.</string>
+    <string name="ai_error_unavailable">OpenRouter is unavailable right now.</string>
+    <string name="ai_error_bad_response">The model returned something unusable. Try rephrasing.</string>
+    <string name="ai_error_no_tasks">Couldn't find any tasks in that.</string>
+    <string name="ai_error_network">No connection.</string>
+    <string name="ai_not_configured">Set up AI task creation in Settings first.</string>
 </resources>

--- a/kmp/src/commonMain/kotlin/org/tasks/TasksUrls.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/TasksUrls.kt
@@ -10,6 +10,7 @@ object TasksUrls {
     const val SOURCE_CODE = "https://tasks.org/source"
     const val TOS = "https://tasks.org/terms"
     const val PRIVACY_POLICY = "https://tasks.org/privacy"
+    const val OPENROUTER_PRIVACY = "https://openrouter.ai/privacy"
     const val LICENSE = "https://tasks.org/license"
     const val SUPPORT_EMAIL = "support@tasks.org"
     const val GOOGLE_PLAY_SUBSCRIPTIONS = "https://play.google.com/store/account/subscriptions"

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/AiDisclosureDialog.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/AiDisclosureDialog.kt
@@ -1,0 +1,67 @@
+package org.tasks.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import org.jetbrains.compose.resources.stringResource
+import org.tasks.TasksUrls
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_disclosure_accept
+import tasks.kmp.generated.resources.ai_disclosure_body
+import tasks.kmp.generated.resources.ai_disclosure_title
+import tasks.kmp.generated.resources.ai_privacy_policy
+import tasks.kmp.generated.resources.cancel
+
+/**
+ * Unlike [TosUpdateDialog] the dismiss action is Cancel, not Exit: declining an optional
+ * feature leaves the feature off rather than closing the app.
+ */
+@Composable
+fun AiDisclosureDialog(
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit,
+    openUrl: (String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+        title = { Text(text = stringResource(Res.string.ai_disclosure_title)) },
+        text = {
+            Column {
+                Text(text = stringResource(Res.string.ai_disclosure_body))
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(Res.string.ai_privacy_policy),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    textDecoration = TextDecoration.Underline,
+                    modifier = Modifier.clickable { openUrl(TasksUrls.OPENROUTER_PRIVACY) },
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(Res.string.cancel))
+            }
+        },
+        confirmButton = {
+            Button(onClick = onAccept) {
+                Text(text = stringResource(Res.string.ai_disclosure_accept))
+            }
+        },
+    )
+}

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/settings/AiTaskCreationScreen.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/settings/AiTaskCreationScreen.kt
@@ -1,0 +1,214 @@
+package org.tasks.compose.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.PermIdentity
+import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import tasks.kmp.generated.resources.Res
+import tasks.kmp.generated.resources.ai_api_key
+import tasks.kmp.generated.resources.ai_disclosure_body
+import tasks.kmp.generated.resources.ai_model
+import tasks.kmp.generated.resources.ai_model_none
+import tasks.kmp.generated.resources.ai_privacy_policy
+import tasks.kmp.generated.resources.ai_task_creation_enable
+import tasks.kmp.generated.resources.cancel
+import tasks.kmp.generated.resources.save
+
+/**
+ * One model the user may pick, flattened for the UI so this screen stays free of transport DTOs
+ * (which live in `jvmCommonMain` and are not visible from `commonMain`).
+ */
+data class AiModelOption(
+    val id: String,
+    val label: String,
+)
+
+data class AiTaskCreationState(
+    val enabled: Boolean = false,
+    val keyInput: String = "",
+    val hasStoredKey: Boolean = false,
+    val keyError: StringResource? = null,
+    val models: List<AiModelOption> = emptyList(),
+    val selectedModel: String? = null,
+    val loadingModels: Boolean = false,
+)
+
+@Composable
+fun AiTaskCreationScreen(
+    state: AiTaskCreationState,
+    onEnabledChange: (Boolean) -> Unit,
+    onKeyChange: (String) -> Unit,
+    onKeySubmit: () -> Unit,
+    onModelSelected: (String) -> Unit,
+    onPrivacyPolicy: () -> Unit,
+) {
+    var showModelPicker by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .verticalScroll(rememberScrollState())
+    ) {
+        if (state.loadingModels) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+
+        Spacer(modifier = Modifier.height(SettingsContentPadding))
+
+        Column(modifier = Modifier.padding(horizontal = SettingsContentPadding)) {
+            SettingsItemCard {
+                SwitchPreferenceRow(
+                    title = stringResource(Res.string.ai_task_creation_enable),
+                    checked = state.enabled,
+                    onCheckedChange = onEnabledChange,
+                    icon = Icons.Outlined.AutoAwesome,
+                    indent = false,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(SettingsContentPadding))
+
+        Column(
+            modifier = Modifier.padding(horizontal = SettingsContentPadding),
+            verticalArrangement = Arrangement.spacedBy(SettingsCardGap),
+        ) {
+            TextInputCard(
+                value = state.keyInput,
+                onValueChange = onKeyChange,
+                label = stringResource(Res.string.ai_api_key),
+                placeholder = if (state.hasStoredKey) "••••••••" else null,
+                error = state.keyError?.let { stringResource(it) },
+                position = CardPosition.First,
+                contentType = ContentType.Password,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    capitalization = KeyboardCapitalization.None,
+                ),
+                visualTransformation = PasswordVisualTransformation(),
+            )
+            SettingsItemCard(position = CardPosition.Middle) {
+                PreferenceRow(
+                    title = stringResource(Res.string.save),
+                    icon = Icons.Outlined.Save,
+                    enabled = state.keyInput.isNotBlank() && !state.loadingModels,
+                    onClick = onKeySubmit,
+                )
+            }
+            SettingsItemCard(position = CardPosition.Last) {
+                PreferenceRow(
+                    title = stringResource(Res.string.ai_model),
+                    summary = state.selectedModel ?: stringResource(Res.string.ai_model_none),
+                    enabled = state.models.isNotEmpty(),
+                    showChevron = state.models.isNotEmpty(),
+                    onClick = { showModelPicker = true },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(SettingsContentPadding))
+
+        Text(
+            text = stringResource(Res.string.ai_disclosure_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = SettingsContentPadding),
+        )
+
+        Spacer(modifier = Modifier.height(SettingsContentPadding))
+
+        Column(modifier = Modifier.padding(horizontal = SettingsContentPadding)) {
+            SettingsItemCard {
+                PreferenceRow(
+                    title = stringResource(Res.string.ai_privacy_policy),
+                    icon = Icons.Outlined.PermIdentity,
+                    onClick = onPrivacyPolicy,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(SettingsContentPadding))
+    }
+
+    if (showModelPicker && state.models.isNotEmpty()) {
+        AlertDialog(
+            onDismissRequest = { showModelPicker = false },
+            title = { Text(stringResource(Res.string.ai_model)) },
+            text = {
+                LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
+                    items(state.models, key = { it.id }) { model ->
+                        val select = {
+                            onModelSelected(model.id)
+                            showModelPicker = false
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(onClick = select)
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = model.id == state.selectedModel,
+                                onClick = select,
+                            )
+                            Column {
+                                Text(
+                                    text = model.label,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                                Text(
+                                    text = model.id,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showModelPicker = false }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            },
+        )
+    }
+}

--- a/kmp/src/commonMain/kotlin/org/tasks/compose/settings/MainSettingsScreen.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/compose/settings/MainSettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Build
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Edit
@@ -35,6 +36,7 @@ import org.tasks.data.entity.CaldavAccount
 import tasks.kmp.generated.resources.Res
 import tasks.kmp.generated.resources.EPr_edit_screen_options
 import tasks.kmp.generated.resources.add_account
+import tasks.kmp.generated.resources.ai_task_creation
 import tasks.kmp.generated.resources.backup_BPr_header
 import tasks.kmp.generated.resources.caldav
 import tasks.kmp.generated.resources.etesync
@@ -66,6 +68,7 @@ sealed class SettingsDestination(override val titleRes: StringResource) : Settin
     data object TaskDefaults : SettingsDestination(Res.string.task_defaults)
     data object TaskList : SettingsDestination(Res.string.task_list_options)
     data object TaskEdit : SettingsDestination(Res.string.EPr_edit_screen_options)
+    data object AiTaskCreation : SettingsDestination(Res.string.ai_task_creation)
     data object DateAndTime : SettingsDestination(Res.string.date_and_time)
     data object NavigationDrawer : SettingsDestination(Res.string.navigation_drawer)
     data object Backups : SettingsDestination(Res.string.backup_BPr_header)
@@ -268,11 +271,18 @@ fun SettingsCategories(
                 onClick = { onSettingsClick(SettingsDestination.TaskList) }
             )
         }
-        SettingsItemCard(position = CardPosition.Last) {
+        SettingsItemCard(position = CardPosition.Middle) {
             PreferenceRow(
                 title = stringResource(Res.string.EPr_edit_screen_options),
                 icon = Icons.Outlined.Edit,
                 onClick = { onSettingsClick(SettingsDestination.TaskEdit) }
+            )
+        }
+        SettingsItemCard(position = CardPosition.Last) {
+            PreferenceRow(
+                title = stringResource(Res.string.ai_task_creation),
+                icon = Icons.Outlined.AutoAwesome,
+                onClick = { onSettingsClick(SettingsDestination.AiTaskCreation) }
             )
         }
     }

--- a/kmp/src/commonMain/kotlin/org/tasks/preferences/TasksPreferences.kt
+++ b/kmp/src/commonMain/kotlin/org/tasks/preferences/TasksPreferences.kt
@@ -116,5 +116,9 @@ class TasksPreferences(private val dataStore: DataStore<Preferences>) {
         val defaultLocation = stringPreferencesKey("default_location")
         val defaultLocationReminder = intPreferencesKey("default_location_reminder")
         val locationUpdateInterval = intPreferencesKey("location_update_interval")
+        val aiTaskCreationEnabled = booleanPreferencesKey("ai_task_creation_enabled")
+        val aiApiKey = stringPreferencesKey("ai_api_key")
+        val aiModel = stringPreferencesKey("ai_model")
+        val aiDisclosureVersion = intPreferencesKey("ai_disclosure_version")
     }
 }

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiCredentialStore.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiCredentialStore.kt
@@ -1,0 +1,29 @@
+package org.tasks.ai
+
+import org.tasks.preferences.TasksPreferences
+import org.tasks.security.KeyStoreEncryption
+
+/**
+ * The only code that touches the stored OpenRouter API key ciphertext.
+ */
+class AiCredentialStore(
+    private val tasksPreferences: TasksPreferences,
+    private val encryption: KeyStoreEncryption,
+) {
+    suspend fun getApiKey(): String? =
+        tasksPreferences.get(TasksPreferences.aiApiKey, "")
+            .takeIf { it.isNotBlank() }
+            ?.let { encryption.decrypt(it) }
+            ?.takeIf { it.isNotBlank() }
+
+    suspend fun setApiKey(key: String) {
+        if (key.isBlank()) {
+            tasksPreferences.set(TasksPreferences.aiApiKey, "")
+        } else {
+            encryption.encrypt(key.trim())
+                ?.let { tasksPreferences.set(TasksPreferences.aiApiKey, it) }
+        }
+    }
+
+    suspend fun hasApiKey(): Boolean = getApiKey() != null
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiTaskParser.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiTaskParser.kt
@@ -1,0 +1,100 @@
+package org.tasks.ai
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.tasks.data.dao.TagDataDao
+import org.tasks.filters.CaldavFilter
+import org.tasks.filters.FilterProvider
+import org.tasks.http.NetworkException
+import org.tasks.http.RateLimitedException
+import org.tasks.http.ServiceUnavailableException
+import org.tasks.http.UnauthorizedException
+import org.tasks.preferences.TasksPreferences
+import java.io.IOException
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+sealed interface AiParseResult {
+    data class Success(val tasks: List<ParsedTask>) : AiParseResult
+    data object NotConfigured : AiParseResult
+    data class Failure(val reason: AiFailure) : AiParseResult
+}
+
+enum class AiFailure { UNAUTHORIZED, RATE_LIMITED, UNAVAILABLE, BAD_RESPONSE, NO_TASKS, NETWORK }
+
+const val DEFAULT_AI_MODEL = "google/gemini-2.0-flash-exp:free"
+
+class AiTaskParser(
+    private val clientProvider: OpenRouterClientProvider,
+    private val filterProvider: FilterProvider,
+    private val tagDataDao: TagDataDao,
+    private val tasksPreferences: TasksPreferences,
+    private val json: Json,
+    private val zoneId: () -> ZoneId = { ZoneId.systemDefault() },
+) {
+    /** Never throws: every failure mode is returned as an [AiParseResult]. */
+    suspend fun parse(input: String): AiParseResult {
+        if (input.isBlank()) return AiParseResult.Failure(AiFailure.NO_TASKS)
+
+        val service = clientProvider.getService() ?: return AiParseResult.NotConfigured
+        val model = tasksPreferences
+            .get(TasksPreferences.aiModel, "")
+            .takeIf { it.isNotBlank() }
+            ?: DEFAULT_AI_MODEL
+
+        return try {
+            val zone = zoneId()
+            val response = service.chat(
+                ChatRequest(
+                    model = model,
+                    messages = buildMessages(
+                        input = input,
+                        listNames = writableLists().map { it.title },
+                        tagNames = tagDataDao.getTagFilters().mapNotNull { it.tagData.name },
+                        nowIso = LocalDateTime.now(zone)
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")),
+                        timeZoneId = zone.id,
+                    ),
+                    responseFormat = ResponseFormat(
+                        jsonSchema = JsonSchemaSpec(name = "tasks", schema = TASK_SCHEMA),
+                    ),
+                )
+            )
+
+            val content = response.choices.firstOrNull()?.message?.content
+                ?: return AiParseResult.Failure(AiFailure.BAD_RESPONSE)
+
+            val tasks = json
+                .decodeFromString<ParsedTaskList>(content)
+                .tasks
+                .filter { it.title.isNotBlank() }
+
+            if (tasks.isEmpty()) {
+                AiParseResult.Failure(AiFailure.NO_TASKS)
+            } else {
+                AiParseResult.Success(tasks)
+            }
+        } catch (e: UnauthorizedException) {
+            AiParseResult.Failure(AiFailure.UNAUTHORIZED)
+        } catch (e: RateLimitedException) {
+            AiParseResult.Failure(AiFailure.RATE_LIMITED)
+        } catch (e: ServiceUnavailableException) {
+            AiParseResult.Failure(AiFailure.UNAVAILABLE)
+        } catch (e: SerializationException) {
+            AiParseResult.Failure(AiFailure.BAD_RESPONSE)
+        } catch (e: NetworkException) {
+            AiParseResult.Failure(AiFailure.NETWORK)
+        } catch (e: IOException) {
+            AiParseResult.Failure(AiFailure.NETWORK)
+        }
+    }
+
+    suspend fun writableLists(): List<CaldavFilter> =
+        filterProvider
+            .allLists()
+            .filterIsInstance<CaldavFilter>()
+            .filter { !it.isReadOnly }
+
+    suspend fun knownTags() = tagDataDao.getTagFilters().map { it.tagData }
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiTaskPrompt.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/AiTaskPrompt.kt
@@ -1,0 +1,99 @@
+package org.tasks.ai
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * OpenRouter's `strict: true` requires every property to appear in `required` and
+ * `additionalProperties` to be false, so optional fields are typed `["string","null"]`
+ * rather than omitted.
+ */
+val TASK_SCHEMA: JsonObject = buildJsonObject {
+    put("type", "object")
+    putJsonObject("properties") {
+        putJsonObject("tasks") {
+            put("type", "array")
+            putJsonObject("items") {
+                put("type", "object")
+                putJsonObject("properties") {
+                    putJsonObject("title") { put("type", "string") }
+                    putJsonObject("notes") { putJsonArray("type") { add("string"); add("null") } }
+                    putJsonObject("list") { putJsonArray("type") { add("string"); add("null") } }
+                    putJsonObject("tags") {
+                        put("type", "array")
+                        putJsonObject("items") { put("type", "string") }
+                    }
+                    putJsonObject("due") { putJsonArray("type") { add("string"); add("null") } }
+                    putJsonObject("start") { putJsonArray("type") { add("string"); add("null") } }
+                    putJsonObject("priority") { putJsonArray("type") { add("string"); add("null") } }
+                    putJsonObject("recurrence") { putJsonArray("type") { add("string"); add("null") } }
+                }
+                putJsonArray("required") {
+                    add("title"); add("notes"); add("list"); add("tags")
+                    add("due"); add("start"); add("priority"); add("recurrence")
+                }
+                put("additionalProperties", false)
+            }
+        }
+    }
+    putJsonArray("required") { add("tasks") }
+    put("additionalProperties", false)
+}
+
+/**
+ * Builds the messages sent to OpenRouter. The transmitted payload is exactly [input] plus
+ * [listNames] and [tagNames] — matching what the privacy disclosure states.
+ */
+fun buildMessages(
+    input: String,
+    listNames: List<String>,
+    tagNames: List<String>,
+    nowIso: String,
+    timeZoneId: String,
+): List<ChatMessage> {
+    val lists = if (listNames.isEmpty()) {
+        "(none)"
+    } else {
+        listNames.joinToString("\n") { "- $it" }
+    }
+    val tags = if (tagNames.isEmpty()) {
+        "(none)"
+    } else {
+        tagNames.joinToString("\n") { "- $it" }
+    }
+    val system = """
+        You turn a person's free-form request into structured to-do tasks.
+
+        The current local date and time is $nowIso in time zone $timeZoneId. Resolve every
+        relative expression ("tomorrow", "next Tuesday", "in two weeks") against that.
+
+        Rules:
+        - Split the request into separate tasks when the person describes multiple distinct
+          items. Otherwise return exactly one task.
+        - "title" is a short imperative task name with the scheduling language removed. It is
+          not a transcript of what the person said.
+        - "list" must be one of the available list names below, copied verbatim, or null.
+        - "tags" must be drawn from the available tag names below, copied verbatim. Return an
+          empty array rather than inventing a tag.
+        - "due" and "start" are local-time ISO-8601: "YYYY-MM-DD", or "YYYY-MM-DDTHH:MM" when a
+          time is stated. Always include the time whenever the person states one.
+        - "priority" is one of "high", "medium", "low", or "none".
+        - "recurrence" is a bare RFC-5545 RRULE such as "FREQ=WEEKLY;BYDAY=MO", or null.
+        - Use null for anything the person did not state. Do not guess.
+
+        Available lists:
+        $lists
+
+        Available tags:
+        $tags
+    """.trimIndent()
+
+    return listOf(
+        ChatMessage(role = "system", content = system),
+        ChatMessage(role = "user", content = input),
+    )
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterClient.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterClient.kt
@@ -1,0 +1,52 @@
+package org.tasks.ai
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+const val OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+fun HttpClientConfig<*>.installOpenRouter(
+    apiKey: String,
+    logLevel: LogLevel = LogLevel.HEADERS,
+    log: (String) -> Unit,
+) {
+    // Non-2xx bodies are read so OpenRouter's own error messages can be surfaced;
+    // status mapping lives in OpenRouterService instead of a plugin.
+    expectSuccess = false
+
+    install(ContentNegotiation) {
+        json(
+            Json {
+                ignoreUnknownKeys = true
+            }
+        )
+    }
+
+    defaultRequest {
+        header(HttpHeaders.Authorization, "Bearer $apiKey")
+        header("HTTP-Referer", "https://tasks.org")
+        header("X-Title", "Tasks.org")
+    }
+
+    install(HttpTimeout) {
+        // Double the Graph client's 30s: model inference is slower than a CRUD call.
+        requestTimeoutMillis = 60_000
+    }
+
+    install(Logging) {
+        logger = object : Logger {
+            override fun log(message: String) = log(message)
+        }
+        level = logLevel
+        sanitizeHeader { header -> header == HttpHeaders.Authorization }
+    }
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterClientProvider.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterClientProvider.kt
@@ -1,0 +1,37 @@
+package org.tasks.ai
+
+import org.tasks.preferences.TasksPreferences
+
+/**
+ * Bump whenever the disclosure text or the set of transmitted data materially changes;
+ * raising it re-prompts every user, mirroring [TasksPreferences.acceptedTosVersion].
+ */
+const val AI_DISCLOSURE_VERSION = 1
+
+interface OpenRouterClientProvider {
+    /** Returns null if the feature is disabled, unconsented, or has no API key. */
+    suspend fun getService(): OpenRouterService?
+
+    /** Builds a throwaway client from [rawKey] to verify it, without reading stored state. */
+    suspend fun validateKey(rawKey: String): List<ModelInfo>
+}
+
+class AiGate(
+    private val tasksPreferences: TasksPreferences,
+    private val credentials: AiCredentialStore,
+) {
+    suspend fun isEnabled(): Boolean =
+        tasksPreferences.get(TasksPreferences.aiTaskCreationEnabled, false)
+
+    suspend fun hasConsent(): Boolean =
+        tasksPreferences.get(TasksPreferences.aiDisclosureVersion, 0) >= AI_DISCLOSURE_VERSION
+
+    suspend fun acceptConsent() =
+        tasksPreferences.set(TasksPreferences.aiDisclosureVersion, AI_DISCLOSURE_VERSION)
+
+    suspend fun revokeConsent() =
+        tasksPreferences.set(TasksPreferences.aiDisclosureVersion, 0)
+
+    /** Every precondition for making a task-parsing network call. */
+    suspend fun canCall(): Boolean = isEnabled() && hasConsent() && credentials.hasApiKey()
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterDtos.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterDtos.kt
@@ -1,0 +1,58 @@
+package org.tasks.ai
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class ChatRequest(
+    val model: String,
+    val messages: List<ChatMessage>,
+    @SerialName("response_format") val responseFormat: ResponseFormat? = null,
+    val temperature: Double = 0.0,
+    @SerialName("max_tokens") val maxTokens: Int = 2048,
+)
+
+@Serializable
+data class ChatMessage(val role: String, val content: String)
+
+@Serializable
+data class ResponseFormat(
+    val type: String = "json_schema",
+    @SerialName("json_schema") val jsonSchema: JsonSchemaSpec,
+)
+
+@Serializable
+data class JsonSchemaSpec(
+    val name: String,
+    val strict: Boolean = true,
+    val schema: JsonObject,
+)
+
+@Serializable
+data class ChatResponse(val choices: List<Choice> = emptyList()) {
+    @Serializable
+    data class Choice(
+        val message: ChatMessage? = null,
+        @SerialName("finish_reason") val finishReason: String? = null,
+    )
+}
+
+@Serializable
+data class OpenRouterError(val error: ErrorBody? = null) {
+    @Serializable
+    data class ErrorBody(val message: String? = null)
+}
+
+@Serializable
+data class ModelsResponse(val data: List<ModelInfo> = emptyList())
+
+@Serializable
+data class ModelInfo(
+    val id: String,
+    val name: String? = null,
+    @SerialName("supported_parameters") val supportedParameters: List<String> = emptyList(),
+) {
+    val isFree: Boolean get() = id.endsWith(":free")
+    val supportsStructuredOutputs: Boolean get() = supportedParameters.contains("structured_outputs")
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterService.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/OpenRouterService.kt
@@ -1,0 +1,46 @@
+package org.tasks.ai
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import org.tasks.http.HttpException
+import org.tasks.http.NotFoundException
+import org.tasks.http.RateLimitedException
+import org.tasks.http.ServiceUnavailableException
+import org.tasks.http.UnauthorizedException
+
+class OpenRouterService(private val client: HttpClient) {
+
+    suspend fun listModels(): List<ModelInfo> =
+        client.get("$OPENROUTER_BASE_URL/models").require<ModelsResponse>().data
+
+    suspend fun chat(request: ChatRequest): ChatResponse =
+        client
+            .post("$OPENROUTER_BASE_URL/chat/completions") {
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+            .require()
+
+    private suspend inline fun <reified T> HttpResponse.require(): T {
+        if (status.isSuccess()) return body()
+        val detail = runCatching { body<OpenRouterError>().error?.message }.getOrNull()
+        val message = "HTTP ${status.value}" + (detail?.let { " - $it" } ?: "")
+        throw when {
+            status.value == 401 || status.value == 403 -> UnauthorizedException(message)
+            status.value == 404 -> NotFoundException(message)
+            status.value == 429 -> RateLimitedException(
+                message,
+                headers["Retry-After"]?.toLongOrNull(),
+            )
+            status.value in 500..599 -> ServiceUnavailableException(message)
+            else -> HttpException(status.value, message)
+        }
+    }
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/ParsedTask.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/ParsedTask.kt
@@ -1,0 +1,21 @@
+package org.tasks.ai
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ParsedTaskList(val tasks: List<ParsedTask> = emptyList())
+
+@Serializable
+data class ParsedTask(
+    val title: String,
+    val notes: String? = null,
+    val list: String? = null,
+    val tags: List<String> = emptyList(),
+    /** Local time, "2026-09-01" or "2026-09-01T14:00". */
+    val due: String? = null,
+    val start: String? = null,
+    /** high | medium | low | none */
+    val priority: String? = null,
+    /** Bare RFC-5545 RRULE, e.g. "FREQ=WEEKLY;BYDAY=MO". */
+    val recurrence: String? = null,
+)

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/ParsedTaskMapper.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/ai/ParsedTaskMapper.kt
@@ -1,0 +1,108 @@
+package org.tasks.ai
+
+import org.tasks.data.GoogleTask
+import org.tasks.data.createDueDate
+import org.tasks.data.createHideUntil
+import org.tasks.data.entity.CaldavTask
+import org.tasks.data.entity.Tag
+import org.tasks.data.entity.TagData
+import org.tasks.data.entity.Task
+import org.tasks.filters.CaldavFilter
+import org.tasks.repeats.RecurrenceUtils
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * Applies a model-produced [ParsedTask] onto an already-built, unsaved [task].
+ *
+ * Every field is defensive: garbage in one field must not lose the whole task, so anything
+ * unparseable is dropped and the value already set by `TaskCreator.create()` is kept.
+ */
+fun ParsedTask.applyTo(
+    task: Task,
+    lists: List<CaldavFilter>,
+    knownTags: List<TagData>,
+) {
+    // The system default zone, deliberately: createDueDate/createHideUntil re-derive the
+    // calendar day in that zone, so parsing in any other zone would shift the date.
+    val zoneId: ZoneId = ZoneId.systemDefault()
+    title.trim().takeIf { it.isNotBlank() }?.let { task.title = it }
+
+    notes?.trim()?.takeIf { it.isNotBlank() }?.let { task.notes = it }
+
+    priorityConstant()?.let { task.priority = it }
+
+    due?.let { value ->
+        parseLocal(value, zoneId)?.let { (millis, hasTime) ->
+            task.dueDate = createDueDate(
+                if (hasTime) Task.URGENCY_SPECIFIC_DAY_TIME else Task.URGENCY_SPECIFIC_DAY,
+                millis,
+            )
+        }
+    }
+
+    start?.let { value ->
+        parseLocal(value, zoneId)?.let { (millis, hasTime) ->
+            task.hideUntil = task.createHideUntil(
+                if (hasTime) Task.HIDE_UNTIL_SPECIFIC_DAY_TIME else Task.HIDE_UNTIL_SPECIFIC_DAY,
+                millis,
+            )
+        }
+    }
+
+    recurrence?.trim()?.takeIf { it.isNotBlank() }?.let { rrule ->
+        runCatching { RecurrenceUtils.newRecur(rrule) }
+            .onSuccess {
+                task.recurrence = rrule
+                task.repeatFrom = Task.RepeatFrom.DUE_DATE
+            }
+    }
+
+    // No match leaves no transitory, so basicQuickAddTask falls back to the default list.
+    list?.trim()?.takeIf { it.isNotBlank() }?.let { name ->
+        lists
+            .filter { !it.isReadOnly }
+            .firstOrNull { it.title.equals(name, ignoreCase = true) }
+            ?.let { filter ->
+                if (filter.isGoogleTasks) {
+                    task.putTransitory(GoogleTask.KEY, filter.uuid)
+                } else {
+                    task.putTransitory(CaldavTask.KEY, filter.uuid)
+                }
+            }
+    }
+
+    // Unmatched names are dropped rather than created: getOrCreateTags would let a hallucinated
+    // tag permanently pollute the drawer.
+    val resolved = tags
+        .mapNotNull { name ->
+            knownTags.firstOrNull { it.name.equals(name.trim(), ignoreCase = true) }?.name
+        }
+        .distinct()
+    if (resolved.isNotEmpty()) {
+        task.putTransitory(Tag.KEY, ArrayList(resolved))
+    }
+}
+
+private fun ParsedTask.priorityConstant(): Int? = when (priority?.trim()?.lowercase()) {
+    "high" -> Task.Priority.HIGH
+    "medium" -> Task.Priority.MEDIUM
+    "low" -> Task.Priority.LOW
+    else -> null // "none", unknown, or absent: keep the configured default priority
+}
+
+/** Returns epoch millis paired with whether the value carried a time. */
+private fun parseLocal(value: String, zoneId: ZoneId): Pair<Long, Boolean>? {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty()) return null
+    runCatching {
+        val dateTime = LocalDateTime.parse(trimmed)
+        return dateTime.atZone(zoneId).toInstant().toEpochMilli() to true
+    }
+    runCatching {
+        val date = LocalDate.parse(trimmed)
+        return date.atStartOfDay(zoneId).toInstant().toEpochMilli() to false
+    }
+    return null
+}

--- a/kmp/src/jvmCommonMain/kotlin/org/tasks/http/HttpErrorHandler.kt
+++ b/kmp/src/jvmCommonMain/kotlin/org/tasks/http/HttpErrorHandler.kt
@@ -42,6 +42,10 @@ class UnauthorizedException(message: String? = null, cause: Throwable? = null, g
 class NotFoundException(message: String? = null, cause: Throwable? = null, graphCode: String? = null) : NetworkException(message, cause, graphCode)
 class ServiceUnavailableException(message: String? = null, cause: Throwable? = null, graphCode: String? = null) : NetworkException(message, cause, graphCode)
 class HttpException(val code: Int, override val message: String? = null, graphCode: String? = null) : NetworkException(message, graphCode = graphCode)
+class RateLimitedException(
+    message: String? = null,
+    val retryAfterSeconds: Long? = null,
+) : NetworkException(message)
 
 class HttpErrorHandler {
     class Config {

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/AiCredentialStoreTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/AiCredentialStoreTest.kt
@@ -1,0 +1,64 @@
+package org.tasks.ai
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.tasks.preferences.TasksPreferences
+
+class AiCredentialStoreTest {
+
+    private val preferences = TasksPreferences(InMemoryDataStore())
+    private val store = AiCredentialStore(preferences, testEncryption())
+
+    @Test
+    fun noKeyByDefault() = runBlocking {
+        assertNull(store.getApiKey())
+        assertFalse(store.hasApiKey())
+    }
+
+    @Test
+    fun roundTripsApiKey() = runBlocking {
+        store.setApiKey("sk-or-v1-secret")
+
+        assertEquals("sk-or-v1-secret", store.getApiKey())
+        assertTrue(store.hasApiKey())
+    }
+
+    @Test
+    fun storesCiphertextNotPlaintext() = runBlocking {
+        store.setApiKey("sk-or-v1-secret")
+
+        val stored = preferences.get(TasksPreferences.aiApiKey, "")
+        assertTrue(stored.isNotBlank())
+        assertNotEquals("sk-or-v1-secret", stored)
+        assertFalse(stored.contains("secret"))
+    }
+
+    @Test
+    fun trimsWhitespaceBeforeStoring() = runBlocking {
+        store.setApiKey("  sk-or-v1-secret \n")
+
+        assertEquals("sk-or-v1-secret", store.getApiKey())
+    }
+
+    @Test
+    fun blankKeyClearsStoredKey() = runBlocking {
+        store.setApiKey("sk-or-v1-secret")
+        store.setApiKey("   ")
+
+        assertNull(store.getApiKey())
+        assertFalse(store.hasApiKey())
+    }
+
+    @Test
+    fun corruptCiphertextReadsAsNoKey() = runBlocking {
+        preferences.set(TasksPreferences.aiApiKey, "not-valid-base64-ciphertext")
+
+        assertNull(store.getApiKey())
+        assertFalse(store.hasApiKey())
+    }
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/AiGateTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/AiGateTest.kt
@@ -1,0 +1,84 @@
+package org.tasks.ai
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.tasks.preferences.TasksPreferences
+
+class AiGateTest {
+
+    private val preferences = TasksPreferences(InMemoryDataStore())
+    private val credentials = AiCredentialStore(preferences, testEncryption())
+    private val gate = AiGate(preferences, credentials)
+
+    private suspend fun configure(enabled: Boolean, consented: Boolean, keyed: Boolean) {
+        preferences.set(TasksPreferences.aiTaskCreationEnabled, enabled)
+        preferences.set(
+            TasksPreferences.aiDisclosureVersion,
+            if (consented) AI_DISCLOSURE_VERSION else 0,
+        )
+        credentials.setApiKey(if (keyed) "sk-or-v1-secret" else "")
+    }
+
+    @Test
+    fun cannotCallWhenNothingConfigured() = runBlocking {
+        assertFalse(gate.isEnabled())
+        assertFalse(gate.hasConsent())
+        assertFalse(gate.canCall())
+    }
+
+    @Test
+    fun canCallOnlyWhenEnabledConsentedAndKeyed() = runBlocking {
+        for (enabled in listOf(false, true)) {
+            for (consented in listOf(false, true)) {
+                for (keyed in listOf(false, true)) {
+                    configure(enabled, consented, keyed)
+                    assertEquals(
+                        "enabled=$enabled consented=$consented keyed=$keyed",
+                        enabled && consented && keyed,
+                        gate.canCall(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun acceptConsentStoresCurrentDisclosureVersion() = runBlocking {
+        gate.acceptConsent()
+
+        assertTrue(gate.hasConsent())
+        assertEquals(
+            AI_DISCLOSURE_VERSION,
+            preferences.get(TasksPreferences.aiDisclosureVersion, 0),
+        )
+    }
+
+    @Test
+    fun revokeConsentClearsIt() = runBlocking {
+        gate.acceptConsent()
+        gate.revokeConsent()
+
+        assertFalse(gate.hasConsent())
+    }
+
+    @Test
+    fun staleConsentVersionDoesNotCount() = runBlocking {
+        configure(enabled = true, consented = true, keyed = true)
+        preferences.set(TasksPreferences.aiDisclosureVersion, AI_DISCLOSURE_VERSION - 1)
+
+        assertFalse(gate.hasConsent())
+        assertFalse(gate.canCall())
+    }
+
+    @Test
+    fun newerConsentVersionStillCounts() = runBlocking {
+        configure(enabled = true, consented = true, keyed = true)
+        preferences.set(TasksPreferences.aiDisclosureVersion, AI_DISCLOSURE_VERSION + 1)
+
+        assertTrue(gate.hasConsent())
+        assertTrue(gate.canCall())
+    }
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/AiTaskParserTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/AiTaskParserTest.kt
@@ -1,0 +1,192 @@
+package org.tasks.ai
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.tasks.data.TagFilters
+import org.tasks.data.dao.TagDataDao
+import org.tasks.data.entity.CaldavAccount
+import org.tasks.data.entity.CaldavCalendar
+import org.tasks.data.entity.TagData
+import org.tasks.filters.CaldavFilter
+import org.tasks.filters.Filter
+import org.tasks.filters.FilterProvider
+import org.tasks.preferences.TasksPreferences
+import java.time.ZoneId
+
+class AiTaskParserTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private class FakeProvider(private val service: OpenRouterService?) : OpenRouterClientProvider {
+        override suspend fun getService(): OpenRouterService? = service
+        override suspend fun validateKey(rawKey: String): List<ModelInfo> = emptyList()
+    }
+
+    private fun serviceReturning(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): OpenRouterService {
+        val engine = MockEngine {
+            respond(
+                content = body,
+                status = status,
+                headers = headersOf(
+                    HttpHeaders.ContentType,
+                    ContentType.Application.Json.toString(),
+                ),
+            )
+        }
+        return OpenRouterService(
+            HttpClient(engine) { installOpenRouter(apiKey = "sk-test", log = {}) }
+        )
+    }
+
+    private fun chatBody(content: String): String {
+        val escaped = json.encodeToString(JsonPrimitive(content))
+        return """{"choices":[{"message":{"role":"assistant","content":$escaped}}]}"""
+    }
+
+    private val lists: List<Filter> = listOf(
+        CaldavFilter(
+            calendar = CaldavCalendar(name = "Personal", uuid = "cal-1"),
+            account = CaldavAccount(accountType = CaldavAccount.TYPE_CALDAV),
+        )
+    )
+
+    private fun parser(service: OpenRouterService?): AiTaskParser {
+        val filterProvider = mock<FilterProvider> {
+            onBlocking { allLists() } doReturn lists
+        }
+        val tagDataDao = mock<TagDataDao> {
+            onBlocking { getTagFilters(any()) } doReturn listOf(
+                TagFilters(tagData = TagData(name = "errand"), count = 0)
+            )
+        }
+        return AiTaskParser(
+            clientProvider = FakeProvider(service),
+            filterProvider = filterProvider,
+            tagDataDao = tagDataDao,
+            tasksPreferences = TasksPreferences(InMemoryDataStore()),
+            json = json,
+            zoneId = { ZoneId.of("America/Chicago") },
+        )
+    }
+
+    @Test
+    fun unconfiguredProviderReturnsNotConfigured() = runBlocking {
+        assertEquals(AiParseResult.NotConfigured, parser(null).parse("buy milk"))
+    }
+
+    @Test
+    fun blankInputIsRejectedWithoutACall() = runBlocking {
+        assertEquals(
+            AiParseResult.Failure(AiFailure.NO_TASKS),
+            parser(null).parse("   "),
+        )
+    }
+
+    @Test
+    fun multiTaskResponseYieldsMultipleParsedTasks() = runBlocking {
+        val content = """
+            {"tasks":[
+              {"title":"Call the dentist","notes":null,"list":"Personal","tags":["errand"],
+               "due":"2026-09-01T14:00","start":null,"priority":"high","recurrence":null},
+              {"title":"Pick up milk","notes":null,"list":null,"tags":[],
+               "due":null,"start":null,"priority":null,"recurrence":null}
+            ]}
+        """.trimIndent()
+
+        val result = parser(serviceReturning(chatBody(content))).parse("dentist and milk")
+
+        assertTrue(result is AiParseResult.Success)
+        val tasks = (result as AiParseResult.Success).tasks
+        assertEquals(2, tasks.size)
+        assertEquals("Call the dentist", tasks[0].title)
+        assertEquals("2026-09-01T14:00", tasks[0].due)
+        assertEquals("high", tasks[0].priority)
+        assertEquals(listOf("errand"), tasks[0].tags)
+        assertEquals("Pick up milk", tasks[1].title)
+    }
+
+    @Test
+    fun blankTitlesAreDropped() = runBlocking {
+        val content = """
+            {"tasks":[
+              {"title":"   ","notes":null,"list":null,"tags":[],
+               "due":null,"start":null,"priority":null,"recurrence":null},
+              {"title":"Real task","notes":null,"list":null,"tags":[],
+               "due":null,"start":null,"priority":null,"recurrence":null}
+            ]}
+        """.trimIndent()
+
+        val result = parser(serviceReturning(chatBody(content))).parse("something")
+
+        assertEquals(
+            listOf("Real task"),
+            (result as AiParseResult.Success).tasks.map { it.title },
+        )
+    }
+
+    @Test
+    fun emptyTaskListIsNoTasks() = runBlocking {
+        val result = parser(serviceReturning(chatBody("""{"tasks":[]}"""))).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.NO_TASKS), result)
+    }
+
+    @Test
+    fun malformedContentIsBadResponse() = runBlocking {
+        val result = parser(serviceReturning(chatBody("I am prose, not JSON"))).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.BAD_RESPONSE), result)
+    }
+
+    @Test
+    fun missingChoiceIsBadResponse() = runBlocking {
+        val result = parser(serviceReturning("""{"choices":[]}""")).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.BAD_RESPONSE), result)
+    }
+
+    @Test
+    fun rateLimitMapsToRateLimited() = runBlocking {
+        val result = parser(serviceReturning("{}", HttpStatusCode.TooManyRequests)).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.RATE_LIMITED), result)
+    }
+
+    @Test
+    fun unauthorizedMapsToUnauthorized() = runBlocking {
+        val result = parser(serviceReturning("{}", HttpStatusCode.Unauthorized)).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.UNAUTHORIZED), result)
+    }
+
+    @Test
+    fun serverErrorMapsToUnavailable() = runBlocking {
+        val result = parser(serviceReturning("{}", HttpStatusCode.InternalServerError)).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.UNAVAILABLE), result)
+    }
+
+    @Test
+    fun otherHttpErrorsMapToNetwork() = runBlocking {
+        val result = parser(serviceReturning("{}", HttpStatusCode.BadRequest)).parse("hmm")
+
+        assertEquals(AiParseResult.Failure(AiFailure.NETWORK), result)
+    }
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/AiTaskPromptTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/AiTaskPromptTest.kt
@@ -1,0 +1,117 @@
+package org.tasks.ai
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AiTaskPromptTest {
+
+    private val itemSchema: JsonObject
+        get() = TASK_SCHEMA["properties"]!!.jsonObject["tasks"]!!.jsonObject["items"]!!.jsonObject
+
+    @Test
+    fun rootDisallowsAdditionalProperties() {
+        assertEquals(JsonPrimitive(false), TASK_SCHEMA["additionalProperties"])
+    }
+
+    @Test
+    fun itemsDisallowAdditionalProperties() {
+        assertEquals(JsonPrimitive(false), itemSchema["additionalProperties"])
+    }
+
+    @Test
+    fun everyItemPropertyIsRequired() {
+        val properties = itemSchema["properties"]!!.jsonObject.keys
+        val required = itemSchema["required"]!!.jsonArray.map { it.jsonPrimitive.content }.toSet()
+
+        assertEquals(properties, required)
+    }
+
+    @Test
+    fun optionalFieldsAcceptNull() {
+        val properties = itemSchema["properties"]!!.jsonObject
+        for (field in listOf("notes", "list", "due", "start", "priority", "recurrence")) {
+            val type = properties[field]!!.jsonObject["type"]
+            assertTrue("$field should be nullable", type is JsonArray)
+            assertTrue(
+                "$field should allow null",
+                (type as JsonArray).map { it.jsonPrimitive.content }.contains("null"),
+            )
+        }
+    }
+
+    @Test
+    fun titleIsAPlainRequiredString() {
+        val title = itemSchema["properties"]!!.jsonObject["title"]!!.jsonObject
+        assertEquals(JsonPrimitive("string"), title["type"])
+    }
+
+    @Test
+    fun rootRequiresTasks() {
+        assertEquals(
+            listOf("tasks"),
+            TASK_SCHEMA["required"]!!.jsonArray.map { it.jsonPrimitive.content },
+        )
+    }
+
+    private fun messages() = buildMessages(
+        input = "call the dentist next Tuesday at 2",
+        listNames = listOf("Personal", "Work"),
+        tagNames = listOf("errand", "urgent"),
+        nowIso = "2026-08-25T09:30",
+        timeZoneId = "America/Chicago",
+    )
+
+    @Test
+    fun systemMessageStatesTheCurrentDateAndZone() {
+        val system = messages().first { it.role == "system" }.content
+
+        assertTrue(system.contains("2026-08-25T09:30"))
+        assertTrue(system.contains("America/Chicago"))
+    }
+
+    @Test
+    fun systemMessageListsCandidateListsAndTags() {
+        val system = messages().first { it.role == "system" }.content
+
+        assertTrue(system.contains("Personal"))
+        assertTrue(system.contains("Work"))
+        assertTrue(system.contains("errand"))
+        assertTrue(system.contains("urgent"))
+    }
+
+    @Test
+    fun userMessageCarriesTheRawInputOnly() {
+        val user = messages().first { it.role == "user" }
+
+        assertEquals("call the dentist next Tuesday at 2", user.content)
+    }
+
+    @Test
+    fun emptyCandidateSetsAreRenderedExplicitly() {
+        val system = buildMessages(
+            input = "buy milk",
+            listNames = emptyList(),
+            tagNames = emptyList(),
+            nowIso = "2026-08-25T09:30",
+            timeZoneId = "UTC",
+        ).first { it.role == "system" }.content
+
+        assertTrue(system.contains("(none)"))
+    }
+
+    @Test
+    fun promptDoesNotLeakAnythingBeyondInputListsAndTags() {
+        val system = messages().first { it.role == "system" }.content
+
+        // The disclosure promises only the input, list names, and tag names are transmitted.
+        assertFalse(system.contains("@"))
+    }
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/InMemoryDataStore.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/InMemoryDataStore.kt
@@ -1,0 +1,26 @@
+package org.tasks.ai
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class InMemoryDataStore : DataStore<Preferences> {
+    private val state = MutableStateFlow(emptyPreferences())
+    override val data: Flow<Preferences> = state
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences {
+        val updated = transform(state.value)
+        state.value = updated
+        return updated
+    }
+}
+
+internal fun testEncryption() = org.tasks.security.KeyStoreEncryption(
+    object : org.tasks.security.KeyProvider {
+        private val key: javax.crypto.SecretKey =
+            javax.crypto.KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+        override fun getKey() = key
+    }
+)

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/OpenRouterServiceTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/OpenRouterServiceTest.kt
@@ -1,0 +1,185 @@
+package org.tasks.ai
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.tasks.http.HttpException
+import org.tasks.http.NotFoundException
+import org.tasks.http.RateLimitedException
+import org.tasks.http.ServiceUnavailableException
+import org.tasks.http.UnauthorizedException
+
+class OpenRouterServiceTest {
+
+    private fun service(
+        status: HttpStatusCode,
+        body: String,
+        extraHeaders: Map<String, String> = emptyMap(),
+    ): OpenRouterService {
+        val engine = MockEngine {
+            respond(
+                content = body,
+                status = status,
+                headers = headersOf(
+                    *(
+                        listOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString())) +
+                            extraHeaders.map { it.key to listOf(it.value) }
+                        ).toTypedArray()
+                ),
+            )
+        }
+        return OpenRouterService(
+            HttpClient(engine) {
+                installOpenRouter(apiKey = "sk-test", log = {})
+            }
+        )
+    }
+
+    private val chatRequest = ChatRequest(
+        model = "some/model:free",
+        messages = listOf(ChatMessage(role = "user", content = "hi")),
+    )
+
+    @Test
+    fun parsesSuccessfulChatResponse() = runBlocking {
+        val response = service(
+            HttpStatusCode.OK,
+            """
+            {
+              "choices": [
+                {
+                  "message": {"role": "assistant", "content": "{\"tasks\":[]}"},
+                  "finish_reason": "stop"
+                }
+              ]
+            }
+            """.trimIndent(),
+        ).chat(chatRequest)
+
+        assertEquals(1, response.choices.size)
+        assertEquals("{\"tasks\":[]}", response.choices[0].message?.content)
+        assertEquals("stop", response.choices[0].finishReason)
+    }
+
+    @Test
+    fun unauthorizedIncludesOpenRouterMessage() = runBlocking {
+        val e = runCatching {
+            service(
+                HttpStatusCode.Unauthorized,
+                """{"error": {"message": "No auth credentials found"}}""",
+            ).chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is UnauthorizedException)
+        assertTrue(e!!.message!!.contains("No auth credentials found"))
+    }
+
+    @Test
+    fun forbiddenIsAlsoUnauthorized() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.Forbidden, """{}""").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is UnauthorizedException)
+    }
+
+    @Test
+    fun notFoundMapsToNotFound() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.NotFound, """{}""").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is NotFoundException)
+    }
+
+    @Test
+    fun rateLimitedCarriesRetryAfter() = runBlocking {
+        val e = runCatching {
+            service(
+                HttpStatusCode.TooManyRequests,
+                """{"error": {"message": "Rate limit exceeded"}}""",
+                extraHeaders = mapOf("Retry-After" to "42"),
+            ).chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is RateLimitedException)
+        assertEquals(42L, (e as RateLimitedException).retryAfterSeconds)
+    }
+
+    @Test
+    fun rateLimitedWithoutRetryAfterHasNullDelay() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.TooManyRequests, """{}""").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is RateLimitedException)
+        assertNull((e as RateLimitedException).retryAfterSeconds)
+    }
+
+    @Test
+    fun serverErrorMapsToServiceUnavailable() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.InternalServerError, """{}""").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is ServiceUnavailableException)
+    }
+
+    @Test
+    fun otherErrorsMapToHttpException() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.BadRequest, """{}""").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is HttpException)
+        assertEquals(400, (e as HttpException).code)
+    }
+
+    @Test
+    fun unparseableErrorBodyStillMapsByStatus() = runBlocking {
+        val e = runCatching {
+            service(HttpStatusCode.Unauthorized, "not json at all").chat(chatRequest)
+        }.exceptionOrNull()
+
+        assertTrue(e is UnauthorizedException)
+        assertEquals("HTTP 401", e!!.message)
+    }
+
+    @Test
+    fun deserializesModelsIncludingSupportedParameters() = runBlocking {
+        val models = service(
+            HttpStatusCode.OK,
+            """
+            {
+              "data": [
+                {
+                  "id": "vendor/model:free",
+                  "name": "Vendor: Model (free)",
+                  "supported_parameters": ["tools", "structured_outputs"],
+                  "unknown_field": 1
+                },
+                {
+                  "id": "vendor/paid",
+                  "name": "Vendor: Paid"
+                }
+              ]
+            }
+            """.trimIndent(),
+        ).listModels()
+
+        assertEquals(2, models.size)
+        assertTrue(models[0].isFree)
+        assertTrue(models[0].supportsStructuredOutputs)
+        assertEquals(false, models[1].isFree)
+        assertEquals(false, models[1].supportsStructuredOutputs)
+    }
+}

--- a/kmp/src/jvmTest/kotlin/org/tasks/ai/ParsedTaskMapperTest.kt
+++ b/kmp/src/jvmTest/kotlin/org/tasks/ai/ParsedTaskMapperTest.kt
@@ -1,0 +1,242 @@
+package org.tasks.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.tasks.data.GoogleTask
+import org.tasks.data.entity.CaldavAccount
+import org.tasks.data.entity.CaldavCalendar
+import org.tasks.data.entity.CaldavTask
+import org.tasks.data.entity.Tag
+import org.tasks.data.entity.TagData
+import org.tasks.data.entity.Task
+import org.tasks.filters.CaldavFilter
+import java.time.Instant
+import java.time.ZoneId
+
+class ParsedTaskMapperTest {
+
+    private val zone: ZoneId = ZoneId.systemDefault()
+
+    private fun caldavList(
+        name: String,
+        uuid: String = "uuid-$name",
+        access: Int = CaldavCalendar.ACCESS_OWNER,
+        accountType: Int = CaldavAccount.TYPE_CALDAV,
+    ) = CaldavFilter(
+        calendar = CaldavCalendar(name = name, uuid = uuid, access = access),
+        account = CaldavAccount(accountType = accountType),
+    )
+
+    private fun task() = Task(title = "placeholder", priority = Task.Priority.NONE)
+
+    private fun parsed(
+        title: String = "Call the dentist",
+        notes: String? = null,
+        list: String? = null,
+        tags: List<String> = emptyList(),
+        due: String? = null,
+        start: String? = null,
+        priority: String? = null,
+        recurrence: String? = null,
+    ) = ParsedTask(title, notes, list, tags, due, start, priority, recurrence)
+
+    private fun Long.fields(): Triple<Int, Int, Int> {
+        val local = Instant.ofEpochMilli(this).atZone(zone)
+        return Triple(local.hour, local.minute, local.second)
+    }
+
+    @Test
+    fun dateOnlyDueIsNoonWithZeroSeconds() {
+        val task = task()
+        parsed(due = "2026-09-01").applyTo(task, emptyList(), emptyList())
+
+        val (hour, _, second) = task.dueDate.fields()
+        assertEquals(12, hour)
+        assertEquals(0, second) // seconds == 0 means "no due time"
+        assertFalse(Task.hasDueTime(task.dueDate))
+    }
+
+    @Test
+    fun timedDueKeepsTheStatedHourAndMarksHasTime() {
+        val task = task()
+        parsed(due = "2026-09-01T14:00").applyTo(task, emptyList(), emptyList())
+
+        val (hour, minute, second) = task.dueDate.fields()
+        assertEquals(14, hour)
+        assertEquals(0, minute)
+        assertEquals(1, second) // seconds > 0 means "has due time"
+        assertTrue(Task.hasDueTime(task.dueDate))
+    }
+
+    @Test
+    fun unparseableDueIsLeftAlone() {
+        val task = task()
+        val before = task.dueDate
+        parsed(due = "next tuesday-ish").applyTo(task, emptyList(), emptyList())
+
+        assertEquals(before, task.dueDate)
+    }
+
+    @Test
+    fun startDateSetsHideUntil() {
+        val task = task()
+        parsed(start = "2026-09-01").applyTo(task, emptyList(), emptyList())
+
+        assertTrue(task.hideUntil > 0)
+    }
+
+    @Test
+    fun prioritiesMapToTheirConstants() {
+        for ((text, expected) in listOf(
+            "high" to Task.Priority.HIGH,
+            "medium" to Task.Priority.MEDIUM,
+            "low" to Task.Priority.LOW,
+        )) {
+            val task = task()
+            parsed(priority = text).applyTo(task, emptyList(), emptyList())
+            assertEquals(text, expected, task.priority)
+        }
+    }
+
+    @Test
+    fun priorityIsCaseInsensitive() {
+        val task = task()
+        parsed(priority = "HIGH").applyTo(task, emptyList(), emptyList())
+
+        assertEquals(Task.Priority.HIGH, task.priority)
+    }
+
+    @Test
+    fun unknownOrNonePriorityKeepsTheConfiguredDefault() {
+        for (text in listOf("none", "urgent-ish", null)) {
+            val task = Task(title = "x", priority = Task.Priority.MEDIUM)
+            parsed(priority = text).applyTo(task, emptyList(), emptyList())
+            assertEquals("priority=$text", Task.Priority.MEDIUM, task.priority)
+        }
+    }
+
+    @Test
+    fun caldavListSetsCaldavTransitory() {
+        val task = task()
+        val lists = listOf(caldavList("Personal", uuid = "cal-1"))
+        parsed(list = "Personal").applyTo(task, lists, emptyList())
+
+        assertEquals("cal-1", task.getTransitory<String>(CaldavTask.KEY))
+        assertFalse(task.hasTransitory(GoogleTask.KEY))
+    }
+
+    @Test
+    fun googleTasksListSetsGoogleTransitory() {
+        val task = task()
+        val lists = listOf(
+            caldavList("Personal", uuid = "gt-1", accountType = CaldavAccount.TYPE_GOOGLE_TASKS)
+        )
+        parsed(list = "Personal").applyTo(task, lists, emptyList())
+
+        assertEquals("gt-1", task.getTransitory<String>(GoogleTask.KEY))
+        assertFalse(task.hasTransitory(CaldavTask.KEY))
+    }
+
+    @Test
+    fun listMatchIsCaseInsensitive() {
+        val task = task()
+        val lists = listOf(caldavList("Personal", uuid = "cal-1"))
+        parsed(list = "personal").applyTo(task, lists, emptyList())
+
+        assertEquals("cal-1", task.getTransitory<String>(CaldavTask.KEY))
+    }
+
+    @Test
+    fun unknownListNameSetsNoTransitory() {
+        val task = task()
+        val lists = listOf(caldavList("Personal", uuid = "cal-1"))
+        parsed(list = "Groceries").applyTo(task, lists, emptyList())
+
+        assertFalse(task.hasTransitory(CaldavTask.KEY))
+        assertFalse(task.hasTransitory(GoogleTask.KEY))
+    }
+
+    @Test
+    fun readOnlyListIsNeverSelected() {
+        val task = task()
+        val lists = listOf(
+            caldavList("Shared", uuid = "ro-1", access = CaldavCalendar.ACCESS_READ_ONLY)
+        )
+        parsed(list = "Shared").applyTo(task, lists, emptyList())
+
+        assertFalse(task.hasTransitory(CaldavTask.KEY))
+        assertFalse(task.hasTransitory(GoogleTask.KEY))
+    }
+
+    @Test
+    fun knownTagsAreResolvedAndUnknownOnesDropped() {
+        val task = task()
+        val known = listOf(TagData(name = "errand"), TagData(name = "urgent"))
+        parsed(tags = listOf("errand", "invented", "URGENT"))
+            .applyTo(task, emptyList(), known)
+
+        assertEquals(listOf("errand", "urgent"), task.getTransitory<ArrayList<String>>(Tag.KEY))
+    }
+
+    @Test
+    fun noResolvedTagsLeavesExistingTransitoryUntouched() {
+        val task = task()
+        task.putTransitory(Tag.KEY, arrayListOf("preexisting"))
+        parsed(tags = listOf("invented")).applyTo(task, emptyList(), emptyList())
+
+        assertEquals(listOf("preexisting"), task.getTransitory<ArrayList<String>>(Tag.KEY))
+    }
+
+    @Test
+    fun validRecurrenceIsStoredWithRepeatFromDueDate() {
+        val task = task()
+        parsed(recurrence = "FREQ=WEEKLY;BYDAY=MO").applyTo(task, emptyList(), emptyList())
+
+        assertEquals("FREQ=WEEKLY;BYDAY=MO", task.recurrence)
+        assertEquals(Task.RepeatFrom.DUE_DATE, task.repeatFrom)
+    }
+
+    @Test
+    fun invalidRecurrenceIsDroppedWithoutThrowing() {
+        val task = task()
+        parsed(recurrence = "every other blue moon")
+            .applyTo(task, emptyList(), emptyList())
+
+        assertNull(task.recurrence)
+    }
+
+    @Test
+    fun notesAreSetWhenPresentAndSkippedWhenBlank() {
+        val withNotes = task()
+        parsed(notes = "  bring insurance card ")
+            .applyTo(withNotes, emptyList(), emptyList())
+        assertEquals("bring insurance card", withNotes.notes)
+
+        val blank = task()
+        parsed(notes = "   ").applyTo(blank, emptyList(), emptyList())
+        assertNull(blank.notes)
+    }
+
+    @Test
+    fun titleIsTrimmedAndApplied() {
+        val task = task()
+        parsed(title = "  Call the dentist  ").applyTo(task, emptyList(), emptyList())
+
+        assertEquals("Call the dentist", task.title)
+    }
+
+    @Test
+    fun everythingNullLeavesTheTaskUnchanged() {
+        val task = Task(title = "original", priority = Task.Priority.LOW)
+        val before = task.copy()
+        parsed(title = "original").applyTo(task, emptyList(), emptyList())
+
+        assertEquals(before.title, task.title)
+        assertEquals(before.priority, task.priority)
+        assertEquals(before.dueDate, task.dueDate)
+        assertEquals(before.recurrence, task.recurrence)
+    }
+}


### PR DESCRIPTION
Implements thoughts/shared/plans/2026-08-25-ai-task-creation-openrouter.md (all four phases).

A dictation-first capture flow: the user dictates a free-form request, an OpenRouter model parses it into structured tasks, and the user reviews them as cards before anything is persisted.

Phase 1 - client foundation:
- Four DataStore preference keys, plus RateLimitedException (the repo's first 429 handling) beside the existing NetworkException hierarchy.
- AiCredentialStore wraps TasksPreferences + KeyStoreEncryption; it is the only code that touches the API-key ciphertext.
- OpenRouter DTOs, Ktor client config, and typed service with central status mapping. Unlike the Graph client, expectSuccess = false so OpenRouter's own error messages surface.
- AiGate + OpenRouterClientProvider enforce the consent gate at client construction time, following the CaldavClientProvider precedent, so no call path can bypass it.

Phase 2 - settings and privacy consent:
- AI task creation settings screen: API key entry, live model picker filtered to models advertising structured_outputs, and the privacy disclosure.
- Toggling the feature on while unconsented raises the disclosure dialog rather than enabling; an unverified key is never stored.

Phase 3 - prompt and mapping:
- Pure, fully unit-tested core: strict JSON schema, prompt construction, and ParsedTask -> Task mapping.
- Dates always go through createDueDate/createHideUntil, which encode has-time in the seconds field. Unmatched lists fall back to the default list and unmatched tags are dropped rather than created, so a hallucinated tag cannot pollute the drawer.
- basicQuickAddTask splits into persistNewTask (verbatim body move) so tasks can be built, reviewed, and persisted only on confirmation.

Phase 4 - capture sheet and wiring:
- Bottom sheet with an auto-focused field (which raises the keyboard and puts the GBoard mic one tap away - no speech API or RECORD_AUDIO), a loading state, and per-task review cards.
- The existing voice menu item reroutes through the sheet only when the feature is fully configured; otherwise its behavior is unchanged.

Nothing is transmitted unless the feature is enabled, a key is stored, and the current disclosure version is accepted. Nothing is written to the database until the user confirms.

84 new tests. See the plan's Verification Notes for three success criteria that could not be met here, each reproduced on the base commit or requiring hardware this environment lacks.