### PR TITLE
fix(desktop): declare jlink runtime modules for native distributions

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -161,6 +161,22 @@ compose.desktop {
             packageVersion = libs.versions.versionName.get().let {
                 if (it.count { c -> c == '.' } < 2) "$it.0" else it
             }
+            // Without an explicit module list, jlink builds the runtime image from the
+            // Compose plugin defaults (java.base, java.desktop, java.logging, jdk.crypto.ec)
+            // and the packaged app dies with NoClassDefFoundError: sun/misc/Unsafe at
+            // startup (DataStore protobuf) and com/sun/net/httpserver/HttpServer when the
+            // GitHub sponsor flow opens its OAuth callback listener.
+            // This is the list reported by ./gradlew :composeApp:suggestRuntimeModules.
+            modules(
+                "java.compiler",
+                "java.instrument",
+                "java.management",
+                "java.security.jgss",
+                "java.sql",
+                "jdk.httpserver",
+                "jdk.security.auth",
+                "jdk.unsupported",
+            )
         }
     }
 }


### PR DESCRIPTION
## What changed

Declare an explicit `modules(...)` list in `compose.desktop.application.nativeDistributions`, using the set reported by `./gradlew :composeApp:suggestRuntimeModules`.

## Why it changed

Fixes #4588.

Without a `modules(...)` list, `jlink` builds the runtime image from the Compose plugin's defaults only — `java.base`, `java.desktop`, `java.logging`, `jdk.crypto.ec`. Several modules the app actually needs are missing, so `createDistributable` / `packageDeb` produce a build that crashes at runtime:

- **at startup** — `NoClassDefFoundError: sun/misc/Unsafe`, from DataStore's bundled protobuf (`jdk.unsupported`)
- **on the GitHub sponsor flow** — `NoClassDefFoundError: com/sun/net/httpserver/HttpServer`, from `GitHubSponsorClientImpl.listenForCallback` starting a local OAuth callback listener (`jdk.httpserver`)

`java.sql`, `java.management` and `java.security.jgss` are in the jdeps list too and were presumably latent crashes on paths I didn't exercise.

Released artifacts were never affected — `conveyor.conf` pulls a full JDK via `/stdlib/jdk/21/jetbrains.conf`, and the AppImage job in `bundle.yml` repackages that Conveyor tarball. This only affects building from source with the Gradle packaging tasks.

## Testing instructions

```
./gradlew :composeApp:createDistributable
./composeApp/build/compose/binaries/main/app/tasks-org/bin/tasks-org
```

Before this change the app dies immediately with the `sun/misc/Unsafe` trace. After it, the app starts, and the GitHub sponsor restore reaches its callback listener instead of throwing.

Also verified on this branch:

- `./gradlew :composeApp:desktopTest` — 170 tests, 0 failures
- runtime image `release` manifest contains all eight declared modules
- `./gradlew :composeApp:packageDeb` builds successfully
- image size 232 MB → 237 MB

Tested on Fedora Asahi Remix 43 (aarch64), OpenJDK 21.0.12. I don't have a Windows or macOS machine to check `packageMsi` / `packageDmg`, but the change is platform-independent — it only adds modules to the jlink image.
