### PR TITLE
feat(desktop): quit with Ctrl+Q

### DIFF
--- a/composeApp/src/desktopMain/kotlin/main.kt
+++ b/composeApp/src/desktopMain/kotlin/main.kt
@@ -31,6 +31,7 @@ import org.tasks.analytics.Reporting
 import org.tasks.App
 import org.tasks.auth.TasksServerEnvironment
 import org.tasks.compose.StableWindowSize
+import org.tasks.desktop.isQuitShortcut
 import org.tasks.jobs.BackgroundWork
 import org.tasks.requestForeground
 import org.tasks.setQuitting
@@ -225,11 +226,14 @@ fun main() {
                     }
                 }
         }
-        Window(
-            // This fires while the composition is still alive, so no editor has been cleared or
-            // stopped and nothing is enqueued yet: ask any open editor to commit first, then give
-            // that save a moment to land before tearing the JVM down.
-            onCloseRequest = {
+        // Named so the Ctrl+Q handler below can go through the exact same shutdown path as the
+        // window's close button - including the "a save failed, stay open and report it" branch.
+        // A shortcut that called exitApplication() directly would silently drop an unsaved edit.
+        //
+        // This fires while the composition is still alive, so no editor has been cleared or
+        // stopped and nothing is enqueued yet: ask any open editor to commit first, then give
+        // that save a moment to land before tearing the JVM down.
+        val requestClose: () -> Unit = {
                 if (!closing) {
                     closing = true
                     setQuitting(true)
@@ -264,6 +268,18 @@ fun main() {
                         }
                         exitApplication()
                     }
+                }
+        }
+        Window(
+            onCloseRequest = requestClose,
+            // Preview, so the shortcut still works while a text field has focus. Consuming the
+            // event (true) keeps the "q" from also being typed into whatever is focused.
+            onPreviewKeyEvent = { event ->
+                if (isQuitShortcut(event)) {
+                    requestClose()
+                    true
+                } else {
+                    false
                 }
             },
             title = "Tasks",

--- a/composeApp/src/desktopMain/kotlin/org/tasks/desktop/QuitShortcut.kt
+++ b/composeApp/src/desktopMain/kotlin/org/tasks/desktop/QuitShortcut.kt
@@ -1,0 +1,38 @@
+package org.tasks.desktop
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+
+/**
+ * Whether a key press is the "quit the application" shortcut.
+ *
+ * Split out from the [KeyEvent] overload so it can be unit tested without building AWT
+ * events. Matches on KeyDown only: matching KeyUp as well would run the close path twice
+ * for a single press.
+ *
+ * @param key the key that was pressed
+ * @param type whether this is the key going down or coming back up
+ * @param ctrlPressed whether Ctrl was held (Linux/Windows convention)
+ * @param metaPressed whether Cmd was held (macOS convention)
+ * @return true if this press means "quit"
+ */
+internal fun isQuitShortcut(
+    key: Key,
+    type: KeyEventType,
+    ctrlPressed: Boolean,
+    metaPressed: Boolean,
+): Boolean = type == KeyEventType.KeyDown && key == Key.Q && (ctrlPressed || metaPressed)
+
+/**
+ * Whether [event] is the "quit the application" shortcut.
+ *
+ * @param event the key event to inspect
+ * @return true if this event means "quit"
+ */
+internal fun isQuitShortcut(event: KeyEvent): Boolean =
+    isQuitShortcut(event.key, event.type, event.isCtrlPressed, event.isMetaPressed)

--- a/composeApp/src/desktopTest/kotlin/org/tasks/desktop/QuitShortcutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/tasks/desktop/QuitShortcutTest.kt
@@ -1,0 +1,35 @@
+package org.tasks.desktop
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuitShortcutTest {
+    @Test
+    fun ctrlQOnKeyDownIsTheQuitShortcut() {
+        assertTrue(isQuitShortcut(Key.Q, KeyEventType.KeyDown, ctrlPressed = true, metaPressed = false))
+    }
+
+    @Test
+    fun metaQOnKeyDownIsTheQuitShortcut() {
+        assertTrue(isQuitShortcut(Key.Q, KeyEventType.KeyDown, ctrlPressed = false, metaPressed = true))
+    }
+
+    @Test
+    fun qWithoutAModifierIsNotTheQuitShortcut() {
+        assertFalse(isQuitShortcut(Key.Q, KeyEventType.KeyDown, ctrlPressed = false, metaPressed = false))
+    }
+
+    @Test
+    fun anotherKeyWithCtrlIsNotTheQuitShortcut() {
+        assertFalse(isQuitShortcut(Key.W, KeyEventType.KeyDown, ctrlPressed = true, metaPressed = false))
+    }
+
+    // KeyUp must not match, or the close path runs twice for a single press.
+    @Test
+    fun keyUpIsNotTheQuitShortcut() {
+        assertFalse(isQuitShortcut(Key.Q, KeyEventType.KeyUp, ctrlPressed = true, metaPressed = false))
+    }
+}


### PR DESCRIPTION
## What changed

Adds a quit keyboard shortcut to the desktop app — **Ctrl+Q**, and **Cmd+Q** on macOS.

- `org/tasks/desktop/QuitShortcut.kt` — `isQuitShortcut()`, the key-matching predicate
- `org/tasks/desktop/QuitShortcutTest.kt` — 5 unit tests
- `main.kt` — extracts the existing `onCloseRequest` lambda into a named `requestClose` and wires `onPreviewKeyEvent`

## Why it changed

There was no keyboard shortcut handling in the desktop app at all — no `KeyShortcut`, no `MenuBar`, and the only two key handlers are widget-scoped (`BlockDrag`, `SubtaskTitleField`). `exitApplication()` was reachable only through the window's close button, so there was no way to quit from the keyboard.

Three decisions worth flagging for review:

**The shortcut reuses the existing close path.** `onCloseRequest` does real work — it flushes pending saves, waits for them, and *cancels the quit and reopens the window if a save failed* so the edit isn't lost. Rather than duplicate that or call `exitApplication()` directly, I extracted it into a `requestClose` val that both the close button and the shortcut call. A shortcut that exited directly would silently drop an unsaved edit, which is the exact failure that code exists to prevent.

**`onPreviewKeyEvent`, not `onKeyEvent`** — so the shortcut still works while a text field has focus. It returns `true` to consume the event, so the `q` isn't also typed into whatever is focused.

**KeyDown only.** Matching KeyUp as well would run the close path twice for one press; there's a test asserting KeyUp does not match.

The predicate is split into a primitives overload (`Key`, `KeyEventType`, two booleans) so it can be unit tested without constructing AWT key events, with a thin `KeyEvent` overload over it.

## Testing instructions

```
./gradlew :composeApp:desktopTest
```

175 tests, 0 failures on this branch (was 170 — the 5 new ones cover Ctrl+Q, Cmd+Q, bare `q`, Ctrl+W, and KeyUp).

Manually verified on Linux: built with `createDistributable`, and Ctrl+Q closes the window and exits. I don't have a Windows or macOS machine, so **Cmd+Q on macOS is untested** — note that macOS also delivers its own Cmd+Q through `QuitStrategy`, which `main.kt` already configures, so a reviewer on a Mac should confirm the two don't interact badly. Happy to drop the `isMetaPressed` half if that's cleaner.

Tested on Fedora Asahi Remix 43 (aarch64), OpenJDK 21.

Unrelated to #4589, which touches only `build.gradle.kts`.
